### PR TITLE
Force overhaul with Configuration by Categories

### DIFF
--- a/Astra Militarum.cat
+++ b/Astra Militarum.cat
@@ -23,7 +23,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -63,7 +63,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -119,7 +119,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -175,7 +175,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -231,7 +231,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -287,7 +287,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -327,7 +327,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -367,7 +367,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -407,7 +407,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -431,7 +431,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -455,7 +455,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1297,7 +1297,7 @@
         <modifier type="set" field="5b26-9ad1-1375-5209" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1467,7 +1467,7 @@
         <modifier type="set" field="45d0-6aab-7cd4-263f" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1748,7 +1748,7 @@
         <modifier type="set" field="8b5c-8df2-bbd0-5e0b" value="3">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1984,7 +1984,7 @@
         <modifier type="set" field="d548-c589-274a-c90c" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -2167,7 +2167,7 @@
         <modifier type="set" field="5e36-2da6-1112-1404" value="4">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/Astra Militarum.cat
+++ b/Astra Militarum.cat
@@ -23,7 +23,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -63,7 +63,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -119,7 +119,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -175,7 +175,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -231,7 +231,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -287,7 +287,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -327,7 +327,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -367,7 +367,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -399,7 +399,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c550-b1f6-5f2c-e6d1" name="Guardsman Fire Team" hidden="false" targetId="90ff-92bf-17b3-38fd" type="selectionEntry">
+    <entryLink id="c550-b1f6-5f2c-e6d1" name="Infantry Squad Fire Team" hidden="false" targetId="90ff-92bf-17b3-38fd" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -407,7 +407,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -431,7 +431,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -455,7 +455,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -531,7 +531,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d5bc-71b5-c24f-4e96" name="Guardsman" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d5bc-71b5-c24f-4e96" name="Guardsman" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="734c-24c1-2d2d-837f" name="Guardsman" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -579,6 +579,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="7d5e-483b-3706-2900" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="c3ea-122f-a944-4d6b" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -642,7 +649,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0e48-4b39-f955-7e20" name="Special Weapons Guardsman" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0e48-4b39-f955-7e20" name="Special Weapons Guardsman" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="239f-9e97-574f-f8b5" name="Special Weapon Guardsman" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -690,6 +697,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="6f7f-d473-fdf9-95ef" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="97b9-3254-0db1-2cba" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -802,7 +816,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="2.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0f8c-8784-485a-5063" name="Militarum Tempestus Scion" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0f8c-8784-485a-5063" name="Militarum Tempestus Scion" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="bf83-c67a-580e-3a3f" name="Militarum Tempestus Scion" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -834,7 +848,15 @@
         </modifier>
       </modifiers>
       <constraints/>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="ff30-2b18-231f-cab5" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
@@ -1043,7 +1065,9 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="fc67-291e-8fe8-c2db" name="Plasma Pistol" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -1247,7 +1271,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5685-5d66-9c9b-faf4" name="Guardsman Gunner" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5685-5d66-9c9b-faf4" name="Guardsman Gunner" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="e4e3-194c-f776-caa8" name="Guardsman Gunner" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -1272,16 +1296,10 @@
       <modifiers>
         <modifier type="set" field="5b26-9ad1-1375-5209" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -1310,6 +1328,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="aa62-7385-5693-6369" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="66d6-dfce-3e94-b963" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1416,7 +1441,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8d63-9ed2-1596-d8e6" name="Sergeant" hidden="false" collective="false" type="unit">
+    <selectionEntry id="8d63-9ed2-1596-d8e6" name="Sergeant" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="086b-7143-0d4a-f1c1" name="Sergeant" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -1441,16 +1466,10 @@
       <modifiers>
         <modifier type="set" field="45d0-6aab-7cd4-263f" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -1463,7 +1482,15 @@
       <constraints>
         <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="45d0-6aab-7cd4-263f" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="b95f-1d96-1aad-e8f9" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="32e4-a8f3-c31a-e347" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="1586-ff04-dd3c-a685">
@@ -1695,7 +1722,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d863-7299-321c-ccec" name="Special Weapons Gunner" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d863-7299-321c-ccec" name="Special Weapons Gunner" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="3c53-4215-8599-c259" name="Special Weapons Gunner" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -1720,16 +1747,10 @@
       <modifiers>
         <modifier type="set" field="8b5c-8df2-bbd0-5e0b" value="3">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -1742,7 +1763,15 @@
       <constraints>
         <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8b5c-8df2-bbd0-5e0b" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="4783-1df3-1fdd-6ecf" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="23ff-926d-2bf2-ec75" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="ca9f-8c6f-4eba-9a24">
@@ -1929,7 +1958,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1896-6dfe-2a22-7878" name="Tempestor" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1896-6dfe-2a22-7878" name="Tempestor" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="d4e7-3ad3-5bf6-c7b9" name="Tempestor" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -1954,16 +1983,10 @@
       <modifiers>
         <modifier type="set" field="d548-c589-274a-c90c" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -1976,7 +1999,15 @@
       <constraints>
         <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d548-c589-274a-c90c" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="aa1c-eae7-e8f6-c508" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="b5f4-1ea1-a482-28c6" name="Melee Weapon" hidden="false" collective="false" defaultSelectionEntryId="b2da-9b76-49ba-6478">
@@ -2110,7 +2141,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3092-d4ca-7c11-034a" name="Scion Gunner" hidden="false" collective="false" type="unit">
+    <selectionEntry id="3092-d4ca-7c11-034a" name="Scion Gunner" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="0204-ee28-fe0e-317e" name="Scion Gunner" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -2135,16 +2166,10 @@
       <modifiers>
         <modifier type="set" field="5e36-2da6-1112-1404" value="4">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -2157,7 +2182,15 @@
       <constraints>
         <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5e36-2da6-1112-1404" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="11d7-89cd-e234-8e72" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="c398-bd7e-fb47-569b" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="8654-069e-eb3a-b5cc">
@@ -2289,7 +2322,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="90ff-92bf-17b3-38fd" name="Infantry Squad Fire Team" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="90ff-92bf-17b3-38fd" name="Infantry Squad Fire Team" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2353,7 +2386,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8180-84cd-518d-ca33" name="Special Weapons Squad Fire Team" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8180-84cd-518d-ca33" name="Special Weapons Squad Fire Team" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2409,7 +2442,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="87be-b807-4a4c-f756" name="Militarum Tempestus Fire Team" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="87be-b807-4a4c-f756" name="Militarum Tempestus Fire Team" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/Asuryani.cat
+++ b/Asuryani.cat
@@ -363,7 +363,7 @@
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="74a1-6b5c-0980-9c59" name="Guardian Defender" hidden="false" collective="false" type="unit">
+    <selectionEntry id="74a1-6b5c-0980-9c59" name="Guardian Defender" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="771a-3824-773d-5dfd" name="Guardian Defender" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -430,6 +430,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="c3f5-b6e4-c4c1-978d" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -482,7 +489,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="7.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="50aa-37f7-ff1c-c4fb" name="Heavy Weapons Platform" hidden="false" collective="false" type="unit">
+    <selectionEntry id="50aa-37f7-ff1c-c4fb" name="Heavy Weapons Platform" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="0064-3cc5-6f0b-1a75" name="Heavy Weapons Platform" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -516,16 +523,10 @@
       <modifiers>
         <modifier type="set" field="cb6d-7f44-85c7-fa00" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -575,6 +576,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="65a0-5d73-4c8e-b47b" name="Heavy Weapon Platform" hidden="false" targetId="ee31-85ca-f460-422c" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="568c-25ae-5331-876e" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -668,23 +676,17 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4910-17dd-356a-4a7b" name="Storm Guardian Gunner" hidden="false" collective="false" type="unit">
+    <selectionEntry id="4910-17dd-356a-4a7b" name="Storm Guardian Gunner" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers>
         <modifier type="set" field="ed8f-b3a0-4b21-b3e4" value="2">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -733,6 +735,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="090a-deb0-ef91-abb2" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -770,7 +779,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="1974-291b-c1a7-954c" name="Shuriken Pistol &amp; Chainsword" hidden="false" collective="false" type="upgrade">
               <profiles/>
@@ -795,7 +806,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -1083,7 +1096,9 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="5c1e-b33e-2027-2661" name="Flamer" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -1171,9 +1186,11 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry id="1134-2e6a-67d3-0875" name="Ranger Long Rifle" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1134-2e6a-67d3-0875" name="Ranger Long Rifle" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="1930-0387-a2a4-4a32" name="Ranger Long Rifle" hidden="false" profileTypeId="c067-7929-f4dc-7825" profileTypeName="Weapon">
           <profiles/>
@@ -1194,11 +1211,21 @@
       <infoLinks/>
       <modifiers/>
       <constraints/>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="5f71-9301-c16d-c86e" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="4ca9-e412-d0c4-fb6f" name="Aeldari Blade" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -1217,7 +1244,9 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="cf61-80b8-da85-bf9a" name="Chainsword" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -1236,9 +1265,11 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry id="52ca-794b-1bce-b44d" name="Storm Guardian" hidden="false" collective="false" type="unit">
+    <selectionEntry id="52ca-794b-1bce-b44d" name="Storm Guardian" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1281,6 +1312,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="3945-d97c-60e4-aea9" name="Storm Guardian" hidden="false" targetId="1644-02f2-4127-d540" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="330c-1697-7eec-6ebd" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1363,7 +1401,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="6.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ca1b-91ef-e78c-9733" name="Dire Avenger" hidden="false" collective="false" type="unit">
+    <selectionEntry id="ca1b-91ef-e78c-9733" name="Dire Avenger" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="3540-fe08-304f-935e" name="Dire Avenger" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -1417,6 +1455,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="bcd6-5ae4-d68f-c238" name="Dire Avenger" hidden="false" targetId="53bc-1d8c-af8a-e8ab" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3831-0df1-8cfb-d73e" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1483,7 +1528,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7b4b-2371-1c46-e837" name="Dire Avenger Exarch" hidden="false" collective="false" type="unit">
+    <selectionEntry id="7b4b-2371-1c46-e837" name="Dire Avenger Exarch" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="5db1-0466-00f2-d97e" name="Dire Avenger Exarch" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -1508,16 +1553,10 @@
       <modifiers>
         <modifier type="set" field="8f38-380c-e13b-9c03" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -1559,6 +1598,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="57ff-2380-cdc8-7eff" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9e1a-c363-6e84-46da" name="Battle Fortune" hidden="false" collective="false" type="upgrade">
@@ -1584,7 +1630,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -1624,7 +1672,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="6143-b6d6-d87f-d3ef" name="Shuriken Pistol &amp; Power Glaive" hidden="false" collective="false" type="upgrade">
               <profiles/>
@@ -1803,9 +1853,11 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry id="c476-e7c5-3a7d-b0fb" name="Ranger" hidden="false" collective="false" type="unit">
+    <selectionEntry id="c476-e7c5-3a7d-b0fb" name="Ranger" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="9303-daa1-63a8-9a41" name="Ranger" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -1865,6 +1917,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="8435-55f7-200d-a1ad" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="77af-92a2-efc7-da53" name="Cameleoline Cloak" hidden="false" collective="false" type="upgrade">
@@ -1890,7 +1949,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>

--- a/Death Guard.cat
+++ b/Death Guard.cat
@@ -55,7 +55,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -111,7 +111,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -135,7 +135,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -159,7 +159,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -183,7 +183,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -255,7 +255,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -279,7 +279,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -297,7 +297,7 @@
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="a65e-bbc9-67a2-46d5" name="Plague Marine" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a65e-bbc9-67a2-46d5" name="Plague Marine" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="3a75-64d1-2293-fcec" name="Plague Marine" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -391,6 +391,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="b777-e4ce-7e3a-7252" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6119-d3ea-6e84-9b09" name="Icon of Despair" hidden="false" collective="false" type="upgrade">
@@ -464,7 +471,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="14.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b751-39a0-8d76-ea16" name="Plague Marine Gunner" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b751-39a0-8d76-ea16" name="Plague Marine Gunner" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="2ab1-3f2b-0e6a-a726" name="Plague Marine Gunner" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -508,16 +515,10 @@
       <modifiers>
         <modifier type="set" field="4052-8cc0-c6ae-1e3e" value="2">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -567,6 +568,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="27ca-78a5-8973-4d7f" name="Plague Marine" hidden="false" targetId="0d05-3565-7b60-3c0f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3b37-c84a-964a-1ab2" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -800,7 +808,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8924-9a68-3d47-fc1c" name="Plague Marine Fighter" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8924-9a68-3d47-fc1c" name="Plague Marine Fighter" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="ed18-c5b3-374b-2350" name="Plague Marine Fighter" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -844,16 +852,10 @@
       <modifiers>
         <modifier type="set" field="ef1e-4c3f-d31d-9e2b" value="2">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -903,6 +905,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="438a-7eb6-3528-1b67" name="Plague Marine" hidden="false" targetId="0d05-3565-7b60-3c0f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e409-dc81-4b30-fac6" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1092,7 +1101,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2f21-de32-6db6-39c9" name="Plague Champion" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="2f21-de32-6db6-39c9" name="Plague Champion" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="7ebb-eb77-c678-eb1a" name="Plague Champion" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -1180,6 +1189,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="9553-55a3-a4da-76bb" name="Plague Marine" hidden="false" targetId="0d05-3565-7b60-3c0f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="08d6-f016-ceab-82f6" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1401,7 +1417,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fb97-e62c-260c-d2e2" name="Poxwalker" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fb97-e62c-260c-d2e2" name="Poxwalker" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="be87-1c81-ff24-edac" name="Poxwalker" hidden="false" profileTypeId="bb0a-aba1-abd0-beb3" profileTypeName="Model">
           <profiles/>
@@ -1477,6 +1493,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="72ec-075b-3fb2-a5e2" name="Poxwalker" hidden="false" targetId="1bc8-a924-22a9-e69a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="ccab-bf7e-0c92-9abd" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/Death Guard.cat
+++ b/Death Guard.cat
@@ -55,7 +55,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -111,7 +111,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -135,7 +135,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -159,7 +159,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -183,7 +183,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -255,7 +255,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -279,7 +279,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -516,7 +516,7 @@
         <modifier type="set" field="4052-8cc0-c6ae-1e3e" value="2">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -853,7 +853,7 @@
         <modifier type="set" field="ef1e-4c3f-d31d-9e2b" value="2">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/Death Guard.cat
+++ b/Death Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="369f-8d9a-1b69-00dc" name="Death Guard" revision="2" battleScribeVersion="2.01" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="369f-8d9a-1b69-00dc" name="Death Guard" revision="3" battleScribeVersion="2.01" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -1150,8 +1150,17 @@
           <conditions/>
           <conditionGroups/>
         </modifier>
+        <modifier type="set" field="9b17-33d2-5ba1-d761" value="1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
       </modifiers>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b17-33d2-5ba1-d761" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="d305-acfe-bd9e-a508" name="Faction: Death Guard" hidden="false" targetId="a8b0-c81f-0fea-65fd" primary="false">
           <profiles/>

--- a/Drukhari.cat
+++ b/Drukhari.cat
@@ -128,7 +128,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -168,7 +168,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -192,7 +192,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -216,7 +216,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -256,7 +256,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -280,7 +280,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -304,7 +304,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -320,7 +320,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -815,16 +815,10 @@
       <modifiers>
         <modifier type="set" field="81f2-e4f8-d4e1-dc47" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -860,6 +854,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="c795-377c-3f82-6835" name="Wych" hidden="false" targetId="4a23-eb9f-45cc-d6da" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1906-4c52-e859-f23a" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1025,16 +1026,10 @@
       <modifiers>
         <modifier type="set" field="cd37-1639-0fc0-06d9" value="3">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -1070,6 +1065,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="40f1-ae17-baf1-4c86" name="Wych" hidden="false" targetId="4a23-eb9f-45cc-d6da" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="157d-0e9b-a3c5-e3e3" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1274,6 +1276,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="f945-b0ad-a72a-b619" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -1356,16 +1365,10 @@
       <modifiers>
         <modifier type="set" field="697b-5baa-d077-19bf" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -1401,6 +1404,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="fb0e-5db9-2e02-3882" name="Kabalite Warrior" hidden="false" targetId="b4b3-1353-2d65-cf24" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="c30f-7f51-74f2-d212" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1536,16 +1546,10 @@
       <modifiers>
         <modifier type="set" field="140d-e671-abaa-c936" value="2">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -1581,6 +1585,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="7329-4ca8-72f2-f5a4" name="Kabalite Warrior" hidden="false" targetId="b4b3-1353-2d65-cf24" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="44c9-9b77-61f1-dc85" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1736,6 +1747,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="8ea6-580b-36b1-5584" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -1764,7 +1782,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="7.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="53c5-45d2-c3b2-9748" name="Kabalite Warrior Fire Team" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="53c5-45d2-c3b2-9748" name="Kabalite Warrior Fire Team" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1834,7 +1852,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7169-992d-3b64-7b89" name="Wych Fire Team" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7169-992d-3b64-7b89" name="Wych Fire Team" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/Genestealer Cults.cat
+++ b/Genestealer Cults.cat
@@ -33,7 +33,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -73,7 +73,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -97,7 +97,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -121,7 +121,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -145,7 +145,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -169,7 +169,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -193,7 +193,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -217,7 +217,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -241,7 +241,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -265,7 +265,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -289,7 +289,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -521,7 +521,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -545,7 +545,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -569,7 +569,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -593,7 +593,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1841,7 +1841,7 @@
             <modifier type="set" field="8255-3591-a1a6-6596" value="1">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1898,7 +1898,7 @@
         <modifier type="set" field="bdb3-410b-9820-f136" value="4">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1958,7 +1958,7 @@
                 <modifier type="set" field="e9a8-91bf-af10-8586" value="2">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -2005,7 +2005,7 @@
                 <modifier type="set" field="37bb-5d2e-d71f-9816" value="2">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -2167,7 +2167,7 @@
         <modifier type="set" field="855c-584d-2a32-1254" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -2537,7 +2537,7 @@
             <modifier type="set" field="a079-2a76-19fd-a500" value="1">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2681,7 +2681,7 @@
         <modifier type="set" field="6735-654f-a791-0497" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -3002,7 +3002,7 @@
             <modifier type="set" field="45b9-086c-a424-d7cd" value="1">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3051,7 +3051,7 @@
         <modifier type="set" field="6f1c-4987-21f8-cccb" value="4">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -3262,7 +3262,7 @@
         <modifier type="set" field="b6fe-73fd-03f7-c0cf" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/Genestealer Cults.cat
+++ b/Genestealer Cults.cat
@@ -33,7 +33,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -73,7 +73,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -97,7 +97,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -121,7 +121,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -145,7 +145,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -169,7 +169,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -193,7 +193,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -217,7 +217,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -241,7 +241,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -265,7 +265,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -289,7 +289,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -521,7 +521,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -545,7 +545,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -569,7 +569,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -593,7 +593,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -759,6 +759,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="c97d-ea8a-ab89-db3c" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="744d-6105-9849-92ad" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1761,6 +1768,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="629a-d49a-b639-8fa5" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -1827,7 +1841,7 @@
             <modifier type="set" field="8255-3591-a1a6-6596" value="1">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1884,7 +1898,7 @@
         <modifier type="set" field="bdb3-410b-9820-f136" value="4">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1914,6 +1928,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="9c88-8a1b-b463-cfc1" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -1937,7 +1958,7 @@
                 <modifier type="set" field="e9a8-91bf-af10-8586" value="2">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -1984,7 +2005,7 @@
                 <modifier type="set" field="37bb-5d2e-d71f-9816" value="2">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -2146,7 +2167,7 @@
         <modifier type="set" field="855c-584d-2a32-1254" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -2170,6 +2191,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="51c1-fa58-ea11-3e78" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="bafd-b8bb-293f-81e9" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2378,6 +2406,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="f553-83af-2d33-78d4" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -2502,7 +2537,7 @@
             <modifier type="set" field="a079-2a76-19fd-a500" value="1">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2646,7 +2681,7 @@
         <modifier type="set" field="6735-654f-a791-0497" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -2670,6 +2705,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="9cde-01ae-a10d-fcf1" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="87e4-8386-9f44-c6b9" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2868,6 +2910,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="e7db-277e-3b8f-9dd2" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -2953,7 +3002,7 @@
             <modifier type="set" field="45b9-086c-a424-d7cd" value="1">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3002,7 +3051,7 @@
         <modifier type="set" field="6f1c-4987-21f8-cccb" value="4">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -3026,6 +3075,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="67c6-55d3-5201-8d7f" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="cd90-4d0f-48a1-47b7" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3206,7 +3262,7 @@
         <modifier type="set" field="b6fe-73fd-03f7-c0cf" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -3230,6 +3286,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="832a-b6fa-7d93-f633" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3256-438f-4f92-71c8" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3427,6 +3490,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="a460-1ece-e3a8-82a8" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="68e5-3aa4-a3d9-b611" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/Grey Knights.cat
+++ b/Grey Knights.cat
@@ -35,7 +35,7 @@
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="38a8-583b-e25a-a707" name="Grey Knight" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="38a8-583b-e25a-a707" name="Grey Knight" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -57,6 +57,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="c8cf-9073-de64-50be" name="New CategoryLink" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3ad9-df2f-4cff-09d3" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -90,7 +97,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="18.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="51c8-182a-6377-4ba7" name="Justicar" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="51c8-182a-6377-4ba7" name="Justicar" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -114,6 +121,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="7310-6324-ae4c-e162" name="New CategoryLink" hidden="false" targetId="ade4-0710-e40e-be3f" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b5be-d5a7-0740-00f6" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -158,7 +172,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="19.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="db0b-99bf-7acc-bc81" name="Grey Knight Gunner" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="db0b-99bf-7acc-bc81" name="Grey Knight Gunner" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -182,6 +196,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="afe9-2346-fbc9-7d71" name="New CategoryLink" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7263-f4b6-6e67-8e05" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/Harlequins.cat
+++ b/Harlequins.cat
@@ -25,7 +25,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -81,7 +81,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -411,6 +411,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="ff9d-2150-ebde-76df" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -570,7 +577,9 @@
           <categoryLinks/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/Heretic Astartes.cat
+++ b/Heretic Astartes.cat
@@ -92,7 +92,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -116,7 +116,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -188,7 +188,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -212,7 +212,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -236,7 +236,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -260,7 +260,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -332,7 +332,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -356,7 +356,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -448,6 +448,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="440c-86a9-0361-2ed7" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -489,16 +496,10 @@
           <modifiers>
             <modifier type="set" field="4547-0559-9103-a271" value="1">
               <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
@@ -741,16 +742,10 @@
       <modifiers>
         <modifier type="set" field="24d7-68a8-ab3f-151a" value="2">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -786,6 +781,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="e10a-d98b-2475-8d82" name="Chaos Space Marine" hidden="false" targetId="be41-2105-548f-c896" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b543-83db-59f3-ac5c" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -828,16 +830,10 @@
               <modifiers>
                 <modifier type="set" field="9003-a457-1760-e71c" value="1">
                   <repeats/>
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </conditionGroup>
-                  </conditionGroups>
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
@@ -861,16 +857,10 @@
               <modifiers>
                 <modifier type="set" field="0104-5f25-89ab-d97b" value="1">
                   <repeats/>
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </conditionGroup>
-                  </conditionGroups>
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
@@ -1068,16 +1058,10 @@
         </modifier>
         <modifier type="set" field="f64a-f4cb-cd54-3361" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -1106,6 +1090,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="5c92-01c8-99c4-d286" name="Chaos Space Marine" hidden="false" targetId="be41-2105-548f-c896" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7077-cfbd-ae33-71cd" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1328,6 +1319,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="9f5b-52bf-9d49-42c1" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -1410,16 +1408,10 @@
       <modifiers>
         <modifier type="set" field="74c5-612f-3a9c-1879" value="2">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -1455,6 +1447,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="bca9-0c45-50b6-2e78" name="Chaos Cultist" hidden="false" targetId="f5f1-3c88-54ba-b808" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e46e-ffcf-29f3-1739" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1580,16 +1579,10 @@
         </modifier>
         <modifier type="set" field="7006-adbd-f976-45b4" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -1618,6 +1611,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="1c5a-9b31-96b0-3f0d" name="Chaos Cultist" hidden="false" targetId="f5f1-3c88-54ba-b808" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b150-93a3-8c66-8380" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/Heretic Astartes.cat
+++ b/Heretic Astartes.cat
@@ -92,7 +92,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -116,7 +116,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -188,7 +188,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -212,7 +212,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -236,7 +236,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -260,7 +260,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -332,7 +332,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -356,7 +356,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -497,7 +497,7 @@
             <modifier type="set" field="4547-0559-9103-a271" value="1">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -743,7 +743,7 @@
         <modifier type="set" field="24d7-68a8-ab3f-151a" value="2">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -831,7 +831,7 @@
                 <modifier type="set" field="9003-a457-1760-e71c" value="1">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -858,7 +858,7 @@
                 <modifier type="set" field="0104-5f25-89ab-d97b" value="1">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -1059,7 +1059,7 @@
         <modifier type="set" field="f64a-f4cb-cd54-3361" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1409,7 +1409,7 @@
         <modifier type="set" field="74c5-612f-3a9c-1879" value="2">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1580,7 +1580,7 @@
         <modifier type="set" field="7006-adbd-f976-45b4" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/Necrons.cat
+++ b/Necrons.cat
@@ -92,6 +92,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="6eb8-8ff4-7efc-c7d6" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d6a4-ab4d-fffe-7c4f" name="Synaptic Disintegrator" book="Kill-Team" hidden="false" collective="false" type="upgrade">
@@ -122,7 +129,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -184,6 +193,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="0961-8bab-fac9-faab" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0e0b-2f70-7467-9da8" name="Flayer Claws" hidden="false" collective="false" type="upgrade">
@@ -214,7 +230,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -276,6 +294,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="5f76-4439-e18e-8ad3" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -317,7 +342,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="75e7-d5ac-1457-2d49" name="Gauss Blaster" hidden="false" collective="false" type="upgrade">
               <profiles>
@@ -346,7 +373,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -411,6 +440,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="fbca-8fb8-4565-1959" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="42f3-8e69-386c-4d16" name="Gauss Flayer" hidden="false" collective="false" type="upgrade">
@@ -441,7 +477,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>

--- a/Orks.cat
+++ b/Orks.cat
@@ -53,7 +53,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -77,7 +77,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -117,7 +117,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -141,7 +141,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -165,7 +165,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -189,7 +189,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -213,7 +213,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -237,7 +237,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -261,7 +261,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -285,7 +285,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -557,7 +557,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a352-fa67-5831-e776" name="Burna Boy Fireteam" hidden="false" targetId="1189-7cbd-cf31-82f0" type="selectionEntry">
+    <entryLink id="a352-fa67-5831-e776" name="Burna Boy Fire Team" hidden="false" targetId="1189-7cbd-cf31-82f0" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -565,7 +565,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -589,7 +589,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -613,7 +613,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -637,7 +637,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -653,7 +653,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3ac3-327a-4529-0f5d" name="Ork Boy Fireteam" hidden="false" targetId="a7f8-a08d-3167-9ce7" type="selectionEntry">
+    <entryLink id="3ac3-327a-4529-0f5d" name="Ork Boy Fire Team" hidden="false" targetId="a7f8-a08d-3167-9ce7" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -661,7 +661,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -865,6 +865,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="3daf-4deb-7586-9832" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="6ea5-2abd-3ce2-69c8" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1313,6 +1320,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="b07e-1390-e778-471b" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -1435,6 +1449,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="4e67-9d44-8f6a-b356" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -1500,6 +1521,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="1748-6e6a-326f-2e1f" name="Ork Boy" hidden="false" targetId="2a73-3eb4-3c77-db12" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="f819-1299-7fff-146b" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1595,6 +1623,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="5bdf-bdba-a9dd-1f55" name="Ork Boy" hidden="false" targetId="2a73-3eb4-3c77-db12" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="21a7-fe76-86fa-9273" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1765,6 +1800,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="9c17-0a7a-b5ba-806f" name="Ork Boy" hidden="false" targetId="2a73-3eb4-3c77-db12" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="6055-936c-1dc0-3c7e" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1945,6 +1987,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="6bea-2625-b8d8-1d89" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -2058,6 +2107,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="c171-bae0-ee09-ceb1" name="Kommando" hidden="false" targetId="5512-42ad-65db-312e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="be13-5c16-fb87-2f93" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2196,6 +2252,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="fa69-0b97-c37d-e06c" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -2292,6 +2355,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="b531-3da2-eb0b-b993" name="Loota" hidden="false" targetId="19cd-daa7-553c-ec0a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9bd0-ce5b-8a09-3380" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2414,7 +2484,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a7f8-a08d-3167-9ce7" name="Ork Boy Fireteam" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a7f8-a08d-3167-9ce7" name="Ork Boy Fire Team" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2534,7 +2604,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1189-7cbd-cf31-82f0" name="Burna Boy Fireteam" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1189-7cbd-cf31-82f0" name="Burna Boy Fire Team" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/T'au Empire.cat
+++ b/T'au Empire.cat
@@ -60,7 +60,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -84,7 +84,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -108,7 +108,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -132,7 +132,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -172,7 +172,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -196,7 +196,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -220,7 +220,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -244,7 +244,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -444,7 +444,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -596,7 +596,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -620,7 +620,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -644,7 +644,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -668,7 +668,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/T'au Empire.cat
+++ b/T'au Empire.cat
@@ -60,7 +60,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -84,7 +84,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -108,7 +108,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -132,7 +132,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -172,7 +172,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -196,7 +196,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -220,7 +220,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -244,7 +244,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -444,7 +444,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -596,7 +596,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -620,7 +620,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -644,7 +644,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -668,7 +668,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -739,6 +739,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="59c4-e043-ddf8-b237" name="Fire Warrior" hidden="false" targetId="6abe-382b-3cd5-c6d4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a9e0-da86-5408-ab20" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -871,6 +878,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="e730-3f61-4120-5b7b" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d2c4-ecd3-69a1-9657" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1091,6 +1105,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="9718-7736-e7e9-0d74" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -1179,6 +1200,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="8d9d-027e-009b-9e73" name="Pathfinder" hidden="false" targetId="68ce-4791-39e0-d5e2" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="c591-9ab8-3acf-e680" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1309,6 +1337,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="72ed-e0c7-b573-ebc4" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -1405,6 +1440,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="1979-65ac-6b87-0ff6" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1384-a27b-58bb-61a3" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1515,6 +1557,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="7ce1-86e7-9bfc-7871" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="874e-83b6-3c12-d493" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1674,6 +1723,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="c297-786f-fed3-3f88" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -1797,6 +1853,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="e953-0513-8f0c-a970" name="XV25 Stealth Battlesuit" hidden="false" targetId="2ed3-4683-ef2f-117f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5f97-cfe8-55f4-aaac" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1932,6 +1995,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="73a2-3e46-e0f9-15c4" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -2018,6 +2088,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="ba0c-8fa8-0c3a-52f7" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1afb-14e1-9345-a947" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2116,6 +2193,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="7fc8-e014-ba8c-ed97" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="99a9-f8c9-319b-0728" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2222,6 +2306,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="1909-70da-39d8-f96a" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -2305,6 +2396,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="20dc-2a7c-f17f-bb3c" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4cb0-c901-f491-2c51" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2400,6 +2498,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="a4e1-c1ee-52ab-7b7d" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -2483,6 +2588,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="ec53-b890-a71f-30a1" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a620-a9b0-eec1-c2d5" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2946,7 +3058,9 @@
           <categoryLinks/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="6121-1ea5-58dc-3db3" name="Fire Warrior Breacher Fire Team" hidden="false" collective="false" type="unit">
       <profiles/>
@@ -3016,7 +3130,9 @@
           <categoryLinks/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="c9fc-551a-7dd5-723f" name="Pathfinder Fire Team" hidden="false" collective="false" type="unit">
       <profiles/>
@@ -3102,7 +3218,9 @@
           <categoryLinks/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="02ca-bd08-d933-61e4" name="XV25 Stealth Battlesuit Fire Team" hidden="false" collective="false" type="unit">
       <profiles/>
@@ -3172,7 +3290,9 @@
           <categoryLinks/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/Thousand Sons.cat
+++ b/Thousand Sons.cat
@@ -142,7 +142,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -166,7 +166,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -190,7 +190,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -214,7 +214,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -238,7 +238,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -262,7 +262,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -286,7 +286,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -499,7 +499,7 @@
         <modifier type="set" field="c813-b02b-3708-bfa1" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -786,7 +786,7 @@
         <modifier type="set" field="3e41-dfe7-5837-049d" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -858,7 +858,7 @@
         <modifier type="set" field="bed5-190a-4269-f79c" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1254,7 +1254,7 @@
         <modifier type="set" field="76fc-4c63-5430-7b48" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1399,7 +1399,7 @@
         <modifier type="set" field="ce20-0822-9c1c-d43a" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/Thousand Sons.cat
+++ b/Thousand Sons.cat
@@ -142,7 +142,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -166,7 +166,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -190,7 +190,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -214,7 +214,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -238,7 +238,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -262,7 +262,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -286,7 +286,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -402,6 +402,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="6982-067a-c2ec-b2cf" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -491,16 +498,10 @@
       <modifiers>
         <modifier type="set" field="c813-b02b-3708-bfa1" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>
@@ -550,6 +551,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="e1da-bc2a-4154-ac82" name="Rubric Marine" hidden="false" targetId="0110-fd3d-1c15-4846" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="f8b6-16a8-e40f-75f2" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -777,16 +785,10 @@
       <modifiers>
         <modifier type="set" field="3e41-dfe7-5837-049d" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -855,16 +857,10 @@
         </modifier>
         <modifier type="set" field="bed5-190a-4269-f79c" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -914,6 +910,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="cf94-e8b1-6b34-31ba" name="Rubric Marine" hidden="false" targetId="0110-fd3d-1c15-4846" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="36d1-eb4f-6c57-cdfa" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1125,6 +1128,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="6671-c4cf-b20a-8d06" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -1243,16 +1253,10 @@
         </modifier>
         <modifier type="set" field="76fc-4c63-5430-7b48" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -1295,6 +1299,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="81bc-d843-b95d-f0a7" name="Tzaangor" hidden="false" targetId="1eaf-47ca-d17e-14b9" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5148-f90c-2b9b-396a" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1387,16 +1398,10 @@
       <modifiers>
         <modifier type="set" field="ce20-0822-9c1c-d43a" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -1419,7 +1424,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="3.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d63c-d18d-ce19-32b9" name="Rubric Marine Fire Team" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d63c-d18d-ce19-32b9" name="Rubric Marine Fire Team" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1483,7 +1488,7 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8545-f3b5-5fba-f75c" name="Tzaangor Fire Team" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8545-f3b5-5fba-f75c" name="Tzaangor Fire Team" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -25,7 +25,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -81,7 +81,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -121,7 +121,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -177,7 +177,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -249,7 +249,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -289,7 +289,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -329,7 +329,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -353,7 +353,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -377,7 +377,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -401,7 +401,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -425,7 +425,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1628,10 +1628,10 @@
           <repeats/>
           <conditions/>
           <conditionGroups>
-            <conditionGroup type="or">
+            <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa4e-0d80-457c-5b71" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3620-0e49-2443-f84c" type="atLeast"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </conditionGroup>

--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -518,6 +518,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="5df8-59a0-13f5-71a2" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -1050,6 +1057,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="a91f-7213-140f-ac2e" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -1136,6 +1150,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="5a4f-6840-f58c-af29" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e2f1-3b46-9225-8dda" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1245,6 +1266,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="f785-6d7e-b17b-777b" name="Synapse" hidden="false" targetId="e3df-6aab-c05a-e47a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="c307-67c3-3508-cdac" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1480,6 +1508,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="a602-dc19-753d-45a9" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2281-a4c6-444f-9ba8" name="Extended Carapace" hidden="false" collective="false" type="upgrade">
@@ -1664,6 +1699,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="c264-ed3b-7092-a030" name="Synapse" hidden="false" targetId="e3df-6aab-c05a-e47a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="48d9-3fcf-8ea8-1b69" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -25,7 +25,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -81,7 +81,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -121,7 +121,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -177,7 +177,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -249,7 +249,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -289,7 +289,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -329,7 +329,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -353,7 +353,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -377,7 +377,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -401,7 +401,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -425,7 +425,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1661,16 +1661,10 @@
       <modifiers>
         <modifier type="set" field="c5ff-4207-095e-3e43" value="1">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3620-0e49-2443-f84c" type="atLeast"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
           <repeats>

--- a/Warhammer 40,000 Kill Team.gst
+++ b/Warhammer 40,000 Kill Team.gst
@@ -350,166 +350,206 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
-  </categoryEntries>
-  <forceEntries>
-    <forceEntry id="e4d5-5711-a9f4-df8a" name="Campaign Command Roster" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="forces" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b7d-6325-e0da-8c90" type="max"/>
-      </constraints>
-      <forceEntries>
-        <forceEntry id="7689-47b4-bf25-9983" name="Additional Faction" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <forceEntries/>
-          <categoryLinks>
-            <categoryLink id="cf5a-b710-c2fe-2208" name="Leader" hidden="false" targetId="ade4-0710-e40e-be3f" primary="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </categoryLink>
-            <categoryLink id="23ab-e0fc-b087-c987" name="Specialist" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </categoryLink>
-            <categoryLink id="3579-9fe2-3b51-0dd6" name="Non-specialist" hidden="false" targetId="79c6-76fc-47ee-c005" primary="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </forceEntry>
-      </forceEntries>
-      <categoryLinks>
-        <categoryLink id="7364-5a55-e70a-b82c" name="Leader" hidden="false" targetId="ade4-0710-e40e-be3f" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="e552-94a3-fada-3ac8" name="Specialist" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="4dba-e9c3-914a-95f1" name="Non-specialist" hidden="false" targetId="79c6-76fc-47ee-c005" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </forceEntry>
-    <forceEntry id="fa4e-0d80-457c-5b71" name="Unbound Kill Team (Faction)" hidden="false">
+    <categoryEntry id="f868-bdfd-567c-3eac" name="Configuration" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
-      <forceEntries/>
-      <categoryLinks>
-        <categoryLink id="d519-88fa-4ff3-3500" name="Non-specialist" hidden="false" targetId="79c6-76fc-47ee-c005" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </forceEntry>
-    <forceEntry id="ac29-0dee-157a-17e9" name="Battle-Forged Kill Team" hidden="false">
+    </categoryEntry>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="cf61-9e5a-51cd-b4d2" name="New ForceEntry" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="increment" field="145c-3c0c-cd54-da88" value="3">
+          <repeats/>
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="increment" field="aeca-a38d-da39-7958" value="21">
+          <repeats/>
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="increment" field="aeca-a38d-da39-7958" value="1">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="true" childId="f868-bdfd-567c-3eac" repeats="1" roundUp="false"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="increment" field="145c-3c0c-cd54-da88" value="1">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="true" childId="f868-bdfd-567c-3eac" repeats="1" roundUp="false"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
-        <constraint field="forces" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65fd-d410-2917-f116" type="max"/>
-        <constraint field="selections" scope="ac29-0dee-157a-17e9" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="337d-f3d4-834e-ea3b" type="min"/>
-        <constraint field="selections" scope="ac29-0dee-157a-17e9" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f544-5d51-3425-4638" type="max"/>
+        <constraint field="selections" scope="cf61-9e5a-51cd-b4d2" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="145c-3c0c-cd54-da88" type="min"/>
+        <constraint field="selections" scope="cf61-9e5a-51cd-b4d2" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeca-a38d-da39-7958" type="max"/>
       </constraints>
       <forceEntries/>
       <categoryLinks>
-        <categoryLink id="deec-4720-97b7-9084" name="Leader" hidden="false" targetId="ade4-0710-e40e-be3f" primary="false">
+        <categoryLink id="ea41-fbff-2a87-03d1" name="Configuration" hidden="false" targetId="f868-bdfd-567c-3eac" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9244-536c-af08-e245" name="Leader" hidden="false" targetId="ade4-0710-e40e-be3f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="4d02-f2ef-451d-d936" value="1">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="5fb4-4918-172f-e221" value="1">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5690-c19e-2b74-b79e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f13-11b7-081e-aed8" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d02-f2ef-451d-d936" type="min"/>
+            <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fb4-4918-172f-e221" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="cf45-e14a-fbf9-1ed4" name="Specialist" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="false">
+        <categoryLink id="cffd-1e9c-9dad-c18c" name="Specialist" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="525d-4bde-68f0-bf69" value="3">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="name" value="Specialists">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2f3-2501-58d1-6ffc" type="max"/>
+            <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="525d-4bde-68f0-bf69" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="0527-f4a1-dd07-1e41" name="Non-specialist" hidden="false" targetId="79c6-76fc-47ee-c005" primary="false">
+        <categoryLink id="dc99-4f37-7093-0143" name="Non-specialist" hidden="false" targetId="79c6-76fc-47ee-c005" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </forceEntry>
-    <forceEntry id="061f-b8d6-9327-b0f4" name="Command Roster" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="forces" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d01d-82c6-f6ee-373d" type="max"/>
-      </constraints>
-      <forceEntries/>
-      <categoryLinks>
-        <categoryLink id="255e-821e-135c-f3f3" name="Leader" hidden="false" targetId="ade4-0710-e40e-be3f" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="1819-3916-66b2-9d97" name="Specialist" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="467b-163e-1bf9-4c5a" name="Non-specialist" hidden="false" targetId="79c6-76fc-47ee-c005" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Non-specialists">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints/>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
   <selectionEntries/>
-  <entryLinks/>
+  <entryLinks>
+    <entryLink id="fc29-676e-4440-e9f0" name="Play Type" hidden="false" targetId="3bad-f4a7-ed42-7df2" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="54b1-1a28-ec4b-3d05" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ead6-9195-5120-43ec" name="Force Type" hidden="false" targetId="5635-dbb6-369f-79a1" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="3155-5a94-043b-34b7" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="2abd-70f4-e7e8-4d18" name="Leader" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -570,7 +610,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -646,7 +686,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -804,7 +844,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1074,7 +1114,7 @@
         <modifier type="set" field="b05f-c8a5-19d9-fdf4" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1118,7 +1158,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1194,7 +1234,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1352,7 +1392,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1627,7 +1667,7 @@
         <modifier type="set" field="71a3-7444-85bc-e92c" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1671,7 +1711,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1747,7 +1787,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1905,7 +1945,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2180,7 +2220,7 @@
         <modifier type="set" field="64c0-e5e2-6e74-cb28" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -2224,7 +2264,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2300,7 +2340,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2458,7 +2498,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2733,7 +2773,7 @@
         <modifier type="set" field="921f-a4b6-c780-7a01" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -2777,7 +2817,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2853,7 +2893,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3011,7 +3051,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3286,7 +3326,7 @@
         <modifier type="set" field="b3fd-1676-cf76-0d32" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -3330,7 +3370,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3406,7 +3446,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3564,7 +3604,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3839,7 +3879,7 @@
         <modifier type="set" field="ca81-0581-b417-da23" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -3883,7 +3923,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3959,7 +3999,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4117,7 +4157,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4392,7 +4432,7 @@
         <modifier type="set" field="e6d8-2bc9-ef07-668e" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -4436,7 +4476,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4512,7 +4552,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4670,7 +4710,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4945,7 +4985,7 @@
         <modifier type="set" field="2b41-63b1-947c-209a" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -4989,7 +5029,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -5065,7 +5105,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -5223,7 +5263,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -5498,7 +5538,7 @@
         <modifier type="set" field="3e55-ff6d-542e-55b2" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac29-0dee-157a-17e9" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -5542,7 +5582,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -5618,7 +5658,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -5776,7 +5816,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e4d5-5711-a9f4-df8a" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -6250,6 +6290,128 @@
       <costs>
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="3bad-f4a7-ed42-7df2" name="Play Type" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6e6f-4faa-0552-2aac" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45f4-6a04-18be-93ae" type="min"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6529-7966-8344-6518" name="Type" hidden="false" collective="false" defaultSelectionEntryId="f0ac-0757-6627-49ef">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e685-a35e-350b-0e3d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a09-37de-fdea-5afd" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="f0ac-0757-6627-49ef" name="Matched Play" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+            <selectionEntry id="fe43-60aa-1723-2ebb" name="Campaign" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+            <selectionEntry id="c121-389a-4aa9-c9ef" name="Open Play" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="5635-dbb6-369f-79a1" name="Force Type" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="25cf-b015-0fff-4289" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e98c-5ca9-b09e-3615" type="min"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fada-d403-903d-a282" name="Type" hidden="false" collective="false" defaultSelectionEntryId="3620-0e49-2443-f84c">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c842-781d-9628-1a37" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1100-9a0d-6c7a-bcae" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="3620-0e49-2443-f84c" name="Kill Team" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+            <selectionEntry id="8dad-156f-fab6-0e6c" name="Command Roster" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups/>

--- a/Warhammer 40,000 Kill Team.gst
+++ b/Warhammer 40,000 Kill Team.gst
@@ -357,25 +357,12 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
-    <categoryEntry id="50dd-a755-e02d-1c30" name="Model" hidden="false">
+    <categoryEntry id="50dd-a755-e02d-1c30" name="Model" hidden="true">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="526b-ce9b-2acd-a91f" value="3">
-          <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" field="4b27-4221-00e5-c79e" value="20">
+        <modifier type="set" field="hidden" value="false">
           <repeats/>
           <conditions/>
           <conditionGroups>
@@ -390,8 +377,8 @@
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4b27-4221-00e5-c79e" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="526b-ce9b-2acd-a91f" type="min"/>
+        <constraint field="selections" scope="force" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4b27-4221-00e5-c79e" type="max"/>
+        <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="526b-ce9b-2acd-a91f" type="min"/>
       </constraints>
     </categoryEntry>
   </categoryEntries>

--- a/Warhammer 40,000 Kill Team.gst
+++ b/Warhammer 40,000 Kill Team.gst
@@ -357,19 +357,19 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
-    <categoryEntry id="50dd-a755-e02d-1c30" name="Model" hidden="true">
+    <categoryEntry id="50dd-a755-e02d-1c30" name="Model" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="hidden" value="false">
+        <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions/>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="beaf-798d-961f-353d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f81f-45d9-e33e-add6" type="greaterThan"/>
               </conditions>
               <conditionGroups/>
             </conditionGroup>
@@ -381,9 +381,44 @@
         <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="526b-ce9b-2acd-a91f" type="min"/>
       </constraints>
     </categoryEntry>
+    <categoryEntry id="c502-39de-965b-6780" name="Style: Matched" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="f81f-45d9-e33e-add6" name="Style: Open" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="7c0b-7da1-facd-d326" name="Style: Campaign" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="d6e9-5af3-c17c-77a0" name="List: Command Roster" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="beaf-798d-961f-353d" name="List: Kill Team" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="cf61-9e5a-51cd-b4d2" name="New ForceEntry" hidden="false">
+    <forceEntry id="cf61-9e5a-51cd-b4d2" name="Kill Team List" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -409,8 +444,8 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="beaf-798d-961f-353d" type="atLeast"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f81f-45d9-e33e-add6" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -422,8 +457,8 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="beaf-798d-961f-353d" type="atLeast"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f81f-45d9-e33e-add6" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -446,8 +481,8 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="beaf-798d-961f-353d" type="atLeast"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f81f-45d9-e33e-add6" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -481,37 +516,13 @@
   </forceEntries>
   <selectionEntries/>
   <entryLinks>
-    <entryLink id="fc29-676e-4440-e9f0" name="Play Type" hidden="false" targetId="3bad-f4a7-ed42-7df2" type="selectionEntry">
+    <entryLink id="5c5e-a332-5578-705f" name="List Configuration" hidden="false" targetId="24de-9906-6401-a20e" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
-      <categoryLinks>
-        <categoryLink id="54b1-1a28-ec4b-3d05" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="ead6-9195-5120-43ec" name="Force Type" hidden="false" targetId="5635-dbb6-369f-79a1" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="3155-5a94-043b-34b7" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
+      <categoryLinks/>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
@@ -574,7 +585,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -650,7 +661,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -808,7 +819,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1078,7 +1089,7 @@
         <modifier type="set" field="b05f-c8a5-19d9-fdf4" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1122,7 +1133,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1198,7 +1209,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1356,7 +1367,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1631,7 +1642,7 @@
         <modifier type="set" field="71a3-7444-85bc-e92c" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1675,7 +1686,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1751,7 +1762,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1909,7 +1920,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2184,7 +2195,7 @@
         <modifier type="set" field="64c0-e5e2-6e74-cb28" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -2228,7 +2239,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2304,7 +2315,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2462,7 +2473,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2737,7 +2748,7 @@
         <modifier type="set" field="921f-a4b6-c780-7a01" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -2781,7 +2792,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -2857,7 +2868,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3015,7 +3026,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3290,7 +3301,7 @@
         <modifier type="set" field="b3fd-1676-cf76-0d32" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -3334,7 +3345,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3410,7 +3421,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3568,7 +3579,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3843,7 +3854,7 @@
         <modifier type="set" field="ca81-0581-b417-da23" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -3887,7 +3898,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3963,7 +3974,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4121,7 +4132,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4396,7 +4407,7 @@
         <modifier type="set" field="e6d8-2bc9-ef07-668e" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -4440,7 +4451,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4516,7 +4527,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4674,7 +4685,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4949,7 +4960,7 @@
         <modifier type="set" field="2b41-63b1-947c-209a" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -4993,7 +5004,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -5069,7 +5080,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -5227,7 +5238,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -5502,7 +5513,7 @@
         <modifier type="set" field="3e55-ff6d-542e-55b2" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -5546,7 +5557,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -5622,7 +5633,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -5780,7 +5791,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe43-60aa-1723-2ebb" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7c0b-7da1-facd-d326" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -6255,70 +6266,171 @@
         <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3bad-f4a7-ed42-7df2" name="Play Type" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="24de-9906-6401-a20e" name="List Configuration" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6e6f-4faa-0552-2aac" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45f4-6a04-18be-93ae" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3390-f434-cef0-6724" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffa5-ce6c-702c-892b" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="e524-6f24-047d-43a6" name="Configuration" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6529-7966-8344-6518" name="Type" hidden="false" collective="false" defaultSelectionEntryId="f0ac-0757-6627-49ef">
+        <selectionEntryGroup id="a763-c901-e2be-22eb" name="List type" hidden="false" collective="false" defaultSelectionEntryId="46a8-9e97-401a-03f7">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e685-a35e-350b-0e3d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a09-37de-fdea-5afd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27bb-e326-e790-fbd8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a64-7810-b1c5-b526" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="f0ac-0757-6627-49ef" name="Matched Play" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="46a8-9e97-401a-03f7" name="Matched Play: Kill Team" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <categoryLinks/>
+              <categoryLinks>
+                <categoryLink id="e565-1c87-f29e-f95e" name="Style: Matched" hidden="false" targetId="c502-39de-965b-6780" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="c47b-098f-8688-9632" name="List: Kill Team" hidden="false" targetId="beaf-798d-961f-353d" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
+              <costs/>
             </selectionEntry>
-            <selectionEntry id="fe43-60aa-1723-2ebb" name="Campaign" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="57bf-6123-c537-58ac" name="Matched Play: Command Roster" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <categoryLinks/>
+              <categoryLinks>
+                <categoryLink id="7876-989e-5dfb-9f1a" name="List: Command Roster" hidden="false" targetId="d6e9-5af3-c17c-77a0" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="648a-1b0f-b346-d480" name="Style: Matched" hidden="false" targetId="c502-39de-965b-6780" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
+              <costs/>
             </selectionEntry>
-            <selectionEntry id="c121-389a-4aa9-c9ef" name="Open Play" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="01b9-249b-0eb4-6437" name="Open Play: Kill Team" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <categoryLinks/>
+              <categoryLinks>
+                <categoryLink id="365c-f9f3-90a0-8e58" name="Style: Open" hidden="false" targetId="f81f-45d9-e33e-add6" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="ad79-7ffc-86d0-b18f" name="List: Kill Team" hidden="false" targetId="beaf-798d-961f-353d" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
+              <costs/>
+            </selectionEntry>
+            <selectionEntry id="f0cd-e1da-e4f1-6a32" name="Campaign: Command Roster" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3742-f20b-fe89-0c70" name="List: Command Roster" hidden="false" targetId="d6e9-5af3-c17c-77a0" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="993e-8df1-dade-1dfb" name="Style: Campaign" hidden="false" targetId="7c0b-7da1-facd-d326" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+            <selectionEntry id="1d42-9d57-38c5-9a02" name="Campaign: Kill Team" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="caba-8b57-b633-365a" name="List: Kill Team" hidden="false" targetId="beaf-798d-961f-353d" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="2926-6d86-3aaa-2f40" name="Style: Campaign" hidden="false" targetId="7c0b-7da1-facd-d326" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -6326,70 +6438,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5635-dbb6-369f-79a1" name="Force Type" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="25cf-b015-0fff-4289" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e98c-5ca9-b09e-3615" type="min"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="fada-d403-903d-a282" name="Type" hidden="false" collective="false" defaultSelectionEntryId="3620-0e49-2443-f84c">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c842-781d-9628-1a37" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1100-9a0d-6c7a-bcae" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="3620-0e49-2443-f84c" name="Kill Team" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8dad-156f-fab6-0e6c" name="Command Roster" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups/>

--- a/Warhammer 40,000 Kill Team.gst
+++ b/Warhammer 40,000 Kill Team.gst
@@ -364,16 +364,10 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="beaf-798d-961f-353d" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f81f-45d9-e33e-add6" type="greaterThan"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c0f7-c442-b695-bf07" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -416,6 +410,13 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
+    <categoryEntry id="c0f7-c442-b695-bf07" name="List: Battle-Forged Kill Team" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="cf61-9e5a-51cd-b4d2" name="Kill Team List" hidden="false">
@@ -440,29 +441,17 @@
           <modifiers>
             <modifier type="set" field="4d02-f2ef-451d-d936" value="1">
               <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="beaf-798d-961f-353d" type="atLeast"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f81f-45d9-e33e-add6" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c0f7-c442-b695-bf07" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
             </modifier>
             <modifier type="set" field="5fb4-4918-172f-e221" value="1">
               <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="beaf-798d-961f-353d" type="atLeast"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f81f-45d9-e33e-add6" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c0f7-c442-b695-bf07" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
@@ -477,16 +466,10 @@
           <modifiers>
             <modifier type="set" field="525d-4bde-68f0-bf69" value="3">
               <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="beaf-798d-961f-353d" type="atLeast"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f81f-45d9-e33e-add6" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c0f7-c442-b695-bf07" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
             </modifier>
             <modifier type="set" field="name" value="Specialists">
               <repeats/>
@@ -6318,6 +6301,13 @@
                   <modifiers/>
                   <constraints/>
                 </categoryLink>
+                <categoryLink id="5f59-f023-e937-0bbd" name="List: Battle-Forged Kill Team" hidden="false" targetId="c0f7-c442-b695-bf07" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
               </categoryLinks>
               <selectionEntries/>
               <selectionEntryGroups/>
@@ -6420,6 +6410,13 @@
                   <constraints/>
                 </categoryLink>
                 <categoryLink id="2926-6d86-3aaa-2f40" name="Style: Campaign" hidden="false" targetId="7c0b-7da1-facd-d326" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="b1b3-d209-71e9-b552" name="List: Battle-Forged Kill Team" hidden="false" targetId="c0f7-c442-b695-bf07" primary="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>

--- a/Warhammer 40,000 Kill Team.gst
+++ b/Warhammer 40,000 Kill Team.gst
@@ -6312,7 +6312,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="57bf-6123-c537-58ac" name="Matched Play: Command Roster" hidden="false" collective="false" type="upgrade">
               <profiles/>
@@ -6339,7 +6341,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="01b9-249b-0eb4-6437" name="Open Play: Kill Team" hidden="false" collective="false" type="upgrade">
               <profiles/>
@@ -6366,7 +6370,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="f0cd-e1da-e4f1-6a32" name="Campaign: Command Roster" hidden="false" collective="false" type="upgrade">
               <profiles/>
@@ -6393,7 +6399,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="1d42-9d57-38c5-9a02" name="Campaign: Kill Team" hidden="false" collective="false" type="upgrade">
               <profiles/>
@@ -6427,7 +6435,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -6435,7 +6445,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups/>

--- a/Warhammer 40,000 Kill Team.gst
+++ b/Warhammer 40,000 Kill Team.gst
@@ -357,14 +357,12 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
-  </categoryEntries>
-  <forceEntries>
-    <forceEntry id="cf61-9e5a-51cd-b4d2" name="New ForceEntry" hidden="false">
+    <categoryEntry id="50dd-a755-e02d-1c30" name="Model" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="increment" field="145c-3c0c-cd54-da88" value="3">
+        <modifier type="set" field="526b-ce9b-2acd-a91f" value="3">
           <repeats/>
           <conditions/>
           <conditionGroups>
@@ -377,38 +375,8 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="increment" field="aeca-a38d-da39-7958" value="21">
+        <modifier type="set" field="4b27-4221-00e5-c79e" value="20">
           <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="increment" field="aeca-a38d-da39-7958" value="1">
-          <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="true" childId="f868-bdfd-567c-3eac" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3620-0e49-2443-f84c" type="atLeast"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c121-389a-4aa9-c9ef" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="increment" field="145c-3c0c-cd54-da88" value="1">
-          <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="true" childId="f868-bdfd-567c-3eac" repeats="1" roundUp="false"/>
-          </repeats>
           <conditions/>
           <conditionGroups>
             <conditionGroup type="and">
@@ -422,9 +390,18 @@
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="cf61-9e5a-51cd-b4d2" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="145c-3c0c-cd54-da88" type="min"/>
-        <constraint field="selections" scope="cf61-9e5a-51cd-b4d2" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeca-a38d-da39-7958" type="max"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4b27-4221-00e5-c79e" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="526b-ce9b-2acd-a91f" type="min"/>
       </constraints>
+    </categoryEntry>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="cf61-9e5a-51cd-b4d2" name="New ForceEntry" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
       <forceEntries/>
       <categoryLinks>
         <categoryLink id="ea41-fbff-2a87-03d1" name="Configuration" hidden="false" targetId="f868-bdfd-567c-3eac" primary="false">
@@ -6324,7 +6301,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="fe43-60aa-1723-2ebb" name="Campaign" hidden="false" collective="false" type="upgrade">
               <profiles/>
@@ -6336,7 +6315,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="c121-389a-4aa9-c9ef" name="Open Play" hidden="false" collective="false" type="upgrade">
               <profiles/>
@@ -6348,7 +6329,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -6356,7 +6339,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="5635-dbb6-369f-79a1" name="Force Type" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -6391,7 +6376,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="8dad-156f-fab6-0e6c" name="Command Roster" hidden="false" collective="false" type="upgrade">
               <profiles/>
@@ -6403,7 +6390,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -6411,7 +6400,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups/>


### PR DESCRIPTION
* Changed Force Types to single `Kill Team List`
* Choice of validation mode etc is by `List Configuration` entry from `Configuration` category, auto-taken by BattleScribe when creating new roster (convenient), with pre-selected `Matched Play: Kill Team`. This entry provides following choice of configurations:
  * Campaign: Command Roster
  * Campaign: Kill Team
  * Matched Play: Command Roster
  * Matched Play: Kill Team
  * Open Play: Kill Team

  These configuration entries have appropriate categories selected out of these new categories:
  * List: Kill Team
  * List: Command Roster
  * Style: Campaign
  * Style: Matched
  * Style: Open

  Show-hide for Fire Teams is now based on Force having at least 1 selection of `Style: Campaign`. Limits that are described in datasheets (max 1 per kill team etc.) should be conditioned on Force having at least 1 selections of `List: Kill Team`.

* Validation of BFKT model count (3-20) is based on new `Model` category, which has to be assigned to every model entry in catalogues (already done in this PR). These limits are on the category itself, and activate on `List: Battle-Forged Kill Team` category selection, which is currently only assigned to `Matched Play: Kill Team` configuration.


It's **important** to note that all these conditions that work off categories need to have the "And all child selections" checkbox selected.