### PR TITLE
Sub faction rework

### DIFF
--- a/Adeptus Astartes.cat
+++ b/Adeptus Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6112-edb9-977c-198e" name="Adeptus Astartes" revision="16" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6112-edb9-977c-198e" name="Adeptus Astartes" revision="17" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="51fd-2592-44bd-2226" name="Intercessor" hidden="false"/>
     <categoryEntry id="200c-8203-0e5a-0f41" name="Primaris" hidden="false"/>
@@ -262,7 +262,6 @@
     <entryLink id="08f3-158b-5743-f46e" name="Primaris Chaplain" hidden="false" collective="false" targetId="846c-7d3e-e6cd-0217" type="selectionEntry"/>
     <entryLink id="175b-3d67-60a5-89b7" name="Primaris Librarian" hidden="false" collective="false" targetId="4674-18d2-2bd6-a9d0" type="selectionEntry"/>
     <entryLink id="1ee7-3a42-52a8-bbb3" name="Janus Draik" hidden="false" collective="false" targetId="51ae-59d9-809a-f5dc" type="selectionEntry"/>
-    <entryLink id="794a-a4a6-5acc-cf20" name="Chapter Tactics" hidden="false" collective="false" targetId="a66e-3a62-2b0e-7d04" type="selectionEntry"/>
     <entryLink id="f6a5-0df6-70f5-bba5" name="Captain in Phobos Armour" hidden="false" collective="false" targetId="f4e6-fc31-8475-2fda" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6c60-7364-7ade-ba6b" name="Faction: Adeptus Astartes" hidden="false" targetId="f0ef-d104-7cde-57ed" primary="false"/>
@@ -520,18 +519,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="c814-3102-b7bb-33e4" name="Space Wolf Terminator" hidden="false" collective="false" targetId="5dfb-22dd-dee3-7841" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9e9-67e7-3016-380a" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="c9eb-a700-490a-5a6b" name="New CategoryLink" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="true"/>
         <categoryLink id="1dc7-b4f6-5077-ffcc" name="Faction: Adeptus Astartes" hidden="false" targetId="f0ef-d104-7cde-57ed" primary="false"/>
@@ -543,16 +530,6 @@
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9e9-67e7-3016-380a" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -567,16 +544,6 @@
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
         </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9e9-67e7-3016-380a" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="9dc9-6aa9-c442-686b" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true"/>
@@ -584,36 +551,12 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="dad1-6464-056d-8dbd" name="Space Wolf Terminator Gunner" hidden="false" collective="false" targetId="f512-7b06-73fb-f089" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9e9-67e7-3016-380a" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9aa5-7191-c36a-94ab" name="New CategoryLink" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="true"/>
         <categoryLink id="8e39-8e3b-3492-a6e4" name="Faction: Adeptus Astartes" hidden="false" targetId="f0ef-d104-7cde-57ed" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9b86-dfdd-45dc-23d6" name="Space Wolf Terminator Sergeant" hidden="false" collective="false" targetId="7a22-4e8b-6f21-a7d6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9e9-67e7-3016-380a" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="8d91-531a-b63b-6c54" name="New CategoryLink" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="true"/>
         <categoryLink id="4068-cdd9-f23f-38df" name="Faction: Adeptus Astartes" hidden="false" targetId="f0ef-d104-7cde-57ed" primary="false"/>
@@ -626,16 +569,6 @@
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="equalTo"/>
           </conditions>
         </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9e9-67e7-3016-380a" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="4deb-c754-5fa3-6dc4" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true"/>
@@ -643,18 +576,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="b7d9-6c0c-e59b-f5d5" name="Space Wolf Terminator Sergeant" hidden="false" collective="false" targetId="7a22-4e8b-6f21-a7d6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9e9-67e7-3016-380a" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="2d67-1915-22e2-b576" name="New CategoryLink" hidden="false" targetId="ade4-0710-e40e-be3f" primary="true"/>
         <categoryLink id="e846-3686-b5ba-4aa4" name="Faction: Adeptus Astartes" hidden="false" targetId="f0ef-d104-7cde-57ed" primary="false"/>
@@ -1534,6 +1455,7 @@
           </constraints>
         </entryLink>
         <entryLink id="b349-e2a0-6ed8-9d22" name="Specialism" hidden="false" collective="false" targetId="a12e-5cf6-d9c6-0e56" type="selectionEntryGroup"/>
+        <entryLink id="d6d6-c1c8-482f-8415" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="12.0"/>
@@ -1586,6 +1508,7 @@
           </constraints>
         </entryLink>
         <entryLink id="a329-1dd7-a0a1-cb27" name="Auspex" hidden="false" collective="false" targetId="9c80-128a-37c7-05a6" type="selectionEntry"/>
+        <entryLink id="2bbe-bc4b-4f42-baab" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="15.0"/>
@@ -1686,6 +1609,7 @@
         </entryLink>
         <entryLink id="90c4-ec8b-45b5-528d" name="Krak grenades" hidden="false" collective="false" targetId="14ce-31b4-2dd1-14f3" type="selectionEntry"/>
         <entryLink id="0849-31bf-862e-538a" name="Auspex" hidden="false" collective="false" targetId="9c80-128a-37c7-05a6" type="selectionEntry"/>
+        <entryLink id="1c6b-5487-6f6a-7f71" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="16.0"/>
@@ -1746,6 +1670,7 @@
         </entryLink>
         <entryLink id="1e2b-f390-45d1-6d1d" name="Krak grenades" hidden="false" collective="false" targetId="14ce-31b4-2dd1-14f3" type="selectionEntry"/>
         <entryLink id="0265-737c-9a40-7e9b" name="Auspex" hidden="false" collective="false" targetId="9c80-128a-37c7-05a6" type="selectionEntry"/>
+        <entryLink id="1335-abdd-8f21-249a" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="16.0"/>
@@ -1813,6 +1738,7 @@
         <entryLink id="2d10-cb45-0562-c572" name="Grav-chute" hidden="false" collective="false" targetId="c1a1-3086-11ef-4958" type="selectionEntry"/>
         <entryLink id="dc27-b1ff-8a8e-5c76" name="Krak grenades" hidden="false" collective="false" targetId="14ce-31b4-2dd1-14f3" type="selectionEntry"/>
         <entryLink id="cac1-d0f2-11c6-62bb" name="Shock grenade" hidden="false" collective="false" targetId="cb80-3365-f752-7ff9" type="selectionEntry"/>
+        <entryLink id="3b19-77b1-9f85-047e" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="16.0"/>
@@ -1927,6 +1853,7 @@
         <entryLink id="2324-06ff-51f0-46e6" name="Grav-chute" hidden="false" collective="false" targetId="c1a1-3086-11ef-4958" type="selectionEntry"/>
         <entryLink id="4dd8-bd07-c11e-ae37" name="Krak grenades" hidden="false" collective="false" targetId="14ce-31b4-2dd1-14f3" type="selectionEntry"/>
         <entryLink id="fc01-0a6f-65c8-482f" name="Shock grenade" hidden="false" collective="false" targetId="cb80-3365-f752-7ff9" type="selectionEntry"/>
+        <entryLink id="4a9a-1a73-0345-b4eb" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="17.0"/>
@@ -2055,6 +1982,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3ee-6d68-5469-8fcf" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="9d6c-a6c8-43cf-043a" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="13.0"/>
@@ -2206,6 +2134,7 @@
         <entryLink id="30e5-c0a5-88ff-c195" name="Specialism" hidden="false" collective="false" targetId="a12e-5cf6-d9c6-0e56" type="selectionEntryGroup"/>
         <entryLink id="6779-9490-4137-ed7c" name="Frag grenades" hidden="false" collective="false" targetId="f748-797c-dbfd-b7a1" type="selectionEntry"/>
         <entryLink id="a5a6-5e89-0693-898a" name="Krak grenades" hidden="false" collective="false" targetId="14ce-31b4-2dd1-14f3" type="selectionEntry"/>
+        <entryLink id="be0b-7bec-ab94-745a" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="13.0"/>
@@ -2269,6 +2198,7 @@
         </entryLink>
         <entryLink id="49d5-cf32-1b82-4d8d" name="Frag grenades" hidden="false" collective="false" targetId="f748-797c-dbfd-b7a1" type="selectionEntry"/>
         <entryLink id="e4fe-4521-5bd5-62fc" name="Krak grenades" hidden="false" collective="false" targetId="14ce-31b4-2dd1-14f3" type="selectionEntry"/>
+        <entryLink id="35f6-ca44-3449-f7c9" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -2373,6 +2303,7 @@
         </entryLink>
         <entryLink id="3fbd-b95f-4a71-f3d1" name="Frag grenades" hidden="false" collective="false" targetId="f748-797c-dbfd-b7a1" type="selectionEntry"/>
         <entryLink id="d55a-068c-9890-fa0e" name="Krak grenades" hidden="false" collective="false" targetId="14ce-31b4-2dd1-14f3" type="selectionEntry"/>
+        <entryLink id="3825-da12-71af-8aac" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="11.0"/>
@@ -2444,6 +2375,7 @@
         </entryLink>
         <entryLink id="76d1-98b9-c7cd-d5b6" name="Frag grenades" hidden="false" collective="false" targetId="f748-797c-dbfd-b7a1" type="selectionEntry"/>
         <entryLink id="e0c5-6412-c985-a627" name="Krak grenades" hidden="false" collective="false" targetId="14ce-31b4-2dd1-14f3" type="selectionEntry"/>
+        <entryLink id="2d80-a06f-eaa3-219f" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="11.0"/>
@@ -2624,6 +2556,7 @@
           </constraints>
         </entryLink>
         <entryLink id="5c3e-428b-8fa4-2d00" name="Specialism" hidden="false" collective="false" targetId="64e2-d393-931b-c7c1" type="selectionEntryGroup"/>
+        <entryLink id="b05a-cc63-1788-3096" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="76.0"/>
@@ -2749,6 +2682,7 @@
         <entryLink id="feb8-fa9d-4224-1018" name="Frag grenades" hidden="false" collective="false" targetId="f748-797c-dbfd-b7a1" type="selectionEntry"/>
         <entryLink id="ea02-d952-a1f7-67a6" name="Krak grenades" hidden="false" collective="false" targetId="14ce-31b4-2dd1-14f3" type="selectionEntry"/>
         <entryLink id="9d96-a301-d7e8-a1ca" name="Specialism" hidden="false" collective="false" targetId="64e2-d393-931b-c7c1" type="selectionEntryGroup"/>
+        <entryLink id="e72b-7a73-d68e-0051" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="46.0"/>
@@ -2867,6 +2801,7 @@
         <entryLink id="ec54-1a0f-ddc4-d714" name="Specialism" hidden="false" collective="false" targetId="64e2-d393-931b-c7c1" type="selectionEntryGroup"/>
         <entryLink id="21d0-197b-5a92-97a0" name="Frag grenades" hidden="false" collective="false" targetId="f748-797c-dbfd-b7a1" type="selectionEntry"/>
         <entryLink id="e5b4-c5fd-8d1d-9aff" name="Krak grenades" hidden="false" collective="false" targetId="14ce-31b4-2dd1-14f3" type="selectionEntry"/>
+        <entryLink id="b647-6065-d1fd-c92c" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="63.0"/>
@@ -2982,6 +2917,7 @@
           </constraints>
         </entryLink>
         <entryLink id="9f38-cebf-3c35-bbd4" name="Specialism" hidden="false" collective="false" targetId="64e2-d393-931b-c7c1" type="selectionEntryGroup"/>
+        <entryLink id="6b53-dd6b-7ed7-27c1" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="81.0"/>

--- a/Adeptus Mechanicus.cat
+++ b/Adeptus Mechanicus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ff2c-d2cf-bc85-3c79" name="Adeptus Mechanicus" revision="14" battleScribeVersion="2.02" authorContact="https://discord.gg/UrrPB3T" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ff2c-d2cf-bc85-3c79" name="Adeptus Mechanicus" revision="15" battleScribeVersion="2.02" authorContact="https://discord.gg/UrrPB3T" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="ff2c-d2cf-pubN65537" name="Kill Team - Core Manual, Kill Team - Commanders"/>
     <publication id="ff2c-d2cf-pubN79124" name="Kill Team - Core manual"/>
@@ -18,6 +18,13 @@
     <categoryEntry id="0d62-5055-94aa-9df2" name="Electro-priest" hidden="false"/>
     <categoryEntry id="ec06-753a-abd7-38a4" name="Corpuscarii" hidden="false"/>
     <categoryEntry id="4e06-5dd8-a9ec-34eb" name="Fulgurite" hidden="false"/>
+    <categoryEntry id="2bdc-872a-a6d0-763b" name="Agripinaa" hidden="false"/>
+    <categoryEntry id="9564-8417-448a-6a3b" name="Graia" hidden="false"/>
+    <categoryEntry id="a9a2-26c7-acda-25e3" name="Lucius" hidden="false"/>
+    <categoryEntry id="4ab2-46e1-6e04-ba29" name="Mars" hidden="false"/>
+    <categoryEntry id="9e2f-9f27-4293-8bba" name="Metalica" hidden="false"/>
+    <categoryEntry id="407a-ddf9-b34f-dc4d" name="Ryza" hidden="false"/>
+    <categoryEntry id="c74a-1f68-016d-8959" name="Stygies VIII" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="873e-f307-8825-033a" name="Skitarii Ranger Alpha" hidden="false" collective="false" targetId="8fe6-d415-13e1-9274" type="selectionEntry">
@@ -264,7 +271,6 @@
     <entryLink id="836c-5b7a-c1f2-d1e3" name="Janus Draik" hidden="false" collective="false" targetId="51ae-59d9-809a-f5dc" type="selectionEntry"/>
     <entryLink id="e4da-79c0-6cd9-f403" name="UR-025" hidden="false" collective="false" targetId="55a0-9cb5-c14a-ea47" type="selectionEntry"/>
     <entryLink id="90e3-7712-b050-0886" name="Tech-priest Manipulus" hidden="false" collective="false" targetId="0de9-a626-0ac5-1a4a" type="selectionEntry"/>
-    <entryLink id="2bb2-4423-196d-93d1" name="Forge World Dogma" hidden="false" collective="false" targetId="d3db-9ebb-0e4b-3f8c" type="selectionEntry"/>
     <entryLink id="b478-e536-a3da-4cf6" name="Corpuscarii Electro-priest" hidden="false" collective="false" targetId="9975-5212-69da-5fa2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7efe-ca47-8584-2981" name="New CategoryLink" hidden="false" targetId="ade4-0710-e40e-be3f" primary="true"/>
@@ -334,6 +340,148 @@
       </categoryLinks>
     </entryLink>
   </entryLinks>
+  <rules>
+    <rule id="6ee8-4d5e-8a77-66b9" name="Staunch Defenders" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9564-8417-448a-6a3b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a9a2-26c7-acda-25e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ab2-46e1-6e04-ba29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e2f-9f27-4293-8bba" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="407a-ddf9-b34f-dc4d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c74a-1f68-016d-8959" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e68c-2cc6-94d1-402c" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When a model in your kill team fires Overwatch, they successfully hit on a roll of 5 or 6.</description>
+    </rule>
+    <rule id="e173-4c59-d342-59fc" name="Refusal to Yield" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2bdc-872a-a6d0-763b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a9a2-26c7-acda-25e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ab2-46e1-6e04-ba29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e2f-9f27-4293-8bba" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="407a-ddf9-b34f-dc4d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c74a-1f68-016d-8959" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e68c-2cc6-94d1-402c" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Roll a dice each time a model in your kill team is reduced to 0 wounds. On a roll of 6 they are restored to 1 wound remaining. In addition, models in your kill team pass Nerve tests on an unmodified roll of 6 (as well as an unmodified roll of 1). However, models in your kill team cannot Retreat or Fall Back unless there is a COMMANDER from your kill team on the battlefield.</description>
+    </rule>
+    <rule id="d07b-07e2-bec9-76cc" name="The Solar Blessing" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2bdc-872a-a6d0-763b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9564-8417-448a-6a3b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ab2-46e1-6e04-ba29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e2f-9f27-4293-8bba" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="407a-ddf9-b34f-dc4d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c74a-1f68-016d-8959" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e68c-2cc6-94d1-402c" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When making saving throws for models in your kill team, treat enemy attacks with an Armour Penetration characteristic of -1 as haing an Armour Penetration characteristic of 0.</description>
+    </rule>
+    <rule id="edd5-11b9-4ec3-740d" name="Glory to the Omnissiah" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2bdc-872a-a6d0-763b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a9a2-26c7-acda-25e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9564-8417-448a-6a3b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e2f-9f27-4293-8bba" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="407a-ddf9-b34f-dc4d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c74a-1f68-016d-8959" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e68c-2cc6-94d1-402c" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Each time you randomly determine which Canticle of the Omnissiah is being chanted, roll two dice instead of one. Models in your kill team receive the benefit of both results, instead of just the result of the first dice (if a duplicate is rolled, no additional Canticle is chanted this turn).</description>
+    </rule>
+    <rule id="c7c2-df0d-8e87-81fa" name="Relentless March" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2bdc-872a-a6d0-763b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a9a2-26c7-acda-25e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ab2-46e1-6e04-ba29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9564-8417-448a-6a3b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="407a-ddf9-b34f-dc4d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c74a-1f68-016d-8959" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e68c-2cc6-94d1-402c" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team can shoot ranged weapons as if they were Assault weapons in the Shooting phase of a battle round in which they Advanced (e.g. a Rapid Fire 1 weapon would be used as if it were an Assault 1 weapon). In addition, models in your kill team do not suffer the penalty to their hit rolls for shooting Assault weapons during a battle round in which they Advanced.</description>
+    </rule>
+    <rule id="27f8-5434-7c64-1c97" name="Red in Cog and Claw" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2bdc-872a-a6d0-763b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a9a2-26c7-acda-25e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ab2-46e1-6e04-ba29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e2f-9f27-4293-8bba" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9564-8417-448a-6a3b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c74a-1f68-016d-8959" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e68c-2cc6-94d1-402c" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll wound rolls of 1 in the Fight phase for attacks made by models in your kill team.</description>
+    </rule>
+    <rule id="cced-cd82-6658-1fee" name="Shroud Protocols" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2bdc-872a-a6d0-763b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a9a2-26c7-acda-25e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ab2-46e1-6e04-ba29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e2f-9f27-4293-8bba" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="407a-ddf9-b34f-dc4d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9564-8417-448a-6a3b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e68c-2cc6-94d1-402c" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team are considered to be obscured to enemy models that target them if they are more than 12&quot; away from those models.</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
     <selectionEntry id="8ed1-8ae4-4628-3b72" name="Arc Pistol" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -662,6 +810,7 @@
           </constraints>
         </entryLink>
         <entryLink id="fa8b-ff10-0b01-e2aa" name="Skitarii Ranger Wargear" hidden="false" collective="false" targetId="4f8d-87c9-cb0f-d88e" type="selectionEntryGroup"/>
+        <entryLink id="d4cb-7f30-fab1-6662" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="9.0"/>
@@ -793,6 +942,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="297e-73e6-7af9-ce61" name="Specialism" hidden="false" collective="false" targetId="5ae8-c885-6dc3-74b0" type="selectionEntryGroup"/>
+        <entryLink id="69f2-2a89-5ea4-42ab" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -858,6 +1008,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="9318-60a4-a995-0575" name="Specialism" hidden="false" collective="false" targetId="5ae8-c885-6dc3-74b0" type="selectionEntryGroup"/>
+        <entryLink id="4923-bd04-0cfe-4458" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -966,6 +1117,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="ca70-6e9a-710c-3c34" name="Specialism" hidden="false" collective="false" targetId="5ae8-c885-6dc3-74b0" type="selectionEntryGroup"/>
+        <entryLink id="5a86-fce0-5aa0-7453" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -1017,6 +1169,7 @@
         </entryLink>
         <entryLink id="0a63-819f-cc66-744e" name="Specialism" hidden="false" collective="false" targetId="5ae8-c885-6dc3-74b0" type="selectionEntryGroup"/>
         <entryLink id="8e37-cc6d-5bfd-6ef4" name="Skitarii Vanguard Wargear" hidden="false" collective="false" targetId="631d-4178-29d4-d8a8" type="selectionEntryGroup"/>
+        <entryLink id="3b62-26e3-e26d-cf54" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="9.0"/>
@@ -1083,6 +1236,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="19ec-9c86-9fca-cf36" name="Specialism" hidden="false" collective="false" targetId="5ae8-c885-6dc3-74b0" type="selectionEntryGroup"/>
+        <entryLink id="d669-7b4b-2b85-898d" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -1181,6 +1335,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="64c8-1caf-6427-20ac" name="Specialism" hidden="false" collective="false" targetId="5ae8-c885-6dc3-74b0" type="selectionEntryGroup"/>
+        <entryLink id="5706-095a-daf8-ceb5" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="14.0"/>
@@ -1287,6 +1442,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="c612-a878-3538-5bea" name="Specialism" hidden="false" collective="false" targetId="5ae8-c885-6dc3-74b0" type="selectionEntryGroup"/>
+        <entryLink id="545b-30ec-8e80-f2b0" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="15.0"/>
@@ -1369,6 +1525,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="ccdd-f68c-5a2a-d501" name="Specialism" hidden="false" collective="false" targetId="5ae8-c885-6dc3-74b0" type="selectionEntryGroup"/>
+        <entryLink id="c536-0d25-e133-0449" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="14.0"/>
@@ -1438,6 +1595,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b20-87e1-0275-427f" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="0ecc-98ba-f84a-0b7f" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="15.0"/>
@@ -1640,6 +1798,7 @@
       <entryLinks>
         <entryLink id="074f-e431-e1ba-abf1" name="Specialism" hidden="false" collective="false" targetId="6675-98bf-621c-8069" type="selectionEntryGroup"/>
         <entryLink id="1b18-fa7b-5ff6-dc24" name="Omnissian axe" hidden="false" collective="false" targetId="81be-b281-b168-8490" type="selectionEntry"/>
+        <entryLink id="41c6-07b6-23f8-d58c" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="28.0"/>
@@ -1824,6 +1983,7 @@
       <entryLinks>
         <entryLink id="2028-88ef-9383-d95e" name="Omnissian axe" hidden="false" collective="false" targetId="81be-b281-b168-8490" type="selectionEntry"/>
         <entryLink id="669e-0639-2456-2be9" name="Specialism" hidden="false" collective="false" targetId="6675-98bf-621c-8069" type="selectionEntryGroup"/>
+        <entryLink id="f048-e6e6-7ded-3e1d" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="130.0"/>
@@ -2087,24 +2247,10 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="2cb0-ca02-17f3-77fd" name="Specialism" hidden="false" collective="false" targetId="6675-98bf-621c-8069" type="selectionEntryGroup"/>
+        <entryLink id="121d-aaa4-7673-875b" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="102.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d3db-9ebb-0e4b-3f8c" name="Forge World Dogma" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7f0c-ea57-e3f8-cdc7" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af52-7faa-ad39-833f" type="max"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="3988-0a86-6626-6063" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="8902-a693-b825-7744" name="Forge World Dogma" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9975-5212-69da-5fa2" name="Corpuscarii Electro-priest" hidden="false" collective="false" type="model">
@@ -2190,6 +2336,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="83af-f44c-790a-a90d" name="Specialism" hidden="false" collective="false" targetId="5ae8-c885-6dc3-74b0" type="selectionEntryGroup"/>
+        <entryLink id="0ab7-738d-0cc8-6428" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="13.0"/>
@@ -2284,6 +2431,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="3cda-7d30-22d8-9f31" name="Specialism" hidden="false" collective="false" targetId="5ae8-c885-6dc3-74b0" type="selectionEntryGroup"/>
+        <entryLink id="bcbb-a734-7001-46ab" name="Forge World" hidden="false" collective="false" targetId="3cd7-fd53-f027-c343" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="14.0"/>
@@ -2526,83 +2674,69 @@
         <entryLink id="a6a9-e388-e848-a483" name="Strength" hidden="false" collective="false" targetId="4550-6c27-1911-68ae" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="3cd7-fd53-f027-c343" name="Forge World Dogma" hidden="false" collective="false" defaultSelectionEntryId="e68c-2cc6-94d1-402c">
+    <selectionEntryGroup id="3cd7-fd53-f027-c343" name="Forge World" hidden="false" collective="false" defaultSelectionEntryId="e68c-2cc6-94d1-402c">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e54-48b2-a664-2412" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6108-5230-937d-a1ba" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="e68c-2cc6-94d1-402c" name="*No Dogma*" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e68c-2cc6-94d1-402c" name="*No Forgeworld*" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ced3-092b-9664-5bc3" name="Mars" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="6df7-91bd-5487-cf6d" name="Glory to the Omnissiah" hidden="false">
-              <description>Each time you randomly determine which Canticle of the Omnissiah is being chanted, roll two dice instead of one. Models in your kill team receive the benefit of both results, instead of just the result of the first dice (if a duplicate is rolled, no additional Canticle is chanted this turn).</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="2dc7-e7fc-bf29-730a" name="Mars" hidden="false" targetId="4ab2-46e1-6e04-ba29" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4219-56bc-2656-b283" name="Graia" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="3ee2-8644-a13a-46b5" name="Refusal to Yield" hidden="false">
-              <description>Roll a dice each time a model in your kill team is reduced to 0 wounds. On a roll of 6 they are restored to 1 wound remaining. In addition, models in your kill team pass Nerve tests on an unmodified roll of 6 (as well as an unmodified roll of 1). However, models in your kill team cannot Retreat or Fall Back unless there is a COMMANDER from your kill team on the battlefield.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="4418-ae3f-c153-fa4c" name="Graia" hidden="false" targetId="9564-8417-448a-6a3b" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3fb2-e102-4e52-cdb8" name="Metalica" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="c73a-bbb0-23eb-5877" name="Relentless March" hidden="false">
-              <description>Models in your kill team can shoot ranged weapons as if they were Assault weapons in the Shooting phase of a battle round in which they Advanced (e.g. a Rapid Fire 1 weapon would be used as if it were an Assault 1 weapon). In addition, models in your kill team do not suffer the penalty to their hit rolls for shooting Assault weapons during a battle round in which they Advanced.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="e004-cf3b-6e9a-3c57" name="Metalica" hidden="false" targetId="9e2f-9f27-4293-8bba" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="414b-a6f1-c780-faca" name="Lucius" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="3453-a089-d471-ddaf" name="The Solar Blessing" hidden="false">
-              <description>When making saving throws for models in your kill team, treat enemy attacks with an Armour Penetration characteristic of -1 as haing an Armour Penetration characteristic of 0.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="7ed5-62da-1c9a-ff7f" name="Lucius" hidden="false" targetId="a9a2-26c7-acda-25e3" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b99d-2363-109a-5a2a" name="Agripinaa" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="d820-04af-ef06-f7cf" name="Staunch Defenders" hidden="false">
-              <description>When a model in your kill team fires Overwatch, they successfully hit on a roll of 5 or 6.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="a92b-03d9-767f-6e2f" name="Agripinaa" hidden="false" targetId="2bdc-872a-a6d0-763b" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0bc2-5cb8-59ae-ee1e" name="Stygies VIII" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="0cc4-274c-1292-a76b" name="Shroud Protocols" hidden="false">
-              <description>Models in your kill team are considered to be obscured to enemy models that target them if they are more than 12&quot; away from those models.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="6789-b817-4b19-f0c1" name="Stygies VIII" hidden="false" targetId="c74a-1f68-016d-8959" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="66a5-4ada-3206-f96d" name="Ryza" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="5598-1c0b-4095-02a9" name="Red in Cog and Claw" hidden="false">
-              <description>You can re-roll wound rolls of 1 in the Fight phase for attacks made by models in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="1660-67cf-289e-f845" name="Ryza" hidden="false" targetId="407a-ddf9-b34f-dc4d" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>

--- a/Astra Militarum.cat
+++ b/Astra Militarum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="4c51-0669-1f79-d8aa" name="Astra Militarum" revision="16" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="4c51-0669-1f79-d8aa" name="Astra Militarum" revision="17" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="23ec-80ab-7550-fb7e" name="Astra Militarum Orders">
       <characteristicTypes>
@@ -31,6 +31,13 @@
     <categoryEntry id="f88b-df65-6f55-8586" name="Severina Raine" hidden="false"/>
     <categoryEntry id="3244-7b29-a389-49ed" name="Ogryn" hidden="false"/>
     <categoryEntry id="26d3-2724-2fef-2315" name="Bullgryn" hidden="false"/>
+    <categoryEntry id="104b-8483-d793-6650" name="Armageddon" hidden="false"/>
+    <categoryEntry id="a901-d251-4a19-f093" name="Cadia" hidden="false"/>
+    <categoryEntry id="0b10-2e90-052d-8f3d" name="Catachan" hidden="false"/>
+    <categoryEntry id="ce52-01a9-272b-0a1b" name="Mordian" hidden="false"/>
+    <categoryEntry id="1d6f-ab14-4f1f-bcc4" name="Tallarn" hidden="false"/>
+    <categoryEntry id="745d-eb46-1636-13a8" name="Valhallan" hidden="false"/>
+    <categoryEntry id="9d69-b25f-975b-83e3" name="Vostroyan" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="9122-f79e-d261-933e" name="Guardsman" hidden="false" collective="false" targetId="d5bc-71b5-c24f-4e96" type="selectionEntry">
@@ -233,7 +240,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="986c-5d9c-6459-1a66" type="greaterThan"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -348,8 +355,183 @@
         <categoryLink id="343c-f379-7186-04e6" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="be4c-4b27-4bdf-bebd" name="Regimental Doctrine" hidden="false" collective="false" targetId="749e-4d7d-da17-23f0" type="selectionEntry"/>
   </entryLinks>
+  <rules>
+    <rule id="47cc-eead-913a-df29" name="Industrial Efficiency" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39d2-4f09-6952-19c5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a901-d251-4a19-f093" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b10-2e90-052d-8f3d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce52-01a9-272b-0a1b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d6f-ab14-4f1f-bcc4" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="745d-eb46-1636-13a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d69-b25f-975b-83e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="104b-8483-d793-6650" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team firing Rapid Fire weapons double the number of attacks they make if all of their targets are within 18&quot; (instead of half the weapon&apos;s Range characteristic).</description>
+    </rule>
+    <rule id="66e7-b363-05c8-ba2b" name="Born Soldiers" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39d2-4f09-6952-19c5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="104b-8483-d793-6650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b10-2e90-052d-8f3d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce52-01a9-272b-0a1b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d6f-ab14-4f1f-bcc4" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="745d-eb46-1636-13a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d69-b25f-975b-83e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a901-d251-4a19-f093" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Re-roll unmodified hit rolls of 1 in the Shooting phase for models in your kill team if they have not moved in this battle round. If a model in your kill team is issued the &apos;Take Aim&apos; order and it has not moved in this battle round, re-roll all failed hit rolls for that model until the end of the phase instead.</description>
+    </rule>
+    <rule id="95a9-9457-0fea-083e" name="Brutal Strength" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39d2-4f09-6952-19c5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a901-d251-4a19-f093" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="104b-8483-d793-6650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce52-01a9-272b-0a1b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d6f-ab14-4f1f-bcc4" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="745d-eb46-1636-13a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d69-b25f-975b-83e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b10-2e90-052d-8f3d" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Add 1 to the Strength characteristic of models in your kill team. In addition, add 1 to the Leadership characteristic of models in your kill team if they are within 6&quot; of a friendly CATACHAN OFFICER.</description>
+    </rule>
+    <rule id="44d0-c655-b55e-768b" name="Storm Troopers" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39d2-4f09-6952-19c5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a901-d251-4a19-f093" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b10-2e90-052d-8f3d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce52-01a9-272b-0a1b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d6f-ab14-4f1f-bcc4" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="745d-eb46-1636-13a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d69-b25f-975b-83e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="104b-8483-d793-6650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="986c-5d9c-6459-1a66" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e7f5-09f4-86d3-cfb0" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2af4-29b9-2a03-0804" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="452e-867b-23cb-68c0" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="43ac-4f8b-b486-da4e" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>If a model from your kill team targets an enemy model that is within range and not at long range when making a shooting attack, it can make an extra shot with the same weapon, at the same target, for each unmodified hit roll of 6.</description>
+    </rule>
+    <rule id="fff5-a9e7-4d52-3a7a" name="Parade Drill" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39d2-4f09-6952-19c5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a901-d251-4a19-f093" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b10-2e90-052d-8f3d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="104b-8483-d793-6650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d6f-ab14-4f1f-bcc4" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="745d-eb46-1636-13a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d69-b25f-975b-83e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce52-01a9-272b-0a1b" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>If the base of a model in your kill team is touching the base of at least two other friendly MORDIAN models, add 1 to that model&apos;s Leadership characteristic, and when that model fires Overwatch they successfully hit on a roll of 5 or 6.</description>
+    </rule>
+    <rule id="03fe-f9ad-4fa4-8947" name="Swift as the Wind" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39d2-4f09-6952-19c5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a901-d251-4a19-f093" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b10-2e90-052d-8f3d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce52-01a9-272b-0a1b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="104b-8483-d793-6650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="745d-eb46-1636-13a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d69-b25f-975b-83e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="104b-8483-d793-6650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d6f-ab14-4f1f-bcc4" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team can shoot in the Shooting phase even if they Advanced in the same battle round (with the exception of Heavy weapons). In addition, these models do not suffer the penalty to hit rolls for shooting Assault weapons during a battle round in which they Advanced.</description>
+    </rule>
+    <rule id="bb82-2071-496a-3212" name="Grim Demeanour" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39d2-4f09-6952-19c5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a901-d251-4a19-f093" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b10-2e90-052d-8f3d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce52-01a9-272b-0a1b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d6f-ab14-4f1f-bcc4" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="104b-8483-d793-6650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d69-b25f-975b-83e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="745d-eb46-1636-13a8" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When you take a Nerve test for a model in your kill team, roll a D3 (instead of a D6).</description>
+    </rule>
+    <rule id="ba4d-74a1-9c06-25ff" name="Heirloom Weapons" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39d2-4f09-6952-19c5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a901-d251-4a19-f093" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b10-2e90-052d-8f3d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="745d-eb46-1636-13a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d6f-ab14-4f1f-bcc4" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce52-01a9-272b-0a1b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="104b-8483-d793-6650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d69-b25f-975b-83e3" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team do not suffer the penalty to hit rolls for their attacks that target enemy models at long range.</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
     <selectionEntry id="2df8-5166-0406-041b" name="Flamer" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -387,15 +569,10 @@
     </selectionEntry>
     <selectionEntry id="d5bc-71b5-c24f-4e96" name="Guardsman" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
+        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1.0">
           <repeats>
             <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="31f8-563e-ab5d-8e63" repeats="1" roundUp="false"/>
           </repeats>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
-          </conditions>
         </modifier>
       </modifiers>
       <profiles>
@@ -440,6 +617,7 @@
           </constraints>
         </entryLink>
         <entryLink id="c467-4e3b-8d17-1008" name="Specialism" hidden="false" collective="false" targetId="d441-da84-8194-ea3e" type="selectionEntryGroup"/>
+        <entryLink id="5946-6819-2046-8faa" name="Regiment" hidden="false" collective="false" targetId="0698-0499-9840-7475" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="5.0"/>
@@ -447,15 +625,10 @@
     </selectionEntry>
     <selectionEntry id="0e48-4b39-f955-7e20" name="Special Weapons Guardsman" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
+        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1.0">
           <repeats>
             <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="31f8-563e-ab5d-8e63" repeats="1" roundUp="false"/>
           </repeats>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
-          </conditions>
         </modifier>
       </modifiers>
       <profiles>
@@ -507,6 +680,7 @@
           </modifiers>
         </entryLink>
         <entryLink id="4bc5-8b36-0e5e-654d" name="Specialism" hidden="false" collective="false" targetId="d441-da84-8194-ea3e" type="selectionEntryGroup"/>
+        <entryLink id="66a5-26e0-6e3d-0c12" name="Regiment" hidden="false" collective="false" targetId="0698-0499-9840-7475" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="5.0"/>
@@ -866,7 +1040,7 @@
     </selectionEntry>
     <selectionEntry id="5685-5d66-9c9b-faf4" name="Guardsman Gunner" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="5b26-9ad1-1375-5209" value="1">
+        <modifier type="set" field="5b26-9ad1-1375-5209" value="1.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
@@ -875,11 +1049,6 @@
           <repeats>
             <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="31f8-563e-ab5d-8e63" repeats="1" roundUp="false"/>
           </repeats>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
-          </conditions>
         </modifier>
       </modifiers>
       <constraints>
@@ -932,6 +1101,7 @@
           </constraints>
         </entryLink>
         <entryLink id="dce0-e701-6657-d716" name="Specialism" hidden="false" collective="false" targetId="d441-da84-8194-ea3e" type="selectionEntryGroup"/>
+        <entryLink id="d9bf-2b6c-30e6-9da5" name="Regiment" hidden="false" collective="false" targetId="0698-0499-9840-7475" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="5.0"/>
@@ -939,7 +1109,7 @@
     </selectionEntry>
     <selectionEntry id="8d63-9ed2-1596-d8e6" name="Sergeant" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="45d0-6aab-7cd4-263f" value="1">
+        <modifier type="set" field="45d0-6aab-7cd4-263f" value="1.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
@@ -948,11 +1118,6 @@
           <repeats>
             <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="31f8-563e-ab5d-8e63" repeats="1" roundUp="false"/>
           </repeats>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
-          </conditions>
         </modifier>
       </modifiers>
       <constraints>
@@ -1023,6 +1188,7 @@
           </modifiers>
         </entryLink>
         <entryLink id="8dac-62a8-8f0d-1bb0" name="Specialism" hidden="false" collective="false" targetId="d441-da84-8194-ea3e" type="selectionEntryGroup"/>
+        <entryLink id="455c-3a18-bbc8-9ab7" name="Regiment" hidden="false" collective="false" targetId="0698-0499-9840-7475" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="5.0"/>
@@ -1085,15 +1251,10 @@
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
         </modifier>
-        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1">
+        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="1.0">
           <repeats>
             <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="31f8-563e-ab5d-8e63" repeats="1" roundUp="false"/>
           </repeats>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
-          </conditions>
         </modifier>
       </modifiers>
       <constraints>
@@ -1157,6 +1318,7 @@
           </modifiers>
         </entryLink>
         <entryLink id="9607-ac3b-768b-bba8" name="Specialism" hidden="false" collective="false" targetId="d441-da84-8194-ea3e" type="selectionEntryGroup"/>
+        <entryLink id="4cb6-5cdb-df90-186e" name="Regiment" hidden="false" collective="false" targetId="0698-0499-9840-7475" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="5.0"/>
@@ -1389,13 +1551,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="90ff-92bf-17b3-38fd" name="Infantry Squad Fire Team" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6f1c-da82-7f1c-908f" type="max"/>
       </constraints>
@@ -1419,13 +1574,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="8180-84cd-518d-ca33" name="Special Weapons Squad Fire Team" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6f35-c35d-4f8d-28c0" type="max"/>
       </constraints>
@@ -1674,7 +1822,7 @@
     </selectionEntry>
     <selectionEntry id="5dc9-5992-cb96-1a85" name="Platoon Commander" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="162e-8f50-d09f-e0bc" value="1">
+        <modifier type="set" field="162e-8f50-d09f-e0bc" value="1.0">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
@@ -1697,11 +1845,6 @@
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="20">
           <conditions>
             <condition field="selections" scope="5dc9-5992-cb96-1a85" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363a-fe8e-4043-4722" type="atLeast"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -1766,6 +1909,7 @@
         <entryLink id="8794-aab8-b73e-b5fb" name="Display Voice of Command Orders" hidden="false" collective="false" targetId="b091-39d9-f78c-b993" type="selectionEntry"/>
         <entryLink id="1f7d-2de3-d432-73d6" name="Commander Specialisim" hidden="false" collective="false" targetId="4025-e686-fa2b-8a8a" type="selectionEntryGroup"/>
         <entryLink id="62b9-ca3d-2a32-4a63" name="Frag Grenades" hidden="false" collective="false" targetId="d2bb-54e6-2f81-1af6" type="selectionEntry"/>
+        <entryLink id="4b2e-0eaa-f748-241c" name="Regiment" hidden="false" collective="false" targetId="0698-0499-9840-7475" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -1800,7 +1944,7 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="5">
+        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="5.0">
           <conditions>
             <condition field="selections" scope="234d-fd85-b46d-5257" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32ef-fb0a-d404-f1ea" type="atLeast"/>
           </conditions>
@@ -1813,11 +1957,6 @@
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="20">
           <conditions>
             <condition field="selections" scope="234d-fd85-b46d-5257" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363a-fe8e-4043-4722" type="atLeast"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -1887,6 +2026,7 @@
         <entryLink id="bd54-b45b-f8a8-5b9f" name="Display Voice of Command Orders" hidden="false" collective="false" targetId="b091-39d9-f78c-b993" type="selectionEntry"/>
         <entryLink id="036b-7930-a157-7c41" name="Specialism (C)" hidden="false" collective="false" targetId="4025-e686-fa2b-8a8a" type="selectionEntryGroup"/>
         <entryLink id="1d44-5b9d-04f9-d494" name="Frag Grenades" hidden="false" collective="false" targetId="d2bb-54e6-2f81-1af6" type="selectionEntry"/>
+        <entryLink id="1dcc-c0af-6e88-4eab" name="Regiment" hidden="false" collective="false" targetId="0698-0499-9840-7475" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="15.0"/>
@@ -2005,7 +2145,7 @@
     </selectionEntry>
     <selectionEntry id="5493-48f5-1ef7-6ff9" name="Taddeus the Purifier" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="1a20-4935-fb2f-8cd3" value="1">
+        <modifier type="set" field="1a20-4935-fb2f-8cd3" value="1.0">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
@@ -2028,11 +2168,6 @@
         <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="15">
           <conditions>
             <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a93-6219-2f28-9a37" type="atLeast"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -2142,14 +2277,9 @@
     </selectionEntry>
     <selectionEntry id="4612-9983-ee71-687f" name="Pious Vorne" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="dddc-b58d-aa3a-1243" value="1">
+        <modifier type="set" field="dddc-b58d-aa3a-1243" value="1.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0f7-c442-b695-bf07" type="atLeast"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -2436,7 +2566,7 @@
             <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363a-fe8e-4043-4722" type="atLeast"/>
           </conditions>
         </modifier>
-        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="10">
+        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="10.0">
           <conditions>
             <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a93-6219-2f28-9a37" type="atLeast"/>
           </conditions>
@@ -2450,11 +2580,6 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
-          </conditions>
         </modifier>
       </modifiers>
       <constraints>
@@ -2645,7 +2770,7 @@
     </selectionEntry>
     <selectionEntry id="53ad-9fd8-5262-f513" name="Sly Marbo" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="6df5-c66f-ee17-662b" value="1">
+        <modifier type="set" field="6df5-c66f-ee17-662b" value="1.0">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
@@ -2654,11 +2779,6 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e6-24f6-8076-c42d" type="equalTo"/>
-          </conditions>
         </modifier>
       </modifiers>
       <constraints>
@@ -2759,6 +2879,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="2c47-2ab9-31c3-b0c8" name="Legendary Hunter - Level 4" hidden="false" collective="false" targetId="1625-23f9-5e9b-d3ac" type="selectionEntry"/>
+        <entryLink id="4029-2867-f582-c815" name="Regiment" hidden="false" collective="false" targetId="0698-0499-9840-7475" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="55.0"/>
@@ -3168,21 +3289,6 @@
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="38.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="749e-4d7d-da17-23f0" name="Regimental Doctrine" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3052-039c-5fc8-75a2" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9d1-6251-3585-ab6b" type="min"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="8bd8-f827-a7f7-5899" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="4dc6-2c73-0d5f-05ac" name="Regimental Doctrine" hidden="false" collective="false" targetId="0698-0499-9840-7475" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-      </costs>
-    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="d441-da84-8194-ea3e" name="Specialism" hidden="false" collective="false">
@@ -3394,93 +3500,69 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="0698-0499-9840-7475" name="Regimental Doctrine" hidden="false" collective="false" defaultSelectionEntryId="39d2-4f09-6952-19c5">
+    <selectionEntryGroup id="0698-0499-9840-7475" name="Regiment" hidden="false" collective="false" defaultSelectionEntryId="39d2-4f09-6952-19c5">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a90-8700-9c50-c014" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9ca-745e-ccdb-fdf3" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="39d2-4f09-6952-19c5" name="*No Doctrine*" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="39d2-4f09-6952-19c5" name="*No Regiment*" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0b4d-3353-d8d0-b6aa" name="Cadian" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="414b-d8e9-776e-bd16" name="Born Soldiers" hidden="false">
-              <description>Re-roll unmodified hit rolls of 1 in the Shooting phase for models in your kill team if they have not moved in this battle round. If a model in your kill team is issued the &apos;Take Aim&apos; order and it has not moved in this battle round, re-roll all failed hit rolls for that model until the end of the phase instead.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="a77d-f530-da90-3526" name="Cadia" hidden="false" targetId="a901-d251-4a19-f093" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="86b7-9c59-197a-d155" name="Catachan" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="048d-5d89-6a94-56fc" name="Brutal Strength" hidden="false">
-              <description>Add 1 to the Strength characteristic of models in your kill team. In addition, add 1 to the Leadership characteristic of models in your kill team if they are within 6&quot; of a friendly CATACHAN OFFICER.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="a7b8-8d0e-47e0-4f86" name="Catachan" hidden="false" targetId="0b10-2e90-052d-8f3d" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="04ad-e70b-cb6e-4a7f" name="Valhallan" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="4f48-5ed9-1cf1-e8f0" name="Grim Demeanour" hidden="false">
-              <description>When you take a Nerve test for a model in your kill team, roll a D3 (instead of a D6).</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="c447-8b4a-44a1-ff6b" name="Valhallan" hidden="false" targetId="745d-eb46-1636-13a8" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b12a-91cf-50eb-a8d0" name="Vostroyan" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="ff33-1407-9152-1218" name="Heirloom Weapons" hidden="false">
-              <description>Models in your kill team do not suffer the penalty to hit rolls for their attacks that target enemy models at long range.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="56b4-412a-4667-89fc" name="Vostroyan" hidden="false" targetId="9d69-b25f-975b-83e3" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="23d9-77a7-2e45-4951" name="Armageddon" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="ae67-bd9a-41bd-ae4e" name="Industrial Efficiency" hidden="false">
-              <description>Models in your kill team firing Rapid Fire weapons double the number of attacks they make if all of their targets are within 18&quot; (instead of half the weapon&apos;s Range characteristic).</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="3790-2092-8db1-456d" name="Armageddon" hidden="false" targetId="104b-8483-d793-6650" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1d62-8ee3-757a-64ba" name="Tallarn" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="de4f-6527-95c3-6faf" name="Swift as the Wind" hidden="false">
-              <description>Models in your kill team can shoot in the Shooting phase even if they Advanced in the same battle round (with the exception of Heavy weapons). In addition, these models do not suffer the penalty to hit rolls for shooting Assault weapons during a battle round in which they Advanced.</description>
-            </rule>
-          </rules>
-          <costs>
-            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="28e6-24f6-8076-c42d" name="Militarum Tempestus" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="636d-9784-9612-34be" name="Storm Troopers" hidden="false">
-              <description>If a model from your kill team targets an enemy model that is within range and not at long range when making a shooting attack, it can make an extra shot with the same weapon, at the same target, for each unmodified hit roll of 6.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="f8a9-a318-bd0f-4850" name="Tallarn" hidden="false" targetId="1d6f-ab14-4f1f-bcc4" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5516-eaf1-87d6-cced" name="Mordian" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="ca92-dba9-453c-624d" name="Parade Drill" hidden="false">
-              <description>If the base of a model in your kill team is touching the base of at least two other friendly MORDIAN models, add 1 to that model&apos;s Leadership characteristic, and when that model fires Overwatch they successfully hit on a roll of 5 or 6.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="7d6e-648d-1bfc-78ca" name="Mordian" hidden="false" targetId="ce52-01a9-272b-0a1b" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>

--- a/Asuryani.cat
+++ b/Asuryani.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a796-a947-905e-205c" name="Asuryani" revision="16" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a796-a947-905e-205c" name="Asuryani" revision="17" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="efd1-273e-3910-f3e8" name="Warhost" hidden="false"/>
     <categoryEntry id="5bef-7545-be74-0e33" name="Guardian" hidden="false"/>
@@ -18,6 +18,10 @@
     <categoryEntry id="bd11-0f22-8ebc-9118" name="Wraith Construct" hidden="false"/>
     <categoryEntry id="3168-ad8a-945a-1bc4" name="Striking Scorpion" hidden="false"/>
     <categoryEntry id="d2aa-fbd7-e051-b22f" name="Howling Banshee" hidden="false"/>
+    <categoryEntry id="2dfa-684d-3925-7a8e" name="Biel-tan" hidden="false"/>
+    <categoryEntry id="9576-58c7-9a57-e053" name="Saim-Hann" hidden="false"/>
+    <categoryEntry id="8f8f-eeb8-3204-9813" name="Iyanden" hidden="false"/>
+    <categoryEntry id="0ef9-45d0-7d15-5fb1" name="Ulthwe" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="38fe-f863-513a-9012" name="Guardian Defender" hidden="false" collective="false" targetId="74a1-6b5c-0980-9c59" type="selectionEntry">
@@ -217,7 +221,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="8970-69d4-d897-d152" name="Amallyn Shadowguide" hidden="false" collective="false" targetId="a3c5-153b-497a-d4b9" type="selectionEntry"/>
-    <entryLink id="519b-d66a-1949-2511" name="Craftworld Attribute" hidden="false" collective="false" targetId="7615-f67e-1956-ffcd" type="selectionEntry"/>
     <entryLink id="ef25-3974-586b-c50d" name="Spiritseer" hidden="false" collective="false" targetId="1b76-0440-e937-7545" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0710-4c4c-ea02-52ac" name="Commander" hidden="false" targetId="6c25-5825-9054-44a7" primary="true"/>
@@ -385,6 +388,103 @@
       </categoryLinks>
     </entryLink>
   </entryLinks>
+  <rules>
+    <rule id="ee87-1d98-f1ab-6064" name="Fieldcraft" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="34bb-10c3-3129-3290" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2dfa-684d-3925-7a8e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9576-58c7-9a57-e053" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f8f-eeb8-3204-9813" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ef9-45d0-7d15-5fb1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="154a-1ea4-ac7b-f8b1" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team are considered to be obscured to enemy models that target them if they are more than 12&quot; away from those models.</description>
+    </rule>
+    <rule id="01f8-3a72-d932-4e19" name="Swordwind" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2dfa-684d-3925-7a8e" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="34bb-10c3-3129-3290" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9576-58c7-9a57-e053" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f8f-eeb8-3204-9813" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ef9-45d0-7d15-5fb1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="154a-1ea4-ac7b-f8b1" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Add 1 to the Leadership characteristic of models in your kill team. In addition, you can re-roll hit rolls of 1 for shuriken weapons used by models in your kill team. A shuriken weapon is any weapon profile whose name includes the word &apos;shuriken&apos; (e.g. shuriken pistol, Avenger shuriken catapult, etc.). The ranged profile of a scorpion&apos;s claw is also a shuriken weapon.</description>
+    </rule>
+    <rule id="3468-2c05-833e-da02" name="Stoic Endurance" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f8f-eeb8-3204-9813" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2dfa-684d-3925-7a8e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9576-58c7-9a57-e053" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="34bb-10c3-3129-3290" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ef9-45d0-7d15-5fb1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="154a-1ea4-ac7b-f8b1" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When you take a Nerve test for models in your kill team, roll a D3 (instead of a D6).</description>
+    </rule>
+    <rule id="bc22-6818-355f-0c2e" name="Wild Host" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9576-58c7-9a57-e053" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2dfa-684d-3925-7a8e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f8f-eeb8-3204-9813" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="34bb-10c3-3129-3290" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ef9-45d0-7d15-5fb1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="154a-1ea4-ac7b-f8b1" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll charge rolls for models in your kill team.</description>
+    </rule>
+    <rule id="9cc7-a7a3-7253-d620" name="Foresight of the Damned" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ef9-45d0-7d15-5fb1" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2dfa-684d-3925-7a8e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9576-58c7-9a57-e053" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="34bb-10c3-3129-3290" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f8f-eeb8-3204-9813" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="154a-1ea4-ac7b-f8b1" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Roll a dice each time a model in your kill team loses a wound. On a 6, the damage is ignored and the model does not lose a wound. If a model already has a similar ability, choose which effect applies, and re-roll 1s when making these rolls.</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
     <selectionEntry id="74a1-6b5c-0980-9c59" name="Guardian Defender" hidden="false" collective="false" type="model">
       <profiles>
@@ -425,6 +525,7 @@
           </constraints>
         </entryLink>
         <entryLink id="2c75-f9e9-d113-40d2" name="Plasma Grenades" hidden="false" collective="false" targetId="e020-7406-fcae-4d17" type="selectionEntry"/>
+        <entryLink id="eb9e-592a-ac02-fec9" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
@@ -558,6 +659,7 @@
       <entryLinks>
         <entryLink id="f49d-791e-d5e0-2385" name="Specialism" hidden="false" collective="false" targetId="9a9b-8261-3296-9a12" type="selectionEntryGroup"/>
         <entryLink id="5c7e-5e95-4edf-b320" name="Plasma Grenades" hidden="false" collective="false" targetId="e020-7406-fcae-4d17" type="selectionEntry"/>
+        <entryLink id="afa4-d544-2a99-dce3" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
@@ -822,6 +924,7 @@
           </constraints>
         </entryLink>
         <entryLink id="db1d-5fb8-65a2-c450" name="Plasma Grenades" hidden="false" collective="false" targetId="e020-7406-fcae-4d17" type="selectionEntry"/>
+        <entryLink id="b2ce-8ae2-4a8a-e0d3" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="6.0"/>
@@ -866,6 +969,7 @@
           </constraints>
         </entryLink>
         <entryLink id="0df1-23d5-4824-27f7" name="Plasma Grenades" hidden="false" collective="false" targetId="e020-7406-fcae-4d17" type="selectionEntry"/>
+        <entryLink id="9e41-1d8d-31b1-2f51" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -993,6 +1097,7 @@
       <entryLinks>
         <entryLink id="4db2-59b3-972a-623b" name="Dire Avenger Specialism" hidden="false" collective="false" targetId="9a9b-8261-3296-9a12" type="selectionEntryGroup"/>
         <entryLink id="8c09-a303-1a60-8032" name="Plasma Grenades" hidden="false" collective="false" targetId="e020-7406-fcae-4d17" type="selectionEntry"/>
+        <entryLink id="bf1c-a303-7642-dc3b" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="11.0"/>
@@ -1042,6 +1147,7 @@
           </constraints>
         </entryLink>
         <entryLink id="8e99-2a9f-9c40-662e" name="Specialism" hidden="false" collective="false" targetId="9a9b-8261-3296-9a12" type="selectionEntryGroup"/>
+        <entryLink id="562a-f26f-64e1-c945" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="11.0"/>
@@ -1267,6 +1373,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="2041-9140-13ba-7e0e" name="Autarch Specialism" hidden="false" collective="false" targetId="764f-3b3e-f597-454a" type="selectionEntryGroup"/>
+        <entryLink id="b6e4-73b6-211c-f710" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="55.0"/>
@@ -1395,6 +1502,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b89-b5fd-abd8-ecc5" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="d3a6-7727-e737-ac4a" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="20.0"/>
@@ -1563,6 +1671,7 @@
           </constraints>
         </entryLink>
         <entryLink id="4142-0dce-c0e0-7039" name="Autarch Specialism" hidden="false" collective="false" targetId="764f-3b3e-f597-454a" type="selectionEntryGroup"/>
+        <entryLink id="8414-ca69-937f-f1a3" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="55.0"/>
@@ -1708,21 +1817,6 @@
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="30.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7615-f67e-1956-ffcd" name="Craftworld Attribute" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d0b-80a0-5113-ae49" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="771a-735c-2785-854b" type="max"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="16aa-727f-7188-2b09" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="62c9-4711-782d-5e4f" name="Craftworld Attribute" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="1b76-0440-e937-7545" name="Spiritseer" hidden="false" collective="false" type="model">
       <modifiers>
         <modifier type="set" field="5291-dc2c-cfa5-a77f" value="76">
@@ -1823,6 +1917,7 @@
           </constraints>
         </entryLink>
         <entryLink id="c2f0-1385-e37b-cd67" name="Specialism" hidden="false" collective="false" targetId="764f-3b3e-f597-454a" type="selectionEntryGroup"/>
+        <entryLink id="790c-aacc-520c-f669" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="61.0"/>
@@ -2068,6 +2163,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="5662-1d51-d93f-d4be" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="41.0"/>
       </costs>
@@ -2195,6 +2293,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a42d-731b-9f8f-2382" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="36.0"/>
       </costs>
@@ -2303,6 +2404,7 @@
           </constraints>
         </entryLink>
         <entryLink id="7d4c-cfbe-aa6e-a53e" name="Specialism" hidden="false" collective="false" targetId="9a9b-8261-3296-9a12" type="selectionEntryGroup"/>
+        <entryLink id="75bd-ae10-bc91-4fa1" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="12.0"/>
@@ -2447,6 +2549,7 @@
       <entryLinks>
         <entryLink id="996b-2e17-8733-acf1" name="Plasma grenades" hidden="false" collective="false" targetId="e020-7406-fcae-4d17" type="selectionEntry"/>
         <entryLink id="bf9b-8ed9-1197-ae90" name="Specialism" hidden="false" collective="false" targetId="9a9b-8261-3296-9a12" type="selectionEntryGroup"/>
+        <entryLink id="23f9-3482-b666-fef0" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="14.0"/>
@@ -2543,6 +2646,7 @@
           </constraints>
         </entryLink>
         <entryLink id="d012-1a54-f27d-d825" name="Specialism" hidden="false" collective="false" targetId="9a9b-8261-3296-9a12" type="selectionEntryGroup"/>
+        <entryLink id="923f-7d57-32b8-cade" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="11.0"/>
@@ -2704,6 +2808,7 @@
           </constraints>
         </entryLink>
         <entryLink id="4ec6-d1a2-9c10-872b" name="Specialism" hidden="false" collective="false" targetId="9a9b-8261-3296-9a12" type="selectionEntryGroup"/>
+        <entryLink id="2c24-8ed7-4458-4fac" name="Craftworld" hidden="false" collective="false" targetId="3bba-3f69-bb8f-48f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="14.0"/>
@@ -3000,63 +3105,53 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="3bba-3f69-bb8f-48f2" name="Craftworld Attribute" hidden="false" collective="false" defaultSelectionEntryId="154a-1ea4-ac7b-f8b1">
+    <selectionEntryGroup id="3bba-3f69-bb8f-48f2" name="Craftworld" hidden="false" collective="false" defaultSelectionEntryId="154a-1ea4-ac7b-f8b1">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5aba-fe94-bc38-cf16" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d08-ba48-d81e-e53e" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="154a-1ea4-ac7b-f8b1" name="*No Attribute*" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="154a-1ea4-ac7b-f8b1" name="*No Craftworld*" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4727-d8f0-7dc8-82ef" name="Ulthwe" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="286f-65ba-145e-4dcb" name="Foresight of the Damned" hidden="false">
-              <description>Roll a dice each time a model in your kill team loses a wound. On a 6, the damage is ignored and the model does not lose a wound. If a model already has a similar ability, choose which effect applies, and re-roll 1s when making these rolls.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="5970-4898-b58e-6a05" name="Ulthw" hidden="false" targetId="0ef9-45d0-7d15-5fb1" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cd3d-bdb9-58e5-37b3" name="Saim-Hann" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="111d-3109-0123-219b" name="Wild Host" hidden="false">
-              <description>You can re-roll charge rolls for models in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="a0e5-9d21-1f2c-5107" name="Saim-Hann" hidden="false" targetId="9576-58c7-9a57-e053" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="35f3-78f8-00fa-914c" name="Alaitoc" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="132d-ee93-66ba-5feb" name="Fieldcraft" hidden="false">
-              <description>Models in your kill team are considered to be obscured to enemy models that target them if they are more than 12&quot; away from those models.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="e997-92b7-c68d-4c97" name="Alaitoc" hidden="false" targetId="34bb-10c3-3129-3290" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ac26-153c-fefe-fd6b" name="Biel-tan" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="4e91-179d-9810-231f" name="Swordwind" hidden="false">
-              <description>Add 1 to the Leadership characteristic of models in your kill team. In addition, you can re-roll hit rolls of 1 for shuriken weapons used by models in your kill team. A shuriken weapon is any weapon profile whose name includes the word &apos;shuriken&apos; (e.g. shuriken pistol, Avenger shuriken catapult, etc.). The ranged profile of a scorpion&apos;s claw is also a shuriken weapon.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="1345-1e12-c51c-ed32" name="Biel-tan" hidden="false" targetId="2dfa-684d-3925-7a8e" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="78d1-27e8-18bf-8140" name="Iyanden" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="9743-c565-47dc-09f0" name="Stoic Endurance" hidden="false">
-              <description>When you take a Nerve test for models in your kill team, roll a D3 (instead of a D6).</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="bb0b-6d9e-14c7-15b6" name="Iyanden" hidden="false" targetId="8f8f-eeb8-3204-9813" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>

--- a/Drukhari.cat
+++ b/Drukhari.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3591-2aa0-250c-ddeb" name="Drukhari" revision="13" battleScribeVersion="2.02" authorName="Farseer Veraenthis" authorContact="@FarseerVeraenthis on Gitter" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3591-2aa0-250c-ddeb" name="Drukhari" revision="14" battleScribeVersion="2.02" authorName="Farseer Veraenthis" authorContact="@FarseerVeraenthis on Gitter" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="3591-2aa0-pubN65537" name="Kill Team Core Manual"/>
   </publications>
@@ -13,6 +13,16 @@
     <categoryEntry id="00e9-ae22-0c43-4e26" name="Mandrake" hidden="false"/>
     <categoryEntry id="b519-33b8-6d25-334e" name="Kabal" hidden="false"/>
     <categoryEntry id="544e-9879-8f40-472b" name="Wych Cult" hidden="false"/>
+    <categoryEntry id="7d23-49a9-045e-2781" name="Cult of Strife" hidden="false"/>
+    <categoryEntry id="0865-b796-9a79-52cf" name="Cult of the Red Grief" hidden="false"/>
+    <categoryEntry id="d77f-ce4e-f7bd-48b7" name="Cult of the Cursed Blade" hidden="false"/>
+    <categoryEntry id="44b9-a081-d709-d5d1" name="The Prophets of Flesh" hidden="false"/>
+    <categoryEntry id="5f8c-e74a-45bb-dff5" name="Coven of Twelve" hidden="false"/>
+    <categoryEntry id="1dab-097e-b6d5-4d81" name="The Dark Creed" hidden="false"/>
+    <categoryEntry id="f05d-f958-10dd-569d" name="Kabal of the Black Heart" hidden="false"/>
+    <categoryEntry id="1f18-16ca-eee8-014a" name="Kabal of the Obsidian Rose" hidden="false"/>
+    <categoryEntry id="1045-c03e-b5bf-8c88" name="Kabal of the Flayed Skull" hidden="false"/>
+    <categoryEntry id="6079-15c0-f7a3-18ed" name="Kabal of the Poisoned Tongue" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="0b86-0f56-a395-319c" name="Hekatrix" hidden="false" collective="false" targetId="7f12-9d40-1248-f67a" type="selectionEntry">
@@ -338,7 +348,6 @@
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink id="984a-d289-f72f-34f8" name="Drukhari Obsession" hidden="false" collective="false" targetId="cb88-ce33-97c0-f56d" type="selectionEntry"/>
     <entryLink id="ffeb-868f-9b26-b70c" name="Incubi Fire Team" hidden="false" collective="false" targetId="337e-6000-7e3d-5206" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -349,6 +358,202 @@
       </modifiers>
     </entryLink>
   </entryLinks>
+  <rules>
+    <rule id="a3b6-78e3-7e1d-de68" name="Butchers of Flesh" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b519-33b8-6d25-334e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="544e-9879-8f40-472b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1693-4fdf-74ba-15eb" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="deb5-6740-7ac5-c399" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c1c9-bee4-3e78-50b6" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12de-4f33-f58f-5089" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Improve the Armour Penetration characteristic of all melee weapons used by your kill team by 1. For example, an Armour Penetration characteristic of 0 becomes -1; an Armour Penetration characteristic of -1 becomes -2, and so on.</description>
+    </rule>
+    <rule id="ecb0-cbb2-b4de-26e0" name="Distillers of Fear" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b519-33b8-6d25-334e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="544e-9879-8f40-472b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="deb5-6740-7ac5-c399" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12de-4f33-f58f-5089" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c1c9-bee4-3e78-50b6" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1693-4fdf-74ba-15eb" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When an opponent takes a Nerve test for a model from their kill team, they must add 1 to the roll for each of your models (rather than shaken models) that is within 3&quot; of that model.</description>
+    </rule>
+    <rule id="bf1d-8842-a818-c546" name="Connoisseurs of Pain" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b519-33b8-6d25-334e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="544e-9879-8f40-472b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1693-4fdf-74ba-15eb" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12de-4f33-f58f-5089" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c1c9-bee4-3e78-50b6" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="deb5-6740-7ac5-c399" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team with the Insensible to Pain ability have an invulnerable save of 4+ (instead of 5+).</description>
+    </rule>
+    <rule id="8acd-d5dc-be53-1d24" name="Thirst for Power" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5129-e78c-6736-a55b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="544e-9879-8f40-472b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1604-dae3-1497-969f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d537-60a9-61dd-ff89" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60e0-ecee-3a78-5aa6" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2753-dda2-a2a9-3e6a" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b878-a3be-ad4c-4a7a" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team count the current battle round as being 1 higher than it actually is when determining what bonuses they get from their Power from Pain ability. Models in your kill team that do not have the Power from Pain ability instead gain the Inured to Suffering bonus.</description>
+    </rule>
+    <rule id="7e7b-c9a7-0f46-778f" name="Inescapable Slayers" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5129-e78c-6736-a55b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="544e-9879-8f40-472b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1604-dae3-1497-969f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2753-dda2-a2a9-3e6a" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60e0-ecee-3a78-5aa6" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d537-60a9-61dd-ff89" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b878-a3be-ad4c-4a7a" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team do not suffer the penalty to hit rolls for the target of their attacks being obcured or because of intervening terrain.</description>
+    </rule>
+    <rule id="c743-2882-3b40-2024" name="Flawless Workmanship" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5129-e78c-6736-a55b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="544e-9879-8f40-472b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1604-dae3-1497-969f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2753-dda2-a2a9-3e6a" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60e0-ecee-3a78-5aa6" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b878-a3be-ad4c-4a7a" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d537-60a9-61dd-ff89" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team do not suffer the penalty to hit rolls for their attacks that target enemy models at long range.</description>
+    </rule>
+    <rule id="5883-cd3f-ab9a-e726" name="The Serpent&apos;s Kiss" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5129-e78c-6736-a55b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="544e-9879-8f40-472b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d537-60a9-61dd-ff89" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2753-dda2-a2a9-3e6a" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60e0-ecee-3a78-5aa6" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1604-dae3-1497-969f" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b878-a3be-ad4c-4a7a" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Re-roll wound rolls of 1 made for melee weapons and poisoned weapons used by models in your kill team. For the purposes of this Obsession, a poisoned weapon is any weapon that wounds on a particular roll (e.g. on a 4+).</description>
+    </rule>
+    <rule id="1361-8bf7-74b8-f4b2" name="The Spectacle of Murder" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5129-e78c-6736-a55b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b519-33b8-6d25-334e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ab2-ee8c-4c9c-509c" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c337-e8b8-4634-f2d7" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3da-7748-6a4a-8435" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0840-9308-2a87-5c01" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can make one additional attack in the Fight phase with a model in your kill team if it charged, was charged or made a pile-in move granted by the Heroic Intervention Commander Tactic in that battle round.</description>
+    </rule>
+    <rule id="3080-cc36-ab00-bf85" name="Only the Strong Will Thrive" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5129-e78c-6736-a55b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b519-33b8-6d25-334e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ab2-ee8c-4c9c-509c" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c337-e8b8-4634-f2d7" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0840-9308-2a87-5c01" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3da-7748-6a4a-8435" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Increase the Strength characteristic of models from your kill team by 1. In addition, when you take a Nerve test for a model in your kill team, subtract 1 from the result.</description>
+    </rule>
+    <rule id="2ce8-9f02-9852-859b" name="Speed of the Kill" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5129-e78c-6736-a55b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b519-33b8-6d25-334e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0840-9308-2a87-5c01" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c337-e8b8-4634-f2d7" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ab2-ee8c-4c9c-509c" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3da-7748-6a4a-8435" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll charge rolls for models in your kill team.</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
     <selectionEntry id="7c6a-ce45-bee2-c316" name="Shardnet and Impaler" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -619,20 +824,10 @@
     </selectionEntry>
     <selectionEntry id="7f12-9d40-1248-f67a" name="Hekatrix" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="81f2-e4f8-d4e1-dc47" value="1">
+        <modifier type="set" field="81f2-e4f8-d4e1-dc47" value="1.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -692,7 +887,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="f454-10da-2dc7-e8a0" name="Plasma Grenade" hidden="false" collective="false" targetId="133b-b340-201b-8879" type="selectionEntry">
+        <entryLink id="f454-10da-2dc7-e8a0" name="Plasma grenades" hidden="false" collective="false" targetId="133b-b340-201b-8879" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c6f-2837-5780-c0f2" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e2f5-3e45-b46c-3768" type="max"/>
@@ -704,6 +899,7 @@
           </constraints>
         </entryLink>
         <entryLink id="479e-d799-2b55-1fde" name="Wych Specialism" hidden="false" collective="false" targetId="7b50-5670-410c-ecbd" type="selectionEntryGroup"/>
+        <entryLink id="561d-0d58-cdc0-ff14" name="Wych Cult" hidden="false" collective="false" targetId="1499-de6a-1a82-ab1a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="9.0"/>
@@ -711,20 +907,10 @@
     </selectionEntry>
     <selectionEntry id="11e5-2ca6-c87b-fbff" name="Wych Fighter" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="cd37-1639-0fc0-06d9" value="3">
+        <modifier type="set" field="cd37-1639-0fc0-06d9" value="3.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -814,24 +1000,13 @@
           </constraints>
         </entryLink>
         <entryLink id="af09-f7f3-0f6b-9f96" name="Wych Specialism" hidden="false" collective="false" targetId="7b50-5670-410c-ecbd" type="selectionEntryGroup"/>
+        <entryLink id="c902-79e3-e211-30b5" name="Wych Cult" hidden="false" collective="false" targetId="1499-de6a-1a82-ab1a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="9.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8da1-5ea3-046c-2bd5" name="Wych" hidden="false" collective="false" type="model">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <profiles>
         <profile id="c30f-b92f-6542-95b0" name="Wych" hidden="false" typeId="bb0a-aba1-abd0-beb3" typeName="Model">
           <characteristics>
@@ -882,6 +1057,7 @@
           </constraints>
         </entryLink>
         <entryLink id="cbed-940c-457e-7a3a" name="Wych Specialism" hidden="false" collective="false" targetId="7b50-5670-410c-ecbd" type="selectionEntryGroup"/>
+        <entryLink id="50ce-8976-11ae-f8c8" name="Wych Cult" hidden="false" collective="false" targetId="1499-de6a-1a82-ab1a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -889,20 +1065,10 @@
     </selectionEntry>
     <selectionEntry id="35a3-8c8a-3e0a-3570" name="Sybarite" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="697b-5baa-d077-19bf" value="1">
+        <modifier type="set" field="697b-5baa-d077-19bf" value="1.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -964,6 +1130,7 @@
           </constraints>
         </entryLink>
         <entryLink id="8282-5dd0-08dc-68f4" name="Kabalite Warrior Specialism" hidden="false" collective="false" targetId="724c-ece1-8107-8e34" type="selectionEntryGroup"/>
+        <entryLink id="bf18-7dd0-c9d8-e72f" name="Kabal" hidden="false" collective="false" targetId="86fc-0394-f66d-3f3a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -971,20 +1138,10 @@
     </selectionEntry>
     <selectionEntry id="e855-16d1-d6be-38e2" name="Kabalite Gunner" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="140d-e671-abaa-c936" value="2">
+        <modifier type="set" field="140d-e671-abaa-c936" value="2.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -1070,24 +1227,13 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="4d6a-92c5-8183-9ba7" name="Kabalite Warrior Specialism" hidden="false" collective="false" targetId="724c-ece1-8107-8e34" type="selectionEntryGroup"/>
+        <entryLink id="4f82-7e8d-9fb4-aab7" name="Kabal" hidden="false" collective="false" targetId="86fc-0394-f66d-3f3a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eada-f83b-0853-5544" name="Kabalite Warrior" hidden="false" collective="false" type="model">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <profiles>
         <profile id="b366-a951-3b9a-7a18" name="Kabalite Warrior" hidden="false" typeId="bb0a-aba1-abd0-beb3" typeName="Model">
           <characteristics>
@@ -1123,24 +1269,13 @@
           </constraints>
         </entryLink>
         <entryLink id="9cca-9179-3ebd-294e" name="Kabalite Warrior Specialism" hidden="false" collective="false" targetId="724c-ece1-8107-8e34" type="selectionEntryGroup"/>
+        <entryLink id="20c8-4e9f-f631-121a" name="Kabal" hidden="false" collective="false" targetId="86fc-0394-f66d-3f3a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="53c5-45d2-c3b2-9748" name="Kabalite Warrior Fire Team" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c42-20d7-9124-8198" type="max"/>
       </constraints>
@@ -1188,18 +1323,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="7169-992d-3b64-7b89" name="Wych Fire Team" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e46f-decb-9dd6-1148" type="max"/>
       </constraints>
@@ -1282,7 +1405,7 @@
     </selectionEntry>
     <selectionEntry id="401b-a8d1-aaaf-d933" name="Archon" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="15">
+        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="15.0">
           <conditions>
             <condition field="selections" scope="401b-a8d1-aaaf-d933" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32ef-fb0a-d404-f1ea" type="equalTo"/>
           </conditions>
@@ -1303,16 +1426,6 @@
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -1399,6 +1512,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="10bc-a7b8-864a-f2d9" name="Archon Specialism" hidden="false" collective="false" targetId="5d93-5837-5b99-bb56" type="selectionEntryGroup"/>
+        <entryLink id="a4d4-430f-acc5-295c" name="Kabal" hidden="false" collective="false" targetId="86fc-0394-f66d-3f3a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="56.0"/>
@@ -1421,22 +1535,12 @@
             <condition field="selections" scope="44c9-3d92-61bd-314a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363a-fe8e-4043-4722" type="atLeast"/>
           </conditions>
         </modifier>
-        <modifier type="set" field="2f89-0c04-b67c-2743" value="1">
+        <modifier type="set" field="2f89-0c04-b67c-2743" value="1.0">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -1535,7 +1639,7 @@
             <condition field="selections" scope="acef-f35c-c102-d3fe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a93-6219-2f28-9a37" type="equalTo"/>
           </conditions>
         </modifier>
-        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="20">
+        <modifier type="increment" field="5291-dc2c-cfa5-a77f" value="20.0">
           <conditions>
             <condition field="selections" scope="acef-f35c-c102-d3fe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363a-fe8e-4043-4722" type="atLeast"/>
           </conditions>
@@ -1546,26 +1650,6 @@
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c0b-7da1-facd-d326" type="atLeast"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -1643,24 +1727,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efa0-2ea0-a7a7-a5ca" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="b04f-b656-213b-8726" name="Haemonculus Coven" hidden="false" collective="false" targetId="962a-1b04-e2d9-2c2a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="30.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5d2c-0220-4311-cd7b" name="Wrack" hidden="false" collective="false" type="model">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <profiles>
         <profile id="d6a0-905c-75dd-a114" name="Wrack" hidden="false" typeId="bb0a-aba1-abd0-beb3" typeName="Model">
           <characteristics>
@@ -1697,6 +1770,7 @@
           </constraints>
         </entryLink>
         <entryLink id="3655-49ec-1513-67d0" name="Wrack Specialism" hidden="false" collective="false" targetId="35bd-216d-599f-0a40" type="selectionEntryGroup"/>
+        <entryLink id="6f00-b008-a1c1-cd36" name="Haemonculus Coven" hidden="false" collective="false" targetId="962a-1b04-e2d9-2c2a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -1721,20 +1795,10 @@
     </selectionEntry>
     <selectionEntry id="8d67-a6d2-81ff-fe91" name="Wrack Gunner" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="32c3-b500-0726-93e9" value="2">
+        <modifier type="set" field="32c3-b500-0726-93e9" value="2.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -1805,6 +1869,7 @@
           </constraints>
         </entryLink>
         <entryLink id="8820-e83e-875a-802c" name="Wrack Specialism" hidden="false" collective="false" targetId="35bd-216d-599f-0a40" type="selectionEntryGroup"/>
+        <entryLink id="5ce6-58ce-b362-64a2" name="Haemonculus Coven" hidden="false" collective="false" targetId="962a-1b04-e2d9-2c2a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="9.0"/>
@@ -1812,20 +1877,10 @@
     </selectionEntry>
     <selectionEntry id="8734-4930-1897-0087" name="Acothyst" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="bf37-bb1a-d0f8-1701" value="1">
+        <modifier type="set" field="bf37-bb1a-d0f8-1701" value="1.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="beaf-798d-961f-353d" type="atLeast"/>
           </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -1968,6 +2023,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="c2f3-e224-c7c0-6271" name="Wrack Specialism" hidden="false" collective="false" targetId="35bd-216d-599f-0a40" type="selectionEntryGroup"/>
+        <entryLink id="3030-5395-9126-e21e" name="Haemonculus Coven" hidden="false" collective="false" targetId="962a-1b04-e2d9-2c2a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="9.0"/>
@@ -2070,18 +2126,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="e556-6a87-b82b-6b1e" name="Wrack Fire Team" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2d7-2529-253f-0c25" type="max"/>
       </constraints>
@@ -2175,18 +2219,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="f4a6-5f17-705e-5606" name="Grotesque" hidden="false" collective="false" type="model">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <profiles>
         <profile id="f96b-b685-b275-9f3f" name="Grotesque" hidden="false" typeId="bb0a-aba1-abd0-beb3" typeName="Model">
           <characteristics>
@@ -2253,6 +2285,7 @@
           </constraints>
         </entryLink>
         <entryLink id="2857-6c7a-0990-09cf" name="Grotesque Specialism" hidden="false" collective="false" targetId="28f8-a68f-8479-6db9" type="selectionEntryGroup"/>
+        <entryLink id="d7fd-663a-e48c-6f28" name="Haemonculus Coven" hidden="false" collective="false" targetId="962a-1b04-e2d9-2c2a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="38.0"/>
@@ -2276,18 +2309,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="d5a9-fe89-67d6-b572" name="Grotesque Fire Team" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb2c-70bc-a429-5818" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e60f-4e6e-7fd8-5c5f" type="max"/>
       </constraints>
@@ -2524,34 +2545,7 @@
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cb88-ce33-97c0-f56d" name="Drukhari Obsession" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a67f-ba6c-bf59-ee4c" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46de-b2bb-3538-a160" type="max"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="3432-99e7-1be7-5513" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="e535-52f9-b02c-be91" name="Drukhari Obsession" hidden="false" collective="false" targetId="7057-8183-1ddc-8282" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="337e-6000-7e3d-5206" name="Incubus Fire Team" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7e9-c673-78db-b7b8" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66a2-f0e0-9acb-c91f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="117f-4eea-b06b-432a" type="max"/>
       </constraints>
@@ -2796,144 +2790,112 @@
         <entryLink id="10ac-e3ed-d7c1-2c14" name="Leader" hidden="false" collective="false" targetId="2abd-70f4-e7e8-4d18" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="7057-8183-1ddc-8282" name="Drukhari Obsession" hidden="false" collective="false" defaultSelectionEntryId="5501-5964-e15b-c922">
+    <selectionEntryGroup id="962a-1b04-e2d9-2c2a" name="Haemonculus Coven" hidden="false" collective="false" defaultSelectionEntryId="c1c9-bee4-3e78-50b6">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5a0-21a8-2ae4-52d5" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d05c-37fe-a764-e7ec" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20db-3977-17b3-745d" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d80e-994e-f9ef-a4fd" type="min"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="5501-5964-e15b-c922" name="*No Obsession*" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d58-bcbf-06dd-8127" type="max"/>
-          </constraints>
+        <selectionEntry id="deb5-6740-7ac5-c399" name="The Prophets of Flesh" hidden="false" collective="false" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="c559-f8f8-7838-7100" name="The Prophets of Flesh" hidden="false" targetId="44b9-a081-d709-d5d1" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="1693-4fdf-74ba-15eb" name="The Dark Creed" hidden="false" collective="false" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="0018-e737-95e2-5218" name="The Dark Creed" hidden="false" targetId="1dab-097e-b6d5-4d81" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="12de-4f33-f58f-5089" name="Coven of Twelve" hidden="false" collective="false" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="db27-95be-f85b-941c" name="Coven of Twelve" hidden="false" targetId="5f8c-e74a-45bb-dff5" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c1c9-bee4-3e78-50b6" name="*No Coven*" hidden="false" collective="false" type="upgrade"/>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="66a2-f0e0-9acb-c91f" name="Kabal" hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f60-d7f1-e914-f52d" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="1210-bad2-f262-8d76" name="Kabal of the Black Heart" hidden="false" collective="false" type="upgrade">
-              <rules>
-                <rule id="f63d-6a90-10e5-2256" name="Thirst for Power" hidden="false">
-                  <description>Models in your kill team count the current battle round as being 1 higher than it actually is when determining what bonuses they get from their Power from Pain ability. Models in your kill team that do not have the Power from Pain ability instead gain the Inured to Suffering bonus.</description>
-                </rule>
-              </rules>
-              <costs>
-                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c658-47aa-0aba-7db0" name="Kabal of the Flayed Skull" hidden="false" collective="false" type="upgrade">
-              <rules>
-                <rule id="ec98-b58d-15aa-18ba" name="Inescapable Slayers" hidden="false">
-                  <description>Models in your kill team do not suffer the penalty to hit rolls for the target of their attacks being obcured or because of intervening terrain.</description>
-                </rule>
-              </rules>
-              <costs>
-                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9616-7b43-1211-3c94" name="Kabal of the Poisoned Tongue" hidden="false" collective="false" type="upgrade">
-              <rules>
-                <rule id="4397-7e26-6a9f-2159" name="The Serpent&apos;s Kiss" hidden="false">
-                  <description>Re-roll wound rolls of 1 made for melee weapons and poisoned weapons used by models in your kill team. For the purposes of this Obsession, a poisoned weapon is any weapon that wounds on a particular roll (e.g. on a 4+).</description>
-                </rule>
-              </rules>
-              <costs>
-                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="83e2-7ad6-fcca-f7a9" name="Kabal of the Obsidian Rose" hidden="false" collective="false" type="upgrade">
-              <rules>
-                <rule id="5f37-e824-082a-153a" name="Flawless Workmanship" hidden="false">
-                  <description>Models in your kill team do not suffer the penalty to hit rolls for their attacks that target enemy models at long range.</description>
-                </rule>
-              </rules>
-              <costs>
-                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="cb2c-70bc-a429-5818" name="Wych Cult" hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae98-37f3-1d06-ec77" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="1232-33d2-8496-38f0" name="Cult of Strife" hidden="false" collective="false" type="upgrade">
-              <rules>
-                <rule id="2918-d6d0-2d07-5aec" name="The Spectacle of Murder" hidden="false">
-                  <description>You can make one additional attack in the Fight phase with a model in your kill team if it charged, was charged or made a pile-in move granted by the Heroic Intervention Commander Tactic in that battle round.</description>
-                </rule>
-              </rules>
-              <costs>
-                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2646-90f1-d628-aee7" name="Cult of the Cursed Blade" hidden="false" collective="false" type="upgrade">
-              <rules>
-                <rule id="e4f4-97d8-b6d7-a12f" name="Only the Strong Will Thrive" hidden="false">
-                  <description>Increase the Strength characteristic of models from your kill team by 1. In addition, when you take a Nerve test for a model in your kill team, subtract 1 from the result.</description>
-                </rule>
-              </rules>
-              <costs>
-                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7bc6-d27d-1b09-74f8" name="Cult of the Red Grief" hidden="false" collective="false" type="upgrade">
-              <rules>
-                <rule id="2385-53c6-4c0b-ef89" name="Speed of the Kill" hidden="false">
-                  <description>You can re-roll charge rolls for models in your kill team.</description>
-                </rule>
-              </rules>
-              <costs>
-                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f7e9-c673-78db-b7b8" name="Haemonculus Coven" hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc1c-d62a-8e5d-35c4" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="d583-25c1-a3c0-cc5d" name="The Prophets of Flesh" hidden="false" collective="false" type="upgrade">
-              <rules>
-                <rule id="b25d-e0d2-c864-d441" name="Connoisseurs of Pain" hidden="false">
-                  <description>Models in yor kill team with the Insensible to Pain ability have an invulnerable save of 4+ (instead of 5+).</description>
-                </rule>
-              </rules>
-              <costs>
-                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="be59-1b26-37dd-bd53" name="The Dark Creed" hidden="false" collective="false" type="upgrade">
-              <rules>
-                <rule id="30b8-729a-532d-79a6" name="Distillers of Fear" hidden="false">
-                  <description>When an opponent takes a Nerve test for a model from their kill team, they must add 1 to the roll for each of your models (rather than shaken models) that is within 3&quot; of that model.</description>
-                </rule>
-              </rules>
-              <costs>
-                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="88cf-0509-ab95-2213" name="Coven of Twelve" hidden="false" collective="false" type="upgrade">
-              <rules>
-                <rule id="8920-114f-8b20-2041" name="Butchers of Flesh" hidden="false">
-                  <description>Improve the Armour Penetration characteristic of all melee weapons used by your kill team by 1. For example, an Armour Penetration characteristic of 0 becomes -1; an Armour Penetration characteristic of -1 becomes -2, and so on.</description>
-                </rule>
-              </rules>
-              <costs>
-                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="86fc-0394-f66d-3f3a" name="Kabal" hidden="false" collective="false" defaultSelectionEntryId="60e0-ecee-3a78-5aa6">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d36-e086-1de8-4913" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3431-bb08-a085-2cbe" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2753-dda2-a2a9-3e6a" name="Kabal of the Black Heart" hidden="false" collective="false" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="7068-53b6-0fc8-6f75" name="Kabal of the Black Heart" hidden="false" targetId="f05d-f958-10dd-569d" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d537-60a9-61dd-ff89" name="Kabal of the Flayed Skull" hidden="false" collective="false" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="df89-fee0-f8e8-c8f0" name="Kabal of the Flayed Skull" hidden="false" targetId="1045-c03e-b5bf-8c88" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1604-dae3-1497-969f" name="Kabal of the Poisoned Tongue" hidden="false" collective="false" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="cc10-378a-5c8b-10b5" name="Kabal of the Poisoned Tongue" hidden="false" targetId="6079-15c0-f7a3-18ed" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b878-a3be-ad4c-4a7a" name="Kabal of the Obsidian Rose" hidden="false" collective="false" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="4652-5348-7409-72dd" name="Kabal of the Obsidian Rose" hidden="false" targetId="1f18-16ca-eee8-014a" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="60e0-ecee-3a78-5aa6" name="*No Kabal*" hidden="false" collective="false" type="upgrade"/>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="1499-de6a-1a82-ab1a" name="Wych Cult" hidden="false" collective="false" defaultSelectionEntryId="c337-e8b8-4634-f2d7">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d439-411a-de34-45da" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f501-fa10-46fe-7475" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="c3da-7748-6a4a-8435" name="Cult of Strife" hidden="false" collective="false" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="4d02-3809-fc6e-48ee" name="Cult of Strife" hidden="false" targetId="7d23-49a9-045e-2781" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0840-9308-2a87-5c01" name="Cult of the Cursed Blade" hidden="false" collective="false" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="42ec-f727-cbf1-d935" name="Cult of the Cursed Blade" hidden="false" targetId="d77f-ce4e-f7bd-48b7" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5ab2-ee8c-4c9c-509c" name="Cult of the Red Grief" hidden="false" collective="false" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="1b34-26f4-8ef3-aee1" name="Cult of the Red Grief" hidden="false" targetId="0865-b796-9a79-52cf" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c337-e8b8-4634-f2d7" name="*No Cult*" hidden="false" collective="false" type="upgrade"/>
+      </selectionEntries>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Genestealer Cults.cat
+++ b/Genestealer Cults.cat
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5479-cc66-3156-2e54" name="Genestealer Cults" revision="11" battleScribeVersion="2.02" authorName="GenWilhelm" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5479-cc66-3156-2e54" name="Genestealer Cults" revision="12" battleScribeVersion="2.02" authorName="GenWilhelm" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="5479-cc66-pubN67382" name="Core Manual"/>
     <publication id="5479-cc66-pubN77125" name="Commanders"/>
   </publications>
   <categoryEntries>
     <categoryEntry id="7a42-ce12-ab98-203e" name="Familiar" hidden="false"/>
+    <categoryEntry id="175d-1bf1-1384-265b" name="Cult of the Four-Armed Emperor" hidden="false"/>
+    <categoryEntry id="03ec-e376-3eb2-cefa" name="The Bladed Cog" hidden="false"/>
+    <categoryEntry id="4d86-5edc-504a-dda3" name="The Hivecult" hidden="false"/>
+    <categoryEntry id="11aa-fb85-9d81-e59e" name="The Pauper Princes" hidden="false"/>
+    <categoryEntry id="1f6b-a20b-0820-b949" name="The Rusted Claw" hidden="false"/>
+    <categoryEntry id="b72f-ebb6-9ad2-b1e5" name="The Twisted Helix" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="1f47-5b15-ef03-990e" name="Genestealer" hidden="false" collective="false" targetId="0370-09e0-183b-da4d" type="selectionEntry">
@@ -288,7 +294,6 @@
         <categoryLink id="4b3a-c2e2-5702-aed8" name="New CategoryLink" hidden="false" targetId="6c25-5825-9054-44a7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c3fd-d632-b520-bb6c" name="Cult Creed" hidden="false" collective="false" targetId="6f64-b7cf-0b57-3c27" type="selectionEntry"/>
     <entryLink id="3b2e-9d2f-563e-0f46" name="Sanctus" hidden="false" collective="false" targetId="2320-9c19-ef87-c46a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="314f-0c1d-f1e3-0c19" name="New CategoryLink" hidden="false" targetId="6c25-5825-9054-44a7" primary="true"/>
@@ -316,6 +321,128 @@
       </categoryLinks>
     </entryLink>
   </entryLinks>
+  <rules>
+    <rule id="e982-88bb-b99a-d646" name="Subterranean Ambushers" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="03ec-e376-3eb2-cefa" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4d86-5edc-504a-dda3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11aa-fb85-9d81-e59e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f6b-a20b-0820-b949" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b72f-ebb6-9ad2-b1e5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="175d-1bf1-1384-265b" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63a3-d226-0983-dc50" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Add 1 to Cult Ambush rolls made for models in your kill team.</description>
+    </rule>
+    <rule id="e90b-aee6-2377-78b8" name="Cyborgised Hybrids" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="175d-1bf1-1384-265b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4d86-5edc-504a-dda3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11aa-fb85-9d81-e59e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f6b-a20b-0820-b949" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b72f-ebb6-9ad2-b1e5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="03ec-e376-3eb2-cefa" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63a3-d226-0983-dc50" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team have a 6+ invulnerable save. Models in your kill team that already have an invulnerable save instead improve their invulnerable save by 1 (to a maximum of 3+). In addition, models in your kill team do not suffer the penalty to their hit rolls for moving and shooting Heavy weapons.</description>
+    </rule>
+    <rule id="7c74-04f8-cad6-7044" name="Disciplined Militants" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="175d-1bf1-1384-265b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="03ec-e376-3eb2-cefa" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11aa-fb85-9d81-e59e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f6b-a20b-0820-b949" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b72f-ebb6-9ad2-b1e5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4d86-5edc-504a-dda3" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63a3-d226-0983-dc50" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When you take a Nerve test for a model in your kill team, roll a D3 (instead of a D6). In addition, models in your kill team can shoot in a battle round in which they Retreated or Fell Back, but if they do a 6 is always required for a successful hit roll, irrespective of the firing model&apos;s Ballistic Skill or any modifiers.</description>
+    </rule>
+    <rule id="18cb-0d87-00b3-d6af" name="Devoted Zealots" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="175d-1bf1-1384-265b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="03ec-e376-3eb2-cefa" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4d86-5edc-504a-dda3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f6b-a20b-0820-b949" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b72f-ebb6-9ad2-b1e5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11aa-fb85-9d81-e59e" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63a3-d226-0983-dc50" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll failed hit rolls in the Fight phase for attacks made by a model in your kill team if it charged, was charged, or made a pile-in movede granted by the Heroic Interventtion Commander Tactic in that battle round.</description>
+    </rule>
+    <rule id="3c23-9e62-22c8-456f" name="Nomadic Survivalists" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="175d-1bf1-1384-265b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="03ec-e376-3eb2-cefa" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4d86-5edc-504a-dda3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11aa-fb85-9d81-e59e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b72f-ebb6-9ad2-b1e5" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f6b-a20b-0820-b949" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63a3-d226-0983-dc50" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When making saving throws for models in your kill team, treat enemy attacks with an Armour Penetration characteristic of -1 as having an Armour Penetration characteristic of 0.</description>
+    </rule>
+    <rule id="65b6-d495-f749-b983" name="Experimental Subjects" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="175d-1bf1-1384-265b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="03ec-e376-3eb2-cefa" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4d86-5edc-504a-dda3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11aa-fb85-9d81-e59e" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f6b-a20b-0820-b949" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b72f-ebb6-9ad2-b1e5" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63a3-d226-0983-dc50" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Add 1 to the Strength characteristic of models in your kill team. In addition, when a model in your kill team Advances add an additional 2&quot; to the distance it can move.</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
     <selectionEntry id="aaff-03b4-3284-61d6" name="Toxin Sacs" hidden="false" collective="false" type="upgrade">
       <constraints>
@@ -1023,6 +1150,7 @@
           </constraints>
         </entryLink>
         <entryLink id="e41c-3cbd-8bf0-b002" name="Specialism" hidden="false" collective="false" targetId="94ea-94d4-b309-099b" type="selectionEntryGroup"/>
+        <entryLink id="dfa8-599b-1b39-5c0e" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="5.0"/>
@@ -1136,6 +1264,7 @@
           </constraints>
         </entryLink>
         <entryLink id="c6a4-7033-1c81-4d24" name="Specialism" hidden="false" collective="false" targetId="94ea-94d4-b309-099b" type="selectionEntryGroup"/>
+        <entryLink id="5e84-3390-1d9d-39c8" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="6.0"/>
@@ -1252,6 +1381,7 @@
           </constraints>
         </entryLink>
         <entryLink id="002f-6aec-b26c-3f31" name="Specialism" hidden="false" collective="false" targetId="94ea-94d4-b309-099b" type="selectionEntryGroup"/>
+        <entryLink id="8d7b-a63b-b3c4-624b" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="6.0"/>
@@ -1371,6 +1501,7 @@
           </constraints>
         </entryLink>
         <entryLink id="1876-ad9e-a59d-e700" name="Specialism" hidden="false" collective="false" targetId="94ea-94d4-b309-099b" type="selectionEntryGroup"/>
+        <entryLink id="f521-0196-3f0e-afd4" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -1543,6 +1674,7 @@
           </constraints>
         </entryLink>
         <entryLink id="3cd7-6b01-71e6-44aa" name="Specialism" hidden="false" collective="false" targetId="94ea-94d4-b309-099b" type="selectionEntryGroup"/>
+        <entryLink id="8c98-3044-d8e4-cad5" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="9.0"/>
@@ -1619,6 +1751,7 @@
             <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="45b9-086c-a424-d7cd" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="2131-a493-5aa4-cc86" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
@@ -1706,6 +1839,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="593b-6d0f-cdd9-3b58" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="a37d-c235-c975-33b1" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -1796,6 +1930,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="666a-e321-1f92-e2d3" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="4dcf-9daf-6ce3-d508" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -1852,6 +1987,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aff-f352-7894-0c37" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="df56-3639-beb9-425c" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="15.0"/>
@@ -2115,6 +2251,7 @@
           </constraints>
         </entryLink>
         <entryLink id="02fc-bb31-6eaa-5392" name="Commander Specialism" hidden="false" collective="false" targetId="deaa-edc3-296c-764e" type="selectionEntryGroup"/>
+        <entryLink id="a939-04c6-b838-1c84" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="30.0"/>
@@ -2240,6 +2377,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3f7-7921-06d1-1045" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="beea-6374-e7c9-1716" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="28.0"/>
@@ -2378,6 +2516,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="c277-a28f-f0cf-2099" name="Commander Specialism" hidden="false" collective="false" targetId="deaa-edc3-296c-764e" type="selectionEntryGroup"/>
+        <entryLink id="3cd7-434a-60ad-4b84" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="131.0"/>
@@ -2467,6 +2606,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aca-ab2e-73b5-b4be" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="8d69-8bf9-db45-10d0" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="18.0"/>
@@ -2586,24 +2726,10 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="dd09-82ab-1c85-2dfb" name="Commander Specialism" hidden="false" collective="false" targetId="deaa-edc3-296c-764e" type="selectionEntryGroup"/>
+        <entryLink id="02cf-d3d3-2898-79ac" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="25.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6f64-b7cf-0b57-3c27" name="Cult Creed" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e9c-49e7-d3b0-1b4c" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffa1-d75f-45a3-d6bb" type="max"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="ef8b-7f0b-23c5-0958" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="140f-1371-f0ee-40eb" name="Cult Creed" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2320-9c19-ef87-c46a" name="Sanctus" hidden="false" collective="false" type="model">
@@ -2691,6 +2817,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -2713,6 +2842,9 @@
                   </characteristics>
                 </profile>
               </profiles>
+              <costs>
+                <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="e3b2-ea9e-2829-d7b5" name="Sanctus bio-dagger" hidden="false" collective="false" type="upgrade">
               <profiles>
@@ -2736,6 +2868,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="cbe6-ac4e-e204-231b" name="Commander Specialism" hidden="false" collective="false" targetId="deaa-edc3-296c-764e" type="selectionEntryGroup"/>
+        <entryLink id="45c1-c930-b008-caec" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="33.0"/>
@@ -2812,6 +2945,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adec-0759-f16f-4dbb" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="4405-3bbf-d68a-6414" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="32.0"/>
@@ -2893,6 +3027,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -2903,6 +3040,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da94-115b-f7ae-a241" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="5c34-b223-97c5-be2b" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="29.0"/>
@@ -3003,6 +3141,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="f8a1-1431-1a8e-e1e7" name="Hypermorph tail" hidden="false" collective="false" type="upgrade">
           <constraints>
@@ -3021,10 +3162,14 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="f7c7-4b3b-a3b5-a38b" name="Commander Specialism" hidden="false" collective="false" targetId="deaa-edc3-296c-764e" type="selectionEntryGroup"/>
+        <entryLink id="fb32-a547-82a6-ac40" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="66.0"/>
@@ -3079,6 +3224,10 @@
         <categoryLink id="5a84-1520-92a2-8ef1" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false"/>
         <categoryLink id="e0e9-ade8-d823-3c8e" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="d1a7-d07f-642c-e7a0" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
+        <entryLink id="14f2-b36b-411e-0161" name="Specialism" hidden="false" collective="false" targetId="94ea-94d4-b309-099b" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="4.0"/>
       </costs>
@@ -3154,6 +3303,7 @@
           </constraints>
         </entryLink>
         <entryLink id="6cff-9e10-fb36-3f75" name="Commander Specialism" hidden="false" collective="false" targetId="deaa-edc3-296c-764e" type="selectionEntryGroup"/>
+        <entryLink id="299e-902f-5ab8-ab00" name="Cult" hidden="false" collective="false" targetId="a5c9-044c-643d-e80b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="26.0"/>
@@ -3553,73 +3703,61 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="a5c9-044c-643d-e80b" name="Cult Creed" hidden="false" collective="false" defaultSelectionEntryId="63a3-d226-0983-dc50">
+    <selectionEntryGroup id="a5c9-044c-643d-e80b" name="Cult" hidden="false" collective="false" defaultSelectionEntryId="63a3-d226-0983-dc50">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43c4-95c3-ab2b-00db" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03d3-f9cf-522d-b03b" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="63a3-d226-0983-dc50" name="*No Creed*" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="63a3-d226-0983-dc50" name="*No Cult*" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6b3d-89c5-78b1-f679" name="Cult of the Four-Armed Emperor" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="5a4d-6d6e-440e-94c0" name="Subterranean Ambushers" hidden="false">
-              <description>Add 1 to Cult Ambush rolls made for models in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="f8da-47bb-fd2f-bb7f" name="Cult of the Four-Armed Emperor" hidden="false" targetId="175d-1bf1-1384-265b" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="aa13-c73d-3870-7b56" name="The Twisted Helix" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="39e8-a2ce-5ad8-b9a9" name="Experimental Subjects" hidden="false">
-              <description>Add 1 to the Strength characteristic of models in your kill team. In addition, when a model in your kill team Advances add an additional 2&quot; to the distance it can move.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="3e27-acd8-38cc-ca22" name="The Twisted Helix" hidden="false" targetId="b72f-ebb6-9ad2-b1e5" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4eed-a1ec-3e30-41d4" name="The Rusted Claw" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="b653-b5b2-cf9d-38c1" name="Nomadic Survivalists" hidden="false">
-              <description>When making saving throws for models in your kill team, treat enemy attacks with an Armour Penetration characteristic of -1 as having an Armour Penetration characteristic of 0.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="551f-375b-d23f-fb0f" name="The Rusted Claw" hidden="false" targetId="1f6b-a20b-0820-b949" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bd29-7565-ed47-1483" name="The Hivecult" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="0edd-bf62-336e-c2b0" name="Disciplined Militants" hidden="false">
-              <description>When you take a Nerve test for a model in your kill team, roll a D3 (instead of a D6). In addition, models in your kill team can shoot in a battle round in which they Retreated or Fell Back, but if they do a 6 is always required for a successful hit roll, irrespective of the firing model&apos;s Ballistic Skill or any modifiers.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="8207-bbc4-7b39-cc13" name="The Hivecult" hidden="false" targetId="4d86-5edc-504a-dda3" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b515-e9b8-cb4f-7480" name="The Bladed Cog" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="0e21-e36a-f5e8-287f" name="Cyborgised Hybrids" hidden="false">
-              <description>Models in your kill team have a 6+ invulnerable save. Models in your kill team that already have an invulnerable save instead improve their invulnerable save by 1 (to a maximum of 3+). In addition, models in your kill team do not suffer the penalty to their hit rolls for moving and shooting Heavy weapons.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="6f80-3c12-6dfc-c2b0" name="The Bladed Cog" hidden="false" targetId="03ec-e376-3eb2-cefa" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="53b4-a541-057e-937b" name="The Pauper Princes" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="4771-55c5-6aff-02ef" name="Devoted Zealots" hidden="false">
-              <description>You can re-roll failed hit rolls in the Fight phase for attacks made by a model in your kill team if it charged, was charged, or made a pile-in movede granted by the Heroic Interventtion Commander Tactic in that battle round.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="fa4f-ce70-36c8-6545" name="The Pauper Princes" hidden="false" targetId="11aa-fb85-9d81-e59e" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>

--- a/Harlequins.cat
+++ b/Harlequins.cat
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8f3b-d6fd-0ad8-06f2" name="Harlequins" revision="7" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8f3b-d6fd-0ad8-06f2" name="Harlequins" revision="8" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="cb52-a195-44b4-d87b" name="Player" hidden="false"/>
+    <categoryEntry id="7c3b-dea4-d6e2-f559" name="Dreaming Shadow" hidden="false"/>
+    <categoryEntry id="155f-1e62-fbee-e25b" name="Frozen Stars" hidden="false"/>
+    <categoryEntry id="261b-dc11-00ed-4c22" name="Midnight Sorrow" hidden="false"/>
+    <categoryEntry id="3c6d-b9af-f9e6-6056" name="Silent Shroud" hidden="false"/>
+    <categoryEntry id="60f8-e0e7-a39f-a358" name="Soaring Spite" hidden="false"/>
+    <categoryEntry id="8faf-e4ce-375d-9a4b" name="Veiled Path" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="2221-a20a-7aa7-9796" name="Player" hidden="false" collective="false" targetId="853e-b6de-ea60-b17e" type="selectionEntry">
@@ -41,8 +47,129 @@
     <entryLink id="7270-9d1e-9fcb-0b61" name="Troupe Master" hidden="false" collective="false" targetId="ab2e-c78c-e6ed-fe1c" type="selectionEntry"/>
     <entryLink id="7129-3117-2f37-35c2" name="Shadowseer" hidden="false" collective="false" targetId="0f8e-40b9-3ed7-2fca" type="selectionEntry"/>
     <entryLink id="ccb7-cf51-1a6d-f4f3" name="Death Jester" hidden="false" collective="false" targetId="789a-12e6-be02-1dc1" type="selectionEntry"/>
-    <entryLink id="70d9-e8d6-aa24-dd58" name="Masque Form" hidden="false" collective="false" targetId="d5fa-5b7c-7a68-42d0" type="selectionEntry"/>
   </entryLinks>
+  <rules>
+    <rule id="e947-b0b9-fa26-5a9f" name="Sombre Sentinels" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c3b-dea4-d6e2-f559" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="155f-1e62-fbee-e25b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="261b-dc11-00ed-4c22" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c6d-b9af-f9e6-6056" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60f8-e0e7-a39f-a358" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8faf-e4ce-375d-9a4b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3a9-f0d0-b8a7-3e86" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When you make a Nerve test for a model in your kill team, subtract 1 from the result. In addition, when a model in your kill team is taken out of action, roll a D6 before removing that model; on a 4+, that model can make a shooting attack with one weapon as if it were the Shooting phase, or make a single attack as if it were the Fight phase.</description>
+    </rule>
+    <rule id="2fab-1dc0-c300-f491" name="Hysterical Fury" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="155f-1e62-fbee-e25b" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c3b-dea4-d6e2-f559" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="261b-dc11-00ed-4c22" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c6d-b9af-f9e6-6056" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60f8-e0e7-a39f-a358" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8faf-e4ce-375d-9a4b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3a9-f0d0-b8a7-3e86" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can make one additional attack in the Fight phase with a model in your kill team if it charged, was charged or performed a pile-in move granted by the Heroic Intervention Commander Tactic in this battle round.</description>
+    </rule>
+    <rule id="91d4-c38d-9324-169f" name="The Art of Death" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="261b-dc11-00ed-4c22" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c3b-dea4-d6e2-f559" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="155f-1e62-fbee-e25b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c6d-b9af-f9e6-6056" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60f8-e0e7-a39f-a358" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8faf-e4ce-375d-9a4b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3a9-f0d0-b8a7-3e86" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team can move an additional D6&quot; when they Fall Back. In addition, they can consolidate up to 6&quot;.</description>
+    </rule>
+    <rule id="6a7c-829e-8233-1d0c" name="Dance of Nightmares Made Flesh" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c6d-b9af-f9e6-6056" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c3b-dea4-d6e2-f559" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="155f-1e62-fbee-e25b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="261b-dc11-00ed-4c22" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60f8-e0e7-a39f-a358" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8faf-e4ce-375d-9a4b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3a9-f0d0-b8a7-3e86" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Subtract 1 from the Leadership characteristic of enemy models while they are within 3&quot; of any models in your kill team. In addition, whenever an opponent takes a Nerve test for a model that is within 3&quot; of any models in your kill team, they must roll two dice and discard the lowest result.</description>
+    </rule>
+    <rule id="0481-8340-6431-3f42" name="Serpent&apos;s Brood" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60f8-e0e7-a39f-a358" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c3b-dea4-d6e2-f559" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="155f-1e62-fbee-e25b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="261b-dc11-00ed-4c22" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c6d-b9af-f9e6-6056" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8faf-e4ce-375d-9a4b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3a9-f0d0-b8a7-3e86" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team treat all Pistol weapons they are equipped with as Assault 1 weapons during a battle round in which they Advanced. In addition, these models do not suffer the penalty to their hit rolls for shooting Assault weapons during a battle round in which they Advanced.</description>
+    </rule>
+    <rule id="06ad-f64a-42ac-60bb" name="Riddle-smiths" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8faf-e4ce-375d-9a4b" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c3b-dea4-d6e2-f559" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="155f-1e62-fbee-e25b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="261b-dc11-00ed-4c22" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c6d-b9af-f9e6-6056" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60f8-e0e7-a39f-a358" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3a9-f0d0-b8a7-3e86" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>At the start of each Fight phase roll 2 dice and discard the highest result. Until the end of the phase, each time an opponent targets a model in your kill team and makes a hit roll that, before modifiers, exactly matches your dice result, that hit roll fails.</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
     <selectionEntry id="69ca-e2bd-a3a1-aae3" name="Fusion pistol" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -242,6 +369,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8459-d6b9-46c7-c254" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="c5b1-f09a-b767-a565" name="Masque" hidden="false" collective="false" targetId="dcd9-b536-3878-81db" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="12.0"/>
@@ -402,6 +530,7 @@
           </constraints>
         </entryLink>
         <entryLink id="b7d1-3803-4a58-930b" name="Specialism" hidden="false" collective="false" targetId="94e9-4e9d-7489-e707" type="selectionEntryGroup"/>
+        <entryLink id="cec4-5f18-c30a-13d8" name="Masque" hidden="false" collective="false" targetId="dcd9-b536-3878-81db" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="50.0"/>
@@ -538,6 +667,7 @@
       <entryLinks>
         <entryLink id="d7df-6a9d-362a-90a8" name="Specialism" hidden="false" collective="false" targetId="94e9-4e9d-7489-e707" type="selectionEntryGroup"/>
         <entryLink id="ee29-24c4-14c4-51eb" name="Psychic Powers" hidden="false" collective="false" targetId="5efb-01f2-e017-4e35" type="selectionEntryGroup"/>
+        <entryLink id="4cdf-7adb-798d-c2ee" name="Masque" hidden="false" collective="false" targetId="dcd9-b536-3878-81db" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="65.0"/>
@@ -651,22 +781,11 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="fd70-342b-fadd-f07d" name="Specialism" hidden="false" collective="false" targetId="94e9-4e9d-7489-e707" type="selectionEntryGroup"/>
+        <entryLink id="4ee0-5b79-90c0-460d" name="Masque" hidden="false" collective="false" targetId="dcd9-b536-3878-81db" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="45.0"/>
       </costs>
-    </selectionEntry>
-    <selectionEntry id="d5fa-5b7c-7a68-42d0" name="Masque Form" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b4b-3d79-50af-a5f5" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7cd2-f483-4ffe-8c48" type="max"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="9bb8-f516-78d2-c49c" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="31a8-e4f0-6566-c6db" name="Masque Form" hidden="false" collective="false" targetId="dcd9-b536-3878-81db" type="selectionEntryGroup"/>
-      </entryLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -808,55 +927,65 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="dcd9-b536-3878-81db" name="Masque Form" hidden="false" collective="false" defaultSelectionEntryId="f3a9-f0d0-b8a7-3e86">
+    <selectionEntryGroup id="dcd9-b536-3878-81db" name="Masque" hidden="false" collective="false" defaultSelectionEntryId="f3a9-f0d0-b8a7-3e86">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41dc-58c6-0413-ffd9" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a49-6822-1e78-6615" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="0160-0e8a-29ad-3492" name="Midnight Sorrow" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="37d4-2c39-4b2f-d35f" name="The Art of Death" hidden="false">
-              <description>Models in your kill team can move an additional D6&quot; when they Fall Back. In addition, they can consolidate up to 6&quot;.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="f93b-f5a1-784c-a29d" name="Midnight Sorrow" hidden="false" targetId="261b-dc11-00ed-4c22" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="4329-d624-7ad3-5782" name="Veiled Path" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="56ce-2b37-b3bd-8e56" name="Riddle-smiths" hidden="false">
-              <description>At the start of each Fight phase roll 2 dice and discard the highest result. Until the end of the phase, each time an opponent targets a model in your kill team and makes a hit roll that, before modifiers, exactly matches your dice result, that hit roll fails.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="2ccc-3078-8960-7bf1" name="Veiled Path" hidden="false" targetId="8faf-e4ce-375d-9a4b" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="fb99-e980-3a05-a275" name="Frozen Stars" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="1dc0-5417-5d58-6334" name="Hysterical Fury" hidden="false">
-              <description>You can make one additional attack in the Fight phase with a model in your kill team if it charged, was charged or performed a pile-in move granted by the Heroic Intervention Commander Tactic in this battle round.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="3690-5388-c36d-5c98" name="Frozen Stars" hidden="false" targetId="155f-1e62-fbee-e25b" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="2d37-e7a1-ab6d-b653" name="Soaring Spite" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="70f7-34dc-692d-fb0e" name="Serpent&apos;s Brood" hidden="false">
-              <description>Models in your kill team treat all Pistol weapons they are equipped with as Assault 1 weapons during a battle round in which they Advanced. In addition, these models do not suffer the penalty to their hit rolls for shooting Assault weapons during a battle round in which they Advanced.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="c74c-40c1-42a9-40b4" name="Soaring Spite" hidden="false" targetId="60f8-e0e7-a39f-a358" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="4b0e-c163-7b08-1093" name="Dreaming Shadow" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="d331-11a1-bafb-76e1" name="Sombre Sentinels" hidden="false">
-              <description>When you make a Nerve test for a model in your kill team, subtract 1 from the result. In addition, when a model in your kill team is taken out of action, roll a D6 before removing that model; on a 4+, that model can make a shooting attack with one weapon as if it were the Shooting phase, or make a single attack as if it were the Fight phase.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="22b9-db89-97cc-ab20" name="Dreaming Shadow" hidden="false" targetId="7c3b-dea4-d6e2-f559" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="514a-670a-6a5d-aa14" name="Silent Shroud" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="5a01-64a5-426f-02f9" name="Dance of Nightmares Made Flesh" hidden="false">
-              <description>Subtract 1 from the Leadership characteristic of enemy models while they are within 3&quot; of any models in your kill team. In addition, whenever an opponent takes a Nerve test for a model that is within 3&quot; of any models in your kill team, they must roll two dice and discard the lowest result.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="a044-c644-3b51-6edc" name="Silent Shroud" hidden="false" targetId="3c6d-b9af-f9e6-6056" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry id="f3a9-f0d0-b8a7-3e86" name="* No Form*" hidden="false" collective="false" type="upgrade"/>
+        <selectionEntry id="f3a9-f0d0-b8a7-3e86" name="* No Masque*" hidden="false" collective="false" type="upgrade">
+          <costs>
+            <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>

--- a/Heretic Astartes.cat
+++ b/Heretic Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ecac-e836-08ce-c0aa" name="Heretic Astartes" revision="9" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ecac-e836-08ce-c0aa" name="Heretic Astartes" revision="10" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="6597-19ae-d64e-0fad" name="Khorne" hidden="false"/>
     <categoryEntry id="8057-475c-beeb-89a1" name="Tzeentch" hidden="false"/>
@@ -12,6 +12,14 @@
     <categoryEntry id="7f4e-8a05-4e12-f790" name="Khorne Berserker" hidden="false"/>
     <categoryEntry id="a71b-a6ef-d7ee-ba50" name="Possessed" publicationId="701a-4a21-90a2-7618" hidden="false"/>
     <categoryEntry id="5a8a-7dbc-0960-2068" name="Dark Disciple" hidden="false"/>
+    <categoryEntry id="2c0a-3b4d-314f-f31c" name="Alpha Legion" hidden="false"/>
+    <categoryEntry id="8b65-b614-a1bb-9883" name="Black Legion" hidden="false"/>
+    <categoryEntry id="fd3e-131d-7a3d-04ea" name="Emperor&apos;s Children" hidden="false"/>
+    <categoryEntry id="8e34-4910-3d06-cbd9" name="Iron Warriors" hidden="false"/>
+    <categoryEntry id="6aea-5e77-49c4-1a15" name="Night Lords" hidden="false"/>
+    <categoryEntry id="fede-d266-926c-1b42" name="Word Bearers" hidden="false"/>
+    <categoryEntry id="d560-27fc-855b-6e4f" name="World Eaters" hidden="false"/>
+    <categoryEntry id="0129-3ae9-62c0-0b7d" name="Renegade Chapter" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="fe39-04a9-3456-5f56" name="Aspiring Champion" hidden="false" collective="false" targetId="9254-c2fe-8376-2bfd" type="selectionEntry">
@@ -152,7 +160,6 @@
     </entryLink>
     <entryLink id="3486-23d6-4036-e910" name="Exalted Champion" hidden="false" collective="false" targetId="84a8-bc92-4068-06ac" type="selectionEntry"/>
     <entryLink id="1833-6975-00bc-d434" name="Sorcerer" hidden="false" collective="false" targetId="e14f-c786-8a3c-56eb" type="selectionEntry"/>
-    <entryLink id="0024-589d-cafa-5c1a" name="Legion Trait" hidden="false" collective="false" targetId="ad60-33e8-2e4d-385e" type="selectionEntry"/>
     <entryLink id="f9e4-0f60-d1f2-d4e7" name="Greater Possessed" hidden="false" collective="false" targetId="bba2-068a-6667-9a3f" type="selectionEntry"/>
     <entryLink id="0385-a8ff-ef20-9ba2" name="Master of Executions" hidden="false" collective="false" targetId="11ed-36fe-5b38-662f" type="selectionEntry"/>
     <entryLink id="adb0-2d93-ce68-14b8" name="Dark Apostle" hidden="false" collective="false" targetId="e787-b559-6782-8a96" type="selectionEntry"/>
@@ -342,6 +349,174 @@
       </modifiers>
       <description>Models with the CHAOS CULTIST keyword cannot be drawn from a Legion. However, their presence in your kill team does not prevent you using a Legion Trait, as long as the model in the kill team that can be drawn from a Legion are all drawn from the same Legion. Note, however, that models with the CHAOS CULTIST keyword can never themselves benefit from a Legion Trait.</description>
     </rule>
+    <rule id="02cf-37fd-75d9-acf4" name="Hidden in Plain Sight" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b65-b614-a1bb-9883" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd3e-131d-7a3d-04ea" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6aea-5e77-49c4-1a15" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e34-4910-3d06-cbd9" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fede-d266-926c-1b42" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team are considered to be obscured to enemy models that target them if they are more than 12&quot; away from those models.</description>
+    </rule>
+    <rule id="a945-298d-a795-b92e" name="Black Crusaders" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0a-3b4d-314f-f31c" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd3e-131d-7a3d-04ea" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6aea-5e77-49c4-1a15" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e34-4910-3d06-cbd9" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fede-d266-926c-1b42" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Add 1 to the Leadership characteristic of models in your kill team. In addition, models in your kill team can shoot Rapid Fire weapons as if they were Assault weapons in the Shooting phase of a battle round in which they Advanced (e.g. a Rapid Fire 1 weapon would be used as if it were Assault 1).</description>
+    </rule>
+    <rule id="17bd-234f-55bc-2727" name="Flawless Perfection" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0a-3b4d-314f-f31c" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b65-b614-a1bb-9883" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6aea-5e77-49c4-1a15" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e34-4910-3d06-cbd9" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fede-d266-926c-1b42" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Only models with the SLAANESH keyword can be drawn from this Legion. If a model in your kill team is wiithn 1&quot; of an enemy model at the beginning of the Fight phase, the model in your kill team is considered to have charged.</description>
+    </rule>
+    <rule id="bd9f-d085-372a-a852" name="Siege Lords" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b65-b614-a1bb-9883" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd3e-131d-7a3d-04ea" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6aea-5e77-49c4-1a15" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0a-3b4d-314f-f31c" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fede-d266-926c-1b42" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team do not suffer the penalty to Injury rolls for the target of their attacks being obscured and within 1&quot; of a model or piece of terrain that is between the two models.</description>
+    </rule>
+    <rule id="1f89-a82d-a3c5-d949" name="Terror Tactics" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b65-b614-a1bb-9883" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd3e-131d-7a3d-04ea" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0a-3b4d-314f-f31c" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e34-4910-3d06-cbd9" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fede-d266-926c-1b42" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When an opponent takes a Nerve test for a model from their kill team, they must add 1 to the test for each of our models (other than shaken models) that is within 3&quot; of that model.</description>
+    </rule>
+    <rule id="ca99-37fc-a5f0-a407" name="Dark Raiders" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b65-b614-a1bb-9883" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd3e-131d-7a3d-04ea" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6aea-5e77-49c4-1a15" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e34-4910-3d06-cbd9" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fede-d266-926c-1b42" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0a-3b4d-314f-f31c" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll charge rolls for models in your kill team.</description>
+    </rule>
+    <rule id="1c6d-f089-654e-924e" name="Profane Zeal" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b65-b614-a1bb-9883" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd3e-131d-7a3d-04ea" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6aea-5e77-49c4-1a15" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e34-4910-3d06-cbd9" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0a-3b4d-314f-f31c" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll failed Nerve tests for models in your kill team.</description>
+    </rule>
+    <rule id="1994-5837-7c40-6e2c" name="Butcher&apos;s Nails" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b65-b614-a1bb-9883" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd3e-131d-7a3d-04ea" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6aea-5e77-49c4-1a15" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e34-4910-3d06-cbd9" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fede-d266-926c-1b42" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0a-3b4d-314f-f31c" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Only models with the KHORNE keyword can be drawn from this Legion. You can make one additional attack in the Fight phase with a model in your kill team if it charged, was charged or made a pile-in move granted by the Heroic Intervention Commander Tactic in that battle round.</description>
+    </rule>
   </rules>
   <sharedSelectionEntries>
     <selectionEntry id="4075-809f-9ee0-32ad" name="Chaos Space Marine" hidden="false" collective="false" type="model">
@@ -407,6 +582,7 @@
           </constraints>
         </entryLink>
         <entryLink id="eae2-0473-e99c-7efe" name="Chaos Icon" hidden="false" collective="false" targetId="bd83-a5d0-a1fe-98d2" type="selectionEntryGroup"/>
+        <entryLink id="2a26-d93b-16da-7609" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="12.0"/>
@@ -535,6 +711,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f55-112c-fc04-d3cd" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="6d54-ed16-a3c2-bc08" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="13.0"/>
@@ -611,6 +788,7 @@
         <entryLink id="781d-fe32-a46a-0f8d" name="Mark of Chaos" hidden="false" collective="false" targetId="5e91-64ba-5229-d2a9" type="selectionEntryGroup"/>
         <entryLink id="1e5f-15b2-fb1b-9547" name="Specialism" hidden="false" collective="false" targetId="2582-24f9-c06f-b44d" type="selectionEntryGroup"/>
         <entryLink id="fea1-6819-c625-30ca" name="Frag and Krak grenades" hidden="false" collective="false" targetId="d688-708b-a896-c8ed" type="selectionEntry"/>
+        <entryLink id="c277-a9dc-6d0d-4d01" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="13.0"/>
@@ -1145,6 +1323,7 @@
         <entryLink id="3aec-2add-0e8a-e484" name="Mark of Chaos" hidden="false" collective="false" targetId="5e91-64ba-5229-d2a9" type="selectionEntryGroup"/>
         <entryLink id="0bf1-b961-1975-d9ae" name="Frag and krak grenades" hidden="false" collective="false" targetId="d688-708b-a896-c8ed" type="selectionEntry"/>
         <entryLink id="0f9b-d929-cae1-074c" name="Specialism" hidden="false" collective="false" targetId="2582-24f9-c06f-b44d" type="selectionEntryGroup"/>
+        <entryLink id="bcd3-bd0c-aeef-c067" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="30.0"/>
@@ -1271,6 +1450,7 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f6e-488b-8aa9-9192" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="9366-a788-142b-581f" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="65.0"/>
@@ -1377,6 +1557,7 @@
       <entryLinks>
         <entryLink id="5ea0-15d0-7f61-a1d4" name="Specialism" hidden="false" collective="false" targetId="2582-24f9-c06f-b44d" type="selectionEntryGroup"/>
         <entryLink id="64c5-4c98-7e2f-69f1" name="Mark of Chaos" hidden="false" collective="false" targetId="5e91-64ba-5229-d2a9" type="selectionEntryGroup"/>
+        <entryLink id="d5ea-c239-aa6b-1bd5" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="80.0"/>
@@ -1479,6 +1660,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1c9-23b3-031a-afc7" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="1fde-2480-5d79-770d" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="71.0"/>
@@ -1569,6 +1751,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b340-2d5d-fdc7-baa8" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="839a-aab0-6102-411c" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="49.0"/>
@@ -1762,6 +1945,7 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b2e-d83b-63b1-9776" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="6517-78df-7776-8af0" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="68.0"/>
@@ -1928,6 +2112,7 @@
         <entryLink id="c321-6b1a-0a3d-b4eb" name="Psychic Powers" hidden="false" collective="false" targetId="f033-f7e2-12b2-addd" type="selectionEntryGroup"/>
         <entryLink id="8fd5-696f-a003-2feb" name="Specialism" hidden="false" collective="false" targetId="2582-24f9-c06f-b44d" type="selectionEntryGroup"/>
         <entryLink id="335e-9847-0328-f243" name="Mark of Chaos" hidden="false" collective="false" targetId="5e91-64ba-5229-d2a9" type="selectionEntryGroup"/>
+        <entryLink id="6bbd-d9f6-7a16-51ca" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="88.0"/>
@@ -2160,6 +2345,7 @@
       <entryLinks>
         <entryLink id="6115-8ab4-ad63-ec7a" name="Mark of Chaos" hidden="false" collective="false" targetId="5e91-64ba-5229-d2a9" type="selectionEntryGroup"/>
         <entryLink id="d4fc-5b20-fdc0-e363" name="Specialism" hidden="false" collective="false" targetId="2582-24f9-c06f-b44d" type="selectionEntryGroup"/>
+        <entryLink id="6b1f-3094-e7da-22ce" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="80.0"/>
@@ -2259,6 +2445,7 @@
       <entryLinks>
         <entryLink id="f092-829c-91e1-f2c8" name="Specialism" hidden="false" collective="false" targetId="2582-24f9-c06f-b44d" type="selectionEntryGroup"/>
         <entryLink id="cdac-4f58-0400-6f3c" name="Frag and krak grenades" hidden="false" collective="false" targetId="d688-708b-a896-c8ed" type="selectionEntry"/>
+        <entryLink id="fd07-1a0e-15b7-8c98" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="16.0"/>
@@ -2402,6 +2589,7 @@
       <entryLinks>
         <entryLink id="8219-9608-8abc-cc97" name="Specialism" hidden="false" collective="false" targetId="2582-24f9-c06f-b44d" type="selectionEntryGroup"/>
         <entryLink id="adb5-1b3d-a2c9-6305" name="Frag and krak grenades" hidden="false" collective="false" targetId="d688-708b-a896-c8ed" type="selectionEntry"/>
+        <entryLink id="e583-9a01-a3bc-b88a" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="17.0"/>
@@ -2589,6 +2777,7 @@
       <entryLinks>
         <entryLink id="0432-2a02-0ac7-5801" name="Specialism" hidden="false" collective="false" targetId="2582-24f9-c06f-b44d" type="selectionEntryGroup"/>
         <entryLink id="30d3-abe7-afc2-36da" name="Frag and krak grenades" hidden="false" collective="false" targetId="d688-708b-a896-c8ed" type="selectionEntry"/>
+        <entryLink id="ab6c-00d4-61f3-ce2c" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="17.0"/>
@@ -2661,6 +2850,7 @@
       <entryLinks>
         <entryLink id="65f0-3492-a72c-d717" name="Mark of Chaos" hidden="false" collective="false" targetId="5e91-64ba-5229-d2a9" type="selectionEntryGroup"/>
         <entryLink id="662a-5209-e3bf-21fe" name="Specialism" hidden="false" collective="false" targetId="2582-24f9-c06f-b44d" type="selectionEntryGroup"/>
+        <entryLink id="a903-c362-211e-169b" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="20.0"/>
@@ -2729,6 +2919,7 @@
         <entryLink id="3838-729c-69c4-7644" name="Chaos Icon" hidden="false" collective="false" targetId="bd83-a5d0-a1fe-98d2" type="selectionEntryGroup"/>
         <entryLink id="07d9-5114-afa6-99f2" name="Ranged weapons" hidden="false" collective="false" targetId="e5f9-e9ec-a67e-d251" type="selectionEntryGroup"/>
         <entryLink id="0022-c5ec-f88a-5d81" name="Melee weapon" hidden="false" collective="false" targetId="4c29-0c9c-8b69-7127" type="selectionEntryGroup"/>
+        <entryLink id="a6c7-10d9-eb65-e392" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="25.0"/>
@@ -2783,6 +2974,7 @@
         <entryLink id="ec7a-0fd7-8631-e458" name="Specialism" hidden="false" collective="false" targetId="2582-24f9-c06f-b44d" type="selectionEntryGroup"/>
         <entryLink id="3412-f24d-65bb-fba9" name="Ranged weapons" hidden="false" collective="false" targetId="e5f9-e9ec-a67e-d251" type="selectionEntryGroup"/>
         <entryLink id="a28b-a350-c4b9-1bde" name="Melee weapon" hidden="false" collective="false" targetId="4c29-0c9c-8b69-7127" type="selectionEntryGroup"/>
+        <entryLink id="7604-fde6-2f81-11a0" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="26.0"/>
@@ -2838,6 +3030,7 @@
         <entryLink id="cb9e-9f6c-671c-34a9" name="Chaos Icon" hidden="false" collective="false" targetId="bd83-a5d0-a1fe-98d2" type="selectionEntryGroup"/>
         <entryLink id="c9b3-b4a4-5008-61cb" name="Ranged weapons" hidden="false" collective="false" targetId="e5f9-e9ec-a67e-d251" type="selectionEntryGroup"/>
         <entryLink id="3d94-2537-e503-43f0" name="Melee weapon" hidden="false" collective="false" targetId="4c29-0c9c-8b69-7127" type="selectionEntryGroup"/>
+        <entryLink id="87fc-6a61-8507-9f08" name="Legion" hidden="false" collective="false" targetId="a273-63fe-5a78-fb5c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="27.0"/>
@@ -2946,11 +3139,11 @@
         </selectionEntry>
         <selectionEntry id="cda4-a3cb-ae7f-13e1" name="Khorne" hidden="false" collective="false" type="upgrade">
           <modifiers>
-            <modifier type="set" field="f0df-1ce3-df4c-c82c" value="1">
+            <modifier type="set" field="f0df-1ce3-df4c-c82c" value="1.0">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="91d8-38e5-8884-0cd9" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="equalTo"/>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f5f1-3c88-54ba-b808" type="notInstanceOf"/>
                   </conditions>
                 </conditionGroup>
@@ -2989,7 +3182,7 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef63-3ac7-7e5a-5258" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd3e-131d-7a3d-04ea" type="equalTo"/>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f5f1-3c88-54ba-b808" type="notInstanceOf"/>
                   </conditions>
                 </conditionGroup>
@@ -3322,93 +3515,77 @@
         <entryLink id="5f56-76ac-e85f-3332" name="Malefic Discipline" hidden="false" collective="false" targetId="6b21-4de9-8a1e-abf1" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="a273-63fe-5a78-fb5c" name="Legion Trait" publicationId="701a-4a21-90a2-7618" page="21" hidden="false" collective="false" defaultSelectionEntryId="e722-2731-e0e2-212f">
+    <selectionEntryGroup id="a273-63fe-5a78-fb5c" name="Legion" publicationId="701a-4a21-90a2-7618" page="21" hidden="false" collective="false" defaultSelectionEntryId="e722-2731-e0e2-212f">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4436-232a-c338-7638" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be00-543c-a45c-5946" type="min"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="e722-2731-e0e2-212f" name="*No Trait*" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e722-2731-e0e2-212f" name="*No Legion*" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ef63-3ac7-7e5a-5258" name="Emperor&apos;s Children" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="6c64-9ed3-32e1-f9e5" name="Flawless Perfection" hidden="false">
-              <description>Only models with the SLAANESH keyword can be drawn from this Legion. If a model in your kill tema is wiithn 1&quot; of an enemy model at the beginning of the Fight phase, the model in your kill team is considered to have charged.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="4900-d6ba-1c04-7afa" name="Emperor&apos;s Children" hidden="false" targetId="fd3e-131d-7a3d-04ea" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3514-0027-ec3b-ab28" name="Iron Warriors" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="c1be-4f25-1099-c4a2" name="Siege Lords" hidden="false">
-              <description>Models in your kill team do not suffer the penalty to Injury rolls for the target of their attacks being obscured and within 1&quot; of a model or piece of terrain that is between the two models.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="c6f9-8cc8-423b-a106" name="Iron Warriors" hidden="false" targetId="8e34-4910-3d06-cbd9" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b9da-30c3-fef1-9d2d" name="Night Lords" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="6456-dfd9-7d1a-2257" name="Terror Tactics" hidden="false">
-              <description>When an opponent takes a Nerve test for a model from their kill team, they must add 1 to the test for each of our models (other than shaken models) that is within 3&quot; of that model.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="30c8-afd7-3c58-aeca" name="Night Lords" hidden="false" targetId="6aea-5e77-49c4-1a15" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="91d8-38e5-8884-0cd9" name="World Eaters" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="f13d-bede-6ba2-4a84" name="Butcher&apos;s Nails" hidden="false">
-              <description>Only models with the KHORNE keyword can be drawn from this Legion. You can make one additional attack in the Fight phase with a model in your kill team if it charged, was charged or made a pile-in move granted by the Heroic Intervention Commander Tactic in that battle round.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="0a18-4eb3-1f6f-6171" name="World Eaters" hidden="false" targetId="d560-27fc-855b-6e4f" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b07c-5d97-1f51-8e17" name="Black Legion" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="94b3-b068-4a06-da9b" name="Black Crusaders" hidden="false">
-              <description>Add 1 to the Leadership characteristic of models in your kill team. In addition, models in your kill team can shoot Rapid Fire weapons as if they were Assault weapons in the Shooting phase of a battle round in which they Advanced (e.g. a Rapid Fire 1 weapon would be used as if it were Assault 1).</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="5059-9a12-ce6d-501b" name="Black Legion" hidden="false" targetId="8b65-b614-a1bb-9883" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0650-d6dd-c8c5-647a" name="Word Bearers" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="fd73-6648-7197-6241" name="Profane Zeal" hidden="false">
-              <description>You can re-roll failed Nerve tests for models in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="2c0e-d89a-35c5-08fe" name="Word Bearers" hidden="false" targetId="fede-d266-926c-1b42" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6970-3fb5-2412-dfcb" name="Alpha Legion" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="802d-0ffa-3bd3-6184" name="Hidden in Plain Sight" hidden="false">
-              <description>Models in your kill team are considered to be obscured to enemy models that target them if they are more than 12&quot; away from those models.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="e068-0629-52a9-588f" name="Alpha Legion" hidden="false" targetId="2c0a-3b4d-314f-f31c" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="22be-0a2e-b0fb-37a9" name="Renegade Chapters" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="fcce-c9f7-1995-ca42" name="Dark Raiders" hidden="false">
-              <description>You can re-roll charge rolls for models in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="2136-0926-a26b-0ecf" name="Renegade Chapter" hidden="false" targetId="0129-3ae9-62c0-0b7d" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>

--- a/Heretic Astartes.cat
+++ b/Heretic Astartes.cat
@@ -363,6 +363,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0a-3b4d-314f-f31c" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -384,6 +385,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b65-b614-a1bb-9883" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -405,6 +407,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd3e-131d-7a3d-04ea" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -426,6 +429,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e34-4910-3d06-cbd9" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -447,6 +451,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6aea-5e77-49c4-1a15" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -468,6 +473,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0a-3b4d-314f-f31c" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -489,6 +495,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fede-d266-926c-1b42" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -510,6 +517,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0a-3b4d-314f-f31c" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0129-3ae9-62c0-0b7d" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e722-2731-e0e2-212f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d560-27fc-855b-6e4f" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>

--- a/Necrons.cat
+++ b/Necrons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d1bc-0b71-2f3d-71eb" name="Necrons" revision="9" battleScribeVersion="2.02" authorName="BSData Team" authorContact="https://discord.gg/UrrPB3T" authorUrl="https://github.com/BSData/wh40k-killteam/" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d1bc-0b71-2f3d-71eb" name="Necrons" revision="10" battleScribeVersion="2.02" authorName="BSData Team" authorContact="https://discord.gg/UrrPB3T" authorUrl="https://github.com/BSData/wh40k-killteam/" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="d1bc-0b71-pubN65537" name="Warhammer 40,000: Kill Team"/>
     <publication id="d1bc-0b71-pubN66483" name="Codex: Necrons"/>
@@ -9,6 +9,11 @@
   <categoryEntries>
     <categoryEntry id="7527-a514-7ada-0c2e" name="Triarch Praetorian" hidden="false"/>
     <categoryEntry id="7758-9ca8-4d2f-34a2" name="Lychguard" hidden="false"/>
+    <categoryEntry id="e70c-eb11-9d9a-f7f8" name="Mephrit" hidden="false"/>
+    <categoryEntry id="d884-4ca1-6d48-fa85" name="Nephrekh" hidden="false"/>
+    <categoryEntry id="e2f0-db23-ba88-e7de" name="Nihilakh" hidden="false"/>
+    <categoryEntry id="ef07-76a9-5bd5-28c2" name="Novokh" hidden="false"/>
+    <categoryEntry id="1e24-87d6-ef0b-6517" name="Sautekh" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="02d4-09c1-3506-61fe" name="Immortal" hidden="false" collective="false" targetId="040a-73a0-6c8d-2733" type="selectionEntry">
@@ -157,11 +162,6 @@
         <categoryLink id="ae9f-1d46-cd56-5ce7" name="New CategoryLink" hidden="false" targetId="6c25-5825-9054-44a7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e0d1-8419-63a1-e0b4" name="Dynastic Code" hidden="false" collective="false" targetId="8b47-91d9-c6d1-4b47" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fefe-264f-0c4b-b31d" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="005c-c10c-1a4d-d677" name="Triarch Praetorian" hidden="false" collective="false" targetId="5166-8ff9-c66d-b073" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="bf38-6e42-9cb8-d9f4" name="New CategoryLink" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="true"/>
@@ -231,6 +231,103 @@
       </categoryLinks>
     </entryLink>
   </entryLinks>
+  <rules>
+    <rule id="e73b-2e7d-c0fa-65f1" name="Solar Fury" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e70c-eb11-9d9a-f7f8" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d884-4ca1-6d48-fa85" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2f0-db23-ba88-e7de" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef07-76a9-5bd5-28c2" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e24-87d6-ef0b-6517" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0aa-7bd4-d887-94b9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>If a model in your kill team targets an enemy model that is within range and not at long range when making a Shooting attack, improve the Armour Penetration characteristic of the weapon&apos;s attack by 1 (i.e. an Armour Penetration characteristic of &apos;0&apos; becomes &apos;-1&apos;; an Armour Penetration characteristic of &apos;-1&apos; becomes &apos;-2&apos;, etc.).</description>
+    </rule>
+    <rule id="795b-9787-680e-6ac7" name="Translocation Beams" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d884-4ca1-6d48-fa85" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e70c-eb11-9d9a-f7f8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2f0-db23-ba88-e7de" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef07-76a9-5bd5-28c2" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e24-87d6-ef0b-6517" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0aa-7bd4-d887-94b9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>If a model in your kill team Advances, you can re-roll the D6 to determine the increase to that model&apos;s Move characteristic. In addition, if a model in your kill team Advances, it can move across models and terrain as if they were not there.</description>
+    </rule>
+    <rule id="afa7-3fad-8d68-58f3" name="Aggressively Territorial" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2f0-db23-ba88-e7de" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e70c-eb11-9d9a-f7f8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d884-4ca1-6d48-fa85" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef07-76a9-5bd5-28c2" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e24-87d6-ef0b-6517" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0aa-7bd4-d887-94b9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Re-roll unmodified hit rolls of 1 in the Shooting phase for models in your kill team if they have not moved in this battle round.</description>
+    </rule>
+    <rule id="8987-4dd6-f243-8e6c" name="Awakened by Murder" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef07-76a9-5bd5-28c2" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e70c-eb11-9d9a-f7f8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d884-4ca1-6d48-fa85" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2f0-db23-ba88-e7de" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e24-87d6-ef0b-6517" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0aa-7bd4-d887-94b9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll failed hit rolls in the Fight phase for attacks made by a model in your kill team if it charged, was charged, or made a pile-in move granted by the Heroic Intervention Commander Tactic in that battle round.</description>
+    </rule>
+    <rule id="4333-5527-ca30-0c93" name="Relentless Advance" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e24-87d6-ef0b-6517" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e70c-eb11-9d9a-f7f8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d884-4ca1-6d48-fa85" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2f0-db23-ba88-e7de" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef07-76a9-5bd5-28c2" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0aa-7bd4-d887-94b9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team can shoot ranged weapons as if they were Assault weapons in the Shooting phase of a battle round in which they Advanced (e.g. a Rapid Fire 1 weapon would be used as if it were an Assault 1 weapon).</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
     <selectionEntry id="e299-24fe-f16d-dd4c" name="Deathmark" hidden="false" collective="false" type="model">
       <modifiers>
@@ -290,6 +387,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="979e-5055-32ce-9227" name="Specialist Type" hidden="false" collective="false" targetId="9654-238a-3415-2111" type="selectionEntryGroup"/>
+        <entryLink id="a1c6-72bf-f9ed-e0f6" name="Dynasty" hidden="false" collective="false" targetId="644a-2bc2-69ca-b770" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="15.0"/>
@@ -353,6 +451,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="7709-3b79-e30b-ba75" name="Specialist Type" hidden="false" collective="false" targetId="9654-238a-3415-2111" type="selectionEntryGroup"/>
+        <entryLink id="0163-14fb-8ce0-c065" name="Dynasty" hidden="false" collective="false" targetId="644a-2bc2-69ca-b770" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -443,6 +542,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="5d94-2180-8a30-0a40" name="Specialist Type" hidden="false" collective="false" targetId="9654-238a-3415-2111" type="selectionEntryGroup"/>
+        <entryLink id="5edc-7637-4ed1-4d05" name="Dynasty" hidden="false" collective="false" targetId="644a-2bc2-69ca-b770" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="16.0"/>
@@ -506,6 +606,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="af71-6616-1275-1de0" name="Specialist Type" hidden="false" collective="false" targetId="9654-238a-3415-2111" type="selectionEntryGroup"/>
+        <entryLink id="b500-d2eb-f262-09d4" name="Dynasty" hidden="false" collective="false" targetId="644a-2bc2-69ca-b770" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="12.0"/>
@@ -729,6 +830,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="9230-6961-9342-1d2d" name="Specialism" hidden="false" collective="false" targetId="9654-238a-3415-2111" type="selectionEntryGroup"/>
+        <entryLink id="26ba-09d8-6b34-8cc1" name="Dynasty" hidden="false" collective="false" targetId="644a-2bc2-69ca-b770" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="86.0"/>
@@ -820,21 +922,10 @@
           </constraints>
         </entryLink>
         <entryLink id="978b-6e9d-936b-60b9" name="Specialism" hidden="false" collective="false" targetId="9654-238a-3415-2111" type="selectionEntryGroup"/>
+        <entryLink id="618e-7962-c9dd-9b55" name="Dynasty" hidden="false" collective="false" targetId="644a-2bc2-69ca-b770" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="44.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8b47-91d9-c6d1-4b47" name="Dynastic Code" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5672-2615-e1e9-7897" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b6d-39a5-aa5a-bc09" type="min"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="1b56-febe-f283-ca5d" name="Dynastic Codes" hidden="false" collective="false" targetId="644a-2bc2-69ca-b770" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5166-8ff9-c66d-b073" name="Triarch Praetorian" hidden="false" collective="false" type="model">
@@ -1058,6 +1149,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="f6e1-caf6-0070-9861" name="Specialism" hidden="false" collective="false" targetId="9654-238a-3415-2111" type="selectionEntryGroup"/>
+        <entryLink id="25c4-01e6-8731-3e52" name="Dynasty" hidden="false" collective="false" targetId="644a-2bc2-69ca-b770" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="20.0"/>
@@ -1305,63 +1397,53 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="644a-2bc2-69ca-b770" name="Dynastic Codes" hidden="false" collective="false" defaultSelectionEntryId="a0aa-7bd4-d887-94b9">
+    <selectionEntryGroup id="644a-2bc2-69ca-b770" name="Dynasty" hidden="false" collective="false" defaultSelectionEntryId="a0aa-7bd4-d887-94b9">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a8c-e5a8-86f5-9bf2" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="661d-b1a3-e27e-e315" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="6d3a-6849-026a-a557" name="Sautekh" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="07c3-af81-1064-c454" name="Relentless Advance" hidden="false">
-              <description>Models in your kill team can shoot ranged weapons as if they were Assault weapons in the Shooting phase of a battle round in which they Advanced (e.g. a Rapid Fire 1 weapon would be used as if it were an Assault 1 weapon).</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="8b75-47d5-1d1b-cc5d" name="Sautekh" hidden="false" targetId="1e24-87d6-ef0b-6517" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="eada-714e-dfa1-f159" name="Mephrit" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="15fb-4e7d-2254-714b" name="Solar Fury" hidden="false">
-              <description>If a model in your kill team targets an enemy model that is within range and not at long range when making a Shooting attack, improve the Armour Penetration characteristic of the weapon&apos;s attack by 1 (i.e. an Armour Penetration characteristic of &apos;0&apos; becomes &apos;-1&apos;; an Armour Penetration characteristic of &apos;-1&apos; becomes &apos;-2&apos;, etc.).</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="694d-c947-1766-994d" name="Mephrit" hidden="false" targetId="e70c-eb11-9d9a-f7f8" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5517-78e5-8921-62cc" name="Novokh" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="d3bb-01ba-8f27-bd7f" name="Awakened by Murder" hidden="false">
-              <description>You can re-roll failed hit rolls in the Fight phase for attacks made by a model in your kill team if it charged, was charged, or made a pile-in move granted by the Heroic Intervention Commander Tactic in that battle round.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="8caf-a81b-fb36-7df3" name="Novokh" hidden="false" targetId="ef07-76a9-5bd5-28c2" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="996d-11a2-d8ca-24dc" name="Nihilakh" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="a338-786a-2f4d-4428" name="Aggressively Territorial" hidden="false">
-              <description>Re-roll unmodified hit rolls of 1 in the Shooting phase for models in your kill team if they have not moved in this battle round.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="3985-1a7b-0b8a-61c0" name="Nihilakh" hidden="false" targetId="e2f0-db23-ba88-e7de" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a0aa-7bd4-d887-94b9" name="*No Code*" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="a0aa-7bd4-d887-94b9" name="*No Dynasty*" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="69a1-3328-0f7b-65a4" name="Nephrekh" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="2edd-d9a8-05ab-042e" name="Translocation Beams" hidden="false">
-              <description>If a model in your kill team Advances, you can re-roll the D6 to determine the increase to that model&apos;s Move characteristic. In addition, if a model in your kill team Advances, it can move across models and terrain as if they were not there.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="39ec-59be-5218-ad6d" name="Nephrekh" hidden="false" targetId="d884-4ca1-6d48-fa85" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>

--- a/Orks.cat
+++ b/Orks.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a34e-d16c-80ff-06bf" name="Orks" revision="21" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a34e-d16c-80ff-06bf" name="Orks" revision="22" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="2a73-3eb4-3c77-db12" name="Ork Boy" hidden="false"/>
     <categoryEntry id="d9e4-66e2-9d74-a149" name="Burna Boy" hidden="false"/>
@@ -11,6 +11,13 @@
     <categoryEntry id="a506-95a9-f463-8b35" name="Mega Armour" hidden="false"/>
     <categoryEntry id="6acc-147c-e2fa-e19c" name="Freebootaz" hidden="false"/>
     <categoryEntry id="4185-c106-c40f-d41c" name="Flash Git" hidden="false"/>
+    <categoryEntry id="d799-b522-8c0e-a310" name="Bad Moons" hidden="false"/>
+    <categoryEntry id="49c9-c9af-e1ad-6f2b" name="Blood Axes" hidden="false"/>
+    <categoryEntry id="cfdd-a5d1-2225-b8ef" name="Deathskulls" hidden="false"/>
+    <categoryEntry id="3e63-d2ff-7faa-478a" name="Evil Sunz" hidden="false"/>
+    <categoryEntry id="300e-b879-4e40-9c9d" name="Freebooterz" hidden="false"/>
+    <categoryEntry id="80b1-ca7a-5d59-05cd" name="Goffs" hidden="false"/>
+    <categoryEntry id="0914-2a26-a686-8798" name="Snakebites" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="7150-a0ae-d338-10a2" name="Burna Boy" hidden="false" collective="false" targetId="6f0a-a880-0cbc-22f2" type="selectionEntry">
@@ -293,7 +300,6 @@
         <categoryLink id="7a7a-ce51-3a04-c3ff" name="New CategoryLink" hidden="false" targetId="6c25-5825-9054-44a7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ddd5-940d-38b9-8dde" name="Clan Kulturs" hidden="false" collective="false" targetId="771a-b31c-265d-ec0f" type="selectionEntry"/>
     <entryLink id="a4b3-6c55-7eb3-b2ab" name="Nob" hidden="false" collective="false" targetId="b5a8-c094-9144-6849" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ad9a-c548-1ef0-01c2" name="New CategoryLink" hidden="false" targetId="29e7-d60f-5acd-4d99" primary="true"/>
@@ -461,6 +467,149 @@
     </entryLink>
     <entryLink id="2966-d841-f505-eebb" name="Boss Snikrot" hidden="false" collective="false" targetId="177b-0582-4ebb-4a42" type="selectionEntry"/>
   </entryLinks>
+  <rules>
+    <rule id="bd38-825a-60cc-bf99" name="Armed to Da Teef" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d799-b522-8c0e-a310" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49c9-c9af-e1ad-6f2b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80b1-ca7a-5d59-05cd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e63-d2ff-7faa-478a" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cfdd-a5d1-2225-b8ef" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0914-2a26-a686-8798" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ece-d436-23c2-ba85" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Re-roll hit rolls of 1 for attacks made by models in your kill team in the Shooting phase.</description>
+    </rule>
+    <rule id="14db-96fd-77d6-a0b6" name="Taktiks" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49c9-c9af-e1ad-6f2b" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d799-b522-8c0e-a310" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80b1-ca7a-5d59-05cd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e63-d2ff-7faa-478a" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cfdd-a5d1-2225-b8ef" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0914-2a26-a686-8798" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ece-d436-23c2-ba85" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team are considered to be obscured to enemy models that target them if they are more than 12&quot; away from those models. In addition, models in your kill team can shoot even if they Fell Back in the same battle round.</description>
+    </rule>
+    <rule id="77e0-7b4b-04cc-f190" name="Lucky Blue Gitz" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cfdd-a5d1-2225-b8ef" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d799-b522-8c0e-a310" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80b1-ca7a-5d59-05cd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e63-d2ff-7faa-478a" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49c9-c9af-e1ad-6f2b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0914-2a26-a686-8798" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ece-d436-23c2-ba85" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team have a 6+ invulnerable save, unless they already have an invulnerable save. In addition, you can re-roll a single failed hit roll and a single failed wound roll in each phase, as long as the attack was made by a model in your kill team.</description>
+    </rule>
+    <rule id="3753-ad8e-8f85-8b90" name="Red Ones Go Fasta" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e63-d2ff-7faa-478a" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d799-b522-8c0e-a310" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80b1-ca7a-5d59-05cd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cfdd-a5d1-2225-b8ef" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49c9-c9af-e1ad-6f2b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0914-2a26-a686-8798" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ece-d436-23c2-ba85" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Add 1 to the Move characteristic of models in your kill team and add 1 to Advance and charge rolls made for them. In addition, these models do not suffer the penalty to their hit rolls for shooting Assault weapons during a battle round in which they Advanced.</description>
+    </rule>
+    <rule id="f429-ea12-eb49-8135" name="Competitive Streak" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="300e-b879-4e40-9c9d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d799-b522-8c0e-a310" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80b1-ca7a-5d59-05cd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cfdd-a5d1-2225-b8ef" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e63-d2ff-7faa-478a" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49c9-c9af-e1ad-6f2b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0914-2a26-a686-8798" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ece-d436-23c2-ba85" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Add 1 to hit rolls for attacks made by models in your kill team for each other model in your kill team that has taken an enemy model out of action with an attack in this phase.</description>
+    </rule>
+    <rule id="0248-8b6f-a538-1a88" name="No Muckin&apos; About" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80b1-ca7a-5d59-05cd" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d799-b522-8c0e-a310" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cfdd-a5d1-2225-b8ef" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e63-d2ff-7faa-478a" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49c9-c9af-e1ad-6f2b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0914-2a26-a686-8798" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ece-d436-23c2-ba85" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Each time you make an unmodified hit roll of 6 for an attack with a melee weapon made by a model in your kill team, immediately make an additional hit roll against the same target with the same weapon. These additional hit rolls cannot themselves generate any further hit rolls.</description>
+    </rule>
+    <rule id="1ea3-6922-0701-0ebb" name="Da Old Ways" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0914-2a26-a686-8798" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d799-b522-8c0e-a310" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cfdd-a5d1-2225-b8ef" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e63-d2ff-7faa-478a" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49c9-c9af-e1ad-6f2b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80b1-ca7a-5d59-05cd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ece-d436-23c2-ba85" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Roll a dice each time a model in your kill team loses a wound. On a 6 the would is not lost. If a model already has a similar ability, choose which effect applies, and re-roll 1s when making these rolls.</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
     <selectionEntry id="a2f7-b7aa-039d-55f4" name="Kombi-weapon with Rokkit Launcha" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -589,6 +738,7 @@
           </constraints>
         </entryLink>
         <entryLink id="d170-ff8c-a928-cc76" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
+        <entryLink id="e35b-92ae-2360-f319" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="12.0"/>
@@ -856,6 +1006,7 @@
           </constraints>
         </entryLink>
         <entryLink id="6bc0-e77e-f835-21b2" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
+        <entryLink id="fb71-5eb0-e7f7-052b" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -992,6 +1143,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63cb-9cbb-0be5-bbf8" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="a7bd-0e3e-8251-be17" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="6.0"/>
@@ -1079,6 +1231,7 @@
           </constraints>
         </entryLink>
         <entryLink id="a74a-fe40-19eb-8225" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
+        <entryLink id="cb2c-b900-ef21-6b37" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
@@ -1157,6 +1310,7 @@
           </constraints>
         </entryLink>
         <entryLink id="2405-b6c0-9c72-0414" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
+        <entryLink id="1f96-2ce0-994c-95e8" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -1216,6 +1370,7 @@
           </constraints>
         </entryLink>
         <entryLink id="41aa-c595-4807-14eb" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
+        <entryLink id="b667-1cc5-3a2d-b528" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -1289,6 +1444,7 @@
           </constraints>
         </entryLink>
         <entryLink id="4f07-91d5-a5c4-1045" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
+        <entryLink id="7db2-198e-01c3-2e02" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="12.0"/>
@@ -1341,6 +1497,7 @@
           </constraints>
         </entryLink>
         <entryLink id="c84e-ac59-5834-1351" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
+        <entryLink id="25a4-61e7-d444-d869" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="12.0"/>
@@ -1408,6 +1565,7 @@
           </constraints>
         </entryLink>
         <entryLink id="1e97-094c-2a68-e2fb" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
+        <entryLink id="deb2-42c9-66a3-ea8c" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="10.0"/>
@@ -1632,6 +1790,7 @@
           </constraints>
         </entryLink>
         <entryLink id="795d-d117-0efe-b9d5" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
+        <entryLink id="bffc-f47e-0019-4d32" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="62.0"/>
@@ -1787,6 +1946,7 @@
           </constraints>
         </entryLink>
         <entryLink id="e960-81d0-b1cd-9821" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
+        <entryLink id="be49-83a7-ac6d-4315" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="20.0"/>
@@ -1900,6 +2060,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca62-9c53-5bff-0740" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="20a5-a03a-8060-c186" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="20.0"/>
@@ -1918,21 +2079,6 @@
           </characteristics>
         </profile>
       </profiles>
-      <costs>
-        <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="771a-b31c-265d-ec0f" name="Clan Kulturs" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be02-e07f-b38e-441a" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff44-fd6d-1489-0f6a" type="max"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="0aed-79a4-2dd2-5289" name="Configuration" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="f50c-3526-45db-6f49" name="Clan Kulturs" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
@@ -1977,6 +2123,7 @@
         <entryLink id="61f2-c312-2154-65b9" name="Kombi-weapons" hidden="false" collective="false" targetId="5dec-dbd4-b12d-1141" type="selectionEntryGroup"/>
         <entryLink id="aa55-65cd-c090-941c" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
         <entryLink id="af3a-8edf-0e97-3717" name="Stikkbombs" hidden="false" collective="false" targetId="8fad-e5b9-1b41-ba1e" type="selectionEntry"/>
+        <entryLink id="2ce2-4ff0-ce4d-5d09" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="15.0"/>
@@ -2061,6 +2208,7 @@
         <entryLink id="b881-5535-8b26-bbe4" name="Kombi-weapons" hidden="false" collective="false" targetId="5dec-dbd4-b12d-1141" type="selectionEntryGroup"/>
         <entryLink id="ae46-5d80-5dc2-7526" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
         <entryLink id="5bd4-084d-e178-40d0" name="Stikkbombs" hidden="false" collective="false" targetId="8fad-e5b9-1b41-ba1e" type="selectionEntry"/>
+        <entryLink id="2fcd-dfe4-01b2-208e" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="16.0"/>
@@ -2121,6 +2269,12 @@
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="11cb-c320-de71-9ad3" name="Faction: Orks" hidden="false" targetId="3630-39cf-f986-6209" primary="false"/>
+        <categoryLink id="eced-4acc-c8d1-3849" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false"/>
+        <categoryLink id="6e7b-9464-f2f7-b43a" name="Gretchin" hidden="false" targetId="9154-0e71-6fa2-2234" primary="false"/>
+        <categoryLink id="5afb-38d5-3222-6f3a" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false"/>
+      </categoryLinks>
       <entryLinks>
         <entryLink id="b0dc-d2f5-b5f5-9078" name="Stikkbombs" hidden="false" collective="false" targetId="8fad-e5b9-1b41-ba1e" type="selectionEntry"/>
       </entryLinks>
@@ -2169,6 +2323,7 @@
         <entryLink id="c779-8098-2052-b4f5" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
         <entryLink id="4389-4ac2-4b31-bd99" name="Stikkbombs" hidden="false" collective="false" targetId="8fad-e5b9-1b41-ba1e" type="selectionEntry"/>
         <entryLink id="0ae0-cd7d-65fa-9fe2" name="Meganob Weapons" hidden="false" collective="false" targetId="f641-5067-0391-08d5" type="selectionEntryGroup"/>
+        <entryLink id="6da8-8436-c8ca-999f" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="37.0"/>
@@ -2221,6 +2376,7 @@
       <entryLinks>
         <entryLink id="7e34-fde3-3cf5-04cd" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
         <entryLink id="cf1b-c247-63e2-8e9a" name="Meganob Weapons" hidden="false" collective="false" targetId="f641-5067-0391-08d5" type="selectionEntryGroup"/>
+        <entryLink id="efc9-27f4-d3a3-ef28" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="41.0"/>
@@ -2256,10 +2412,10 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7bfc-974b-f21b-20ba" name="Faction: Orks" hidden="false" targetId="3630-39cf-f986-6209" primary="false"/>
-        <categoryLink id="1aab-be8a-ff09-5550" name="Freebootaz" hidden="false" targetId="6acc-147c-e2fa-e19c" primary="false"/>
         <categoryLink id="aac5-4a9b-c8c8-658c" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false"/>
         <categoryLink id="8e65-16e3-0216-c4ac" name="Flash Git" hidden="false" targetId="4185-c106-c40f-d41c" primary="false"/>
         <categoryLink id="9d61-5ed4-81cd-3bea" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false"/>
+        <categoryLink id="b9c6-9f8b-5447-be20" name="Freebooterz" hidden="false" targetId="300e-b879-4e40-9c9d" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="755c-160b-3b1a-986a" name="Specialism" hidden="false" collective="false" targetId="f283-dca5-da62-3f8a" type="selectionEntryGroup"/>
@@ -2323,6 +2479,7 @@
         <entryLink id="23b3-3dad-dee4-5938" name="Gitfinda Squig" hidden="false" collective="false" targetId="5555-14bf-47cd-f0f2" type="selectionEntry"/>
         <entryLink id="902e-6bbf-aeea-3393" name="Choppa" hidden="false" collective="false" targetId="bff6-ef1d-1635-a0dc" type="selectionEntry"/>
         <entryLink id="5921-1a88-8500-11f8" name="Slugga" hidden="false" collective="false" targetId="03d5-f89c-c9ad-e706" type="selectionEntry"/>
+        <entryLink id="f494-619b-c826-0911" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="24.0"/>
@@ -2537,6 +2694,7 @@
       <entryLinks>
         <entryLink id="6f89-b7d2-039c-8655" name="Stikkbombs" hidden="false" collective="false" targetId="8fad-e5b9-1b41-ba1e" type="selectionEntry"/>
         <entryLink id="0f28-1a69-808a-4aea" name="Legendary Hunter - Level 3" hidden="false" collective="false" targetId="7da4-b687-c93e-28d0" type="selectionEntry"/>
+        <entryLink id="7615-041f-025e-0db1" name="Clan" hidden="false" collective="false" targetId="842a-673e-f031-5ad9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="82.0"/>
@@ -2770,83 +2928,69 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="842a-673e-f031-5ad9" name="Clan Kulturs" hidden="false" collective="false" defaultSelectionEntryId="5ece-d436-23c2-ba85">
+    <selectionEntryGroup id="842a-673e-f031-5ad9" name="Clan" hidden="false" collective="false" defaultSelectionEntryId="5ece-d436-23c2-ba85">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf82-c1f3-736c-5e14" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad5f-48c5-7460-50d2" type="min"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="6b20-7a02-1b19-1807" name="Goffs" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="af56-55d2-42db-c811" name="No Muckin&apos; About" hidden="false">
-              <description>Each time you make an unmodified hit roll of 6 for an attack with a melee weapon made by a model in your kill team, immediately make an additional hit roll against the same target with the same weapon. These additional hit rolls cannot themselves generate any further hit rolls.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="1541-c792-8991-7347" name="Goffs" hidden="false" targetId="80b1-ca7a-5d59-05cd" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c942-7b53-5ff0-3be8" name="Bad Moons" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="54b8-1657-6f5c-3357" name="Armed to Da Teef" hidden="false">
-              <description>Re-roll hit rolls of 1 for attacks made by models in your kill team in the Shooting phase.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="9b8c-4405-6074-31d6" name="Bad Moons" hidden="false" targetId="d799-b522-8c0e-a310" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a92a-194b-65fe-74a9" name="Evil Sunz" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="78aa-3718-dbd0-1db3" name="Red Ones Go Fasta" hidden="false">
-              <description>Add 1 to the Move characteristic of models in your kill team and add 1 to Advance and charge rolls made for them. In addition, these models do not suffer the penalty to their hit rolls for shooting Assault weapons during a battle round in which they Advanced.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="4fa2-e3ce-6896-6899" name="Evil Sunz" hidden="false" targetId="3e63-d2ff-7faa-478a" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0cca-07f3-c92c-4b1b" name="Deathskulls" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="db97-fb51-4b26-d9b8" name="Lucky Blue Gitz" hidden="false">
-              <description>Models in your kill team have a 6+ invulnerable save, unless they already have an invulnerable save. In addition, you can re-roll a single failed hit roll and a single failed wound roll in each phase, as long as the attack was made by a model in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="13bf-d64c-48f4-f2b4" name="Deathskulls" hidden="false" targetId="cfdd-a5d1-2225-b8ef" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0c5d-28b0-4abc-1798" name="Snakebites" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="304d-08c3-e5eb-d73d" name="Da Old Ways" hidden="false">
-              <description>Roll a dice each time a model in your kill team loses a wound. On a 6 the would is not lost. If a model already has a similar ability, choose which effect applies, and re-roll 1s when making these rolls.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="7b23-a0b4-c7a7-b8db" name="Snakebites" hidden="false" targetId="0914-2a26-a686-8798" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8769-60bf-f58a-db36" name="Blood Axes" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="93fb-b6ba-cdbd-b7f6" name="Taktiks" hidden="false">
-              <description>Models in your kill team are considered to be obscured to enemy models that target them if they are more than 12&quot; away from those models. In addition, models in your kill team can shoot even if they Fell Back in the same battle round.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="89db-c7ad-6c5c-1b40" name="Blood Axes" hidden="false" targetId="49c9-c9af-e1ad-6f2b" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ff08-0821-e4e0-783e" name="Freebooterz" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="3c79-fe8a-dc55-cbd0" name="Competitive Streak" hidden="false">
-              <description>Add 1 to hit rolls for attacks made by models in your kill team for each other model in your kill team that has taken an enemy model out of action with an attack in this phase.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="4d95-e749-db6b-eb21" name="Freebooterz" hidden="false" targetId="300e-b879-4e40-9c9d" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="5ece-d436-23c2-ba85" name="*No Kultur*" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="5ece-d436-23c2-ba85" name="*No Clan*" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>

--- a/Space Marines.cat
+++ b/Space Marines.cat
@@ -45,6 +45,7 @@
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -68,6 +69,7 @@
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7df-60bf-379d-8847" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -91,6 +93,7 @@
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -114,6 +117,7 @@
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd3b-adcc-8bc3-c31d" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -137,6 +141,7 @@
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -160,6 +165,7 @@
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc4e-633e-b7e7-91fc" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -183,6 +189,7 @@
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def9-9207-76e0-fefd" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -206,6 +213,7 @@
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ea9-3cbd-e934-0180" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -229,6 +237,7 @@
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -252,6 +261,7 @@
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>

--- a/Space Marines.cat
+++ b/Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="fce0-30e5-a4fc-8736" name="Space Marines" revision="9" battleScribeVersion="2.02" library="true" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="25" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="fce0-30e5-a4fc-8736" name="Space Marines" revision="10" battleScribeVersion="2.02" library="true" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="25" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="6c15-6156-5ba7-10f3" name="Special Issue Ammunition">
       <characteristicTypes>
@@ -17,23 +17,250 @@
     <categoryEntry id="a3fb-18f1-f728-dc5d" name="Vanguard Veteran" hidden="false"/>
     <categoryEntry id="7daa-feba-8317-5773" name="Company Veteran" hidden="false"/>
     <categoryEntry id="8828-0395-080e-7e88" name="Jump Pack" hidden="false"/>
+    <categoryEntry id="76f6-42a4-c0d7-01a1" name="Black Templars" hidden="false"/>
+    <categoryEntry id="f7df-60bf-379d-8847" name="Blood Angels" hidden="false"/>
+    <categoryEntry id="6dc1-298a-5459-4a25" name="Dark Angels" hidden="false"/>
+    <categoryEntry id="dd3b-adcc-8bc3-c31d" name="Imperial Fists" hidden="false"/>
+    <categoryEntry id="757f-382d-12cf-0f49" name="Iron Hands" hidden="false"/>
+    <categoryEntry id="dc4e-633e-b7e7-91fc" name="Raven Guard" hidden="false"/>
+    <categoryEntry id="def9-9207-76e0-fefd" name="Salamanders" hidden="false"/>
+    <categoryEntry id="2ea9-3cbd-e934-0180" name="Space Wolves" hidden="false"/>
+    <categoryEntry id="db00-918b-4bd1-9446" name="Ultramarines" hidden="false"/>
+    <categoryEntry id="3b17-281f-ac2d-0410" name="White Scars" hidden="false"/>
   </categoryEntries>
+  <rules>
+    <rule id="b9d3-f144-2eae-fe1b" name="Righteous Zeal" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7df-60bf-379d-8847" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd3b-adcc-8bc3-c31d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc4e-633e-b7e7-91fc" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def9-9207-76e0-fefd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ea9-3cbd-e934-0180" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll charge rolls for models in your kill team.</description>
+    </rule>
+    <rule id="a79d-77b9-671b-cca9" name="The Red Thirst" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd3b-adcc-8bc3-c31d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc4e-633e-b7e7-91fc" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def9-9207-76e0-fefd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ea9-3cbd-e934-0180" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>In any battle round in which a model from your kill team charged, was charged or made a pile-in move granted by the Heroic Intervention Commander Tactic, add 1 to wound rolls for attacks made by that model in the Fight phase.</description>
+    </rule>
+    <rule id="044a-445b-9846-45bf" name="Grim Resolve" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7df-60bf-379d-8847" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd3b-adcc-8bc3-c31d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc4e-633e-b7e7-91fc" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def9-9207-76e0-fefd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ea9-3cbd-e934-0180" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll hit rolls of 1 for shooting attacks made by models in your kill team (including when firing Overwatch) that have not moved in this battle round. In addition, you can re-roll the dice to determine whether or not your team is broken in the Morale phase.</description>
+    </rule>
+    <rule id="1e89-4789-866e-5d34" name="Siege Masters" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7df-60bf-379d-8847" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc4e-633e-b7e7-91fc" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def9-9207-76e0-fefd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ea9-3cbd-e934-0180" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team do not suffer the penalty to Injury rolls for the target of their attacks being obscured and within 1&quot; of a model or piece of terrain that is between the two models.</description>
+    </rule>
+    <rule id="1b7b-2d08-5bdf-ff9d" name="The Flesh is Weak" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7df-60bf-379d-8847" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd3b-adcc-8bc3-c31d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc4e-633e-b7e7-91fc" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def9-9207-76e0-fefd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ea9-3cbd-e934-0180" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Roll a dice each time a model in your kill team loses a wound. On a 6, the damage is ignored and the model does not lose a wound. If a model already has a similar ability, choose which effect applies, and re-roll 1s when making these rolls.</description>
+    </rule>
+    <rule id="023b-b1a1-9e6d-c407" name="Shadow Masters" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7df-60bf-379d-8847" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd3b-adcc-8bc3-c31d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def9-9207-76e0-fefd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ea9-3cbd-e934-0180" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team are considered to be obscured to enemy models that target them if they are more than 12&quot; away from those models.</description>
+    </rule>
+    <rule id="b317-a031-f868-9561" name="Master Artisans" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7df-60bf-379d-8847" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd3b-adcc-8bc3-c31d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc4e-633e-b7e7-91fc" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ea9-3cbd-e934-0180" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll a single hit roll and a single wound roll in each phase, as long as the attack was made by a model in your kill team.</description>
+    </rule>
+    <rule id="c441-6931-289c-e3ff" name="Hunters Unleashed" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7df-60bf-379d-8847" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd3b-adcc-8bc3-c31d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc4e-633e-b7e7-91fc" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def9-9207-76e0-fefd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>In any battle round in which a model from your kill team charged, was charged or made a pile-in move granted by the Heroic Intervention Commander Tactic, add 1 to hit rolls for attacks made by that model in the Fight phase. In addition, you can use the Heroic Intervention Commander Tactic if there are any enemy models within 6&quot; (rather than 3&quot;) of your Commander, and when you do so they can make a pile-in move of 6&quot;, rather than 3&quot;.</description>
+    </rule>
+    <rule id="9ec8-8736-4dbf-fde6" name="Codex Discipline" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7df-60bf-379d-8847" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd3b-adcc-8bc3-c31d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc4e-633e-b7e7-91fc" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def9-9207-76e0-fefd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ea9-3cbd-e934-0180" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b17-281f-ac2d-0410" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Add 1 to the Leadership characteristic of all models in your kill team. In addition, models in your kill team can still shoot in a battle round in which they Retreated or Fell Back, but if they do, a 6 is always required for a successful hit roll, irrespective of the firing model&apos;s Ballistic Skill or any modifiers.</description>
+    </rule>
+    <rule id="6a74-f31e-ff21-e2cd" name="Lightning Assault" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7df-60bf-379d-8847" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd3b-adcc-8bc3-c31d" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="757f-382d-12cf-0f49" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc4e-633e-b7e7-91fc" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def9-9207-76e0-fefd" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ea9-3cbd-e934-0180" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db00-918b-4bd1-9446" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76f6-42a4-c0d7-01a1" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When a model from your kill team Advances, add an additional 2&quot; to the distance it can move. In addition, if a model in your kill team started the Movement phase within 1&quot; of an enemy model, but when you pick it to move there are no enemy models within 1&quot;, that model can make a charge attempt instead of Falling Back or remaining stationary.</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
-    <selectionEntry id="a66e-3a62-2b0e-7d04" name="Chapter Tactics" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d000-3a97-555d-b8a7" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e49e-ef95-cd48-bb99" type="max"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="874f-b731-48ed-ea2c" name="Configuration" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="4663-024d-cf0b-c46a" name="Chapter Tactics" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="9bab-e586-46f1-a293" name="Lieutenant in Phobos Armour" hidden="false" collective="false" type="upgrade">
       <modifiers>
         <modifier type="set" field="33aa-bfda-db7d-8f1e" value="1">
@@ -154,6 +381,7 @@
           </constraints>
         </entryLink>
         <entryLink id="ebb2-0077-4527-7408" name="Frag and krak grenades" hidden="false" collective="false" targetId="c0eb-48a8-64a0-8635" type="selectionEntry"/>
+        <entryLink id="371a-a2d3-c669-6a50" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="51.0"/>
@@ -333,6 +561,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fe2-95d7-3fef-38c5" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="dc29-7825-eb55-41e0" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="81.0"/>
@@ -428,6 +657,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef8f-e98f-a15b-c426" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="b5c1-51c4-3618-55ad" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="91.0"/>
@@ -564,6 +794,7 @@
           </constraints>
         </entryLink>
         <entryLink id="25ba-4ff1-d954-84dc" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="ef65-d854-c76e-c48a" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="88.0"/>
@@ -828,6 +1059,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="24bf-e5b3-7a87-9afe" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="b8c6-b517-ed23-632a" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="74.0"/>
@@ -983,6 +1215,7 @@
           </constraints>
         </entryLink>
         <entryLink id="04bf-fad3-441a-7791" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="4daf-9794-e481-d9f4" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="80.0"/>
@@ -1198,6 +1431,7 @@
           </constraints>
         </entryLink>
         <entryLink id="4052-d7e2-35c7-80b4" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="7bac-53b8-cbaf-2454" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="17.0"/>
@@ -1286,6 +1520,7 @@
           </constraints>
         </entryLink>
         <entryLink id="3157-46d1-1e4f-583b" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="f481-242c-b95d-62b6" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="18.0"/>
@@ -1357,6 +1592,7 @@
           </constraints>
         </entryLink>
         <entryLink id="11f8-5de7-d545-becc" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="eca1-a891-e98f-925f" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="18.0"/>
@@ -1416,6 +1652,7 @@
           </constraints>
         </entryLink>
         <entryLink id="b2ff-f5b4-194e-0bc4" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="7389-d0a5-de15-acda" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="29.0"/>
@@ -1504,6 +1741,7 @@
           </constraints>
         </entryLink>
         <entryLink id="7f09-3340-3ef6-99d5" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="7790-4bb6-2e6c-b746" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="30.0"/>
@@ -1562,6 +1800,7 @@
           </constraints>
         </entryLink>
         <entryLink id="c7c5-e981-3b11-1534" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="dd1a-67cf-e819-d8b1" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="18.0"/>
@@ -1674,6 +1913,7 @@
           </constraints>
         </entryLink>
         <entryLink id="2e93-714b-c616-7d65" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="4c36-2dae-35ef-149c" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="19.0"/>
@@ -1797,6 +2037,7 @@
           </constraints>
         </entryLink>
         <entryLink id="34a5-9b4d-14fe-2669" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="2d98-ab0d-3de8-d754" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="25.0"/>
@@ -1931,6 +2172,7 @@
           </constraints>
         </entryLink>
         <entryLink id="6f75-e787-b06d-7bda" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="585e-af6c-3ca5-1ffd" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="27.0"/>
@@ -2048,6 +2290,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e17-f769-1fb5-d989" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="defc-8bee-dacd-5c13" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="26.0"/>
@@ -2198,6 +2441,7 @@
         <categoryLink id="f22f-4a65-4c9f-8359" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false"/>
         <categoryLink id="783f-7e7b-c272-76c1" name="Terminator" hidden="false" targetId="1ec0-dd6e-9680-2288" primary="false"/>
         <categoryLink id="e417-bc74-f390-8e39" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false"/>
+        <categoryLink id="a537-5331-fa92-448e" name="Space Wolves" hidden="false" targetId="2ea9-3cbd-e934-0180" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="4e0e-6efa-b752-903f" name="Terminator weapons" hidden="false" collective="false" targetId="4572-8411-5f7e-7aee" type="selectionEntryGroup">
@@ -2266,6 +2510,7 @@
         <categoryLink id="0b6c-6ddd-35cf-a50f" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false"/>
         <categoryLink id="518d-eab3-56b5-5ac7" name="Terminator" hidden="false" targetId="1ec0-dd6e-9680-2288" primary="false"/>
         <categoryLink id="ff7c-bc5c-aa5e-72b6" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false"/>
+        <categoryLink id="18c4-d4ae-0f9e-fcc4" name="Space Wolves" hidden="false" targetId="2ea9-3cbd-e934-0180" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="d7c3-0d08-face-4fe1" name="Terminator weapons" hidden="false" collective="false" targetId="4572-8411-5f7e-7aee" type="selectionEntryGroup">
@@ -2339,6 +2584,7 @@
         <categoryLink id="5afa-df1e-0061-3977" name="Infantry" hidden="false" targetId="96c1-32dc-d9dc-4678" primary="false"/>
         <categoryLink id="6542-36ff-34ea-de22" name="Terminator" hidden="false" targetId="1ec0-dd6e-9680-2288" primary="false"/>
         <categoryLink id="b209-11b4-77bb-e6be" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false"/>
+        <categoryLink id="3d4d-6c1c-3962-fe4b" name="Space Wolves" hidden="false" targetId="2ea9-3cbd-e934-0180" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="d397-c912-e6a7-0bc8" name="Terminator weapons" hidden="false" collective="false" targetId="4572-8411-5f7e-7aee" type="selectionEntryGroup">
@@ -2433,6 +2679,7 @@
           </constraints>
         </entryLink>
         <entryLink id="e400-757b-91ba-9754" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="1d09-f1b0-caec-5ff6" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="13.0"/>
@@ -2821,6 +3068,7 @@
           </constraints>
         </entryLink>
         <entryLink id="a17f-fd97-5a4e-49f9" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="cd29-26e0-44ca-290d" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="14.0"/>
@@ -2933,6 +3181,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0441-9970-164a-5ed6" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="d018-7d36-6c9e-1f64" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="14.0"/>
@@ -3029,6 +3278,7 @@
           </constraints>
         </entryLink>
         <entryLink id="58ad-38dc-b480-edd2" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="37c7-4fee-73ed-1c55" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="13.0"/>
@@ -3129,6 +3379,7 @@
           </constraints>
         </entryLink>
         <entryLink id="8baf-daab-51df-6d91" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="e64f-37f6-490c-ada1" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="14.0"/>
@@ -3284,6 +3535,7 @@
         </entryLink>
         <entryLink id="6bc9-b62b-1ef8-589b" name="Frag and krak grenades" hidden="false" collective="false" targetId="c0eb-48a8-64a0-8635" type="selectionEntry"/>
         <entryLink id="effc-c0e9-ffa5-114c" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="26e7-947c-85c1-9110" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="13.0"/>
@@ -3443,6 +3695,7 @@
         </entryLink>
         <entryLink id="493d-8116-0160-f8a9" name="Frag and krak grenades" hidden="false" collective="false" targetId="c0eb-48a8-64a0-8635" type="selectionEntry"/>
         <entryLink id="2397-76fe-d233-5303" name="Specialism" hidden="false" collective="false" targetId="ba29-ffa4-b77c-6b17" type="selectionEntryGroup"/>
+        <entryLink id="f154-e677-3406-4324" name="Chapter" hidden="false" collective="false" targetId="72dc-01ba-36f1-563f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="14.0"/>
@@ -3450,113 +3703,106 @@
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="72dc-01ba-36f1-563f" name="Chapter Tactics" hidden="false" collective="false" defaultSelectionEntryId="77cd-3383-52b2-a4e3">
+    <selectionEntryGroup id="72dc-01ba-36f1-563f" name="Chapter" hidden="false" collective="false" defaultSelectionEntryId="77cd-3383-52b2-a4e3">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39d2-5428-8d48-d189" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="728f-3b5a-0a6c-5cad" type="min"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="77cd-3383-52b2-a4e3" name="*No Chapter Tactics*" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="77cd-3383-52b2-a4e3" name="*No Chapter*" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="170b-c261-fa08-eb51" name="Dark Angels" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="ee12-db22-ac5c-0eaa" name="Grim Resolve" hidden="false">
-              <description>You can re-roll hit rolls of 1 for shooting attacks made by models in your kill team (including when firing Overwatch) that have not moved in this battle round. In addition, you can re-roll the dice to determine whether or not your team is broken in the Morale phase.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="7a16-2c56-dc6d-a207" name="Dark Angels" hidden="false" targetId="6dc1-298a-5459-4a25" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7aa6-52de-a233-fb98" name="White Scars" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="93ac-ad36-7c51-7efd" name="Lightning Assault" hidden="false">
-              <description>When a model from your kill team Advances, add an additional 2&quot; to the distance it can move. In addition, if a model in your kill team started the Movement phase within 1&quot; of an enemy model, but when you pick it to move there are no enemy models within 1&quot;, that model can make a charge attempt instead of Falling Back or remaining stationary.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="64fd-5498-ed75-2ce9" name="White Scars" hidden="false" targetId="3b17-281f-ac2d-0410" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e9e9-67e7-3016-380a" name="Space Wolves" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="5bf6-2353-e0fa-5f8d" name="Hunters Unleashed" hidden="false">
-              <description>In any battle round in which a model from your kill team charged, was charged or made a pile-in move granted by the Heroic Intervention Commander Tactic, add 1 to hit rolls for attacks made by that model in the Fight phase. In addition, you can use the Heroic Intervention Commander Tactic if there are any enemy models within 6&quot; (rather than 3&quot;) of your Commander, and when you do so they can make a pile-in move of 6&quot;, rather than 3&quot;.</description>
-            </rule>
-          </rules>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ca38-d54c-3ff9-5c1c" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8adc-9d8c-0bf8-6bc3" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4c64-f195-7269-1fff" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <categoryLinks>
+            <categoryLink id="83e8-c7fc-b0f9-e8f5" name="Space Wolves" hidden="false" targetId="2ea9-3cbd-e934-0180" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6c73-30e4-a816-c07f" name="Imperial Fists" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="d0f9-7f0e-9441-b91a" name="Siege Masters" hidden="false">
-              <description>Models in your kill team do not suffer the penalty to Injury rolls for the target of their attacks being obscured and within 1&quot; of a model or piece of terrain that is between the two models.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="b6da-984f-bf56-fa36" name="Imperial Fists" hidden="false" targetId="dd3b-adcc-8bc3-c31d" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="feb8-7a4d-22a1-7613" name="Blood Angels" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="9134-be44-fa2a-f493" name="The Red Thirst" hidden="false">
-              <description>In any battle round in which a model from your kill team charged, was charged or made a pile-in move granted by the Heroic Intervention Commander Tactic, add 1 to wound rolls for attacks made by that model in the Fight phase.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="5d0d-84c6-9352-bc58" name="Blood Angels" hidden="false" targetId="f7df-60bf-379d-8847" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3548-8c20-5040-9cd5" name="Iron Hands" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="8c9b-0d12-50a0-d3dd" name="The Flesh is Weak" hidden="false">
-              <description>Roll a dice each time a model in your kill team loses a wound. On a 6, the damage is ignored and the model does not lose a wound. If a model already has a similar ability, choose which effect applies, and re-roll 1s when making these rolls.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="0f49-32e3-27b3-b795" name="Iron Hands" hidden="false" targetId="757f-382d-12cf-0f49" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cfbb-3f48-decd-e938" name="Salamanders" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="c01c-2dd9-da6c-8a3c" name="Master Artisans" hidden="false">
-              <description>You can re-roll a single hit roll and a single wound roll in each phase, as long as the attack was made by a model in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="4fbf-a5ae-8283-b9c6" name="Salamanders" hidden="false" targetId="def9-9207-76e0-fefd" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f832-a06d-b522-e093" name="Ultramarines" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="644c-6aa9-0f6b-94fe" name="Codex Discipline" hidden="false">
-              <description>Add 1 to the Leadership characteristic of all models in your kill team. In addition, models in your kill team can still shoot in a battle round in which they Retreated or Fell Back, but if they do, a 6 is always required for a successful hit roll, irrespective of the firing model&apos;s Ballistic Skill or any modifiers.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="fbbd-b73f-4a61-d58e" name="Ultramarines" hidden="false" targetId="db00-918b-4bd1-9446" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cbb7-95a9-5d3b-9ab2" name="Raven Guard" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="c47d-b334-5ab5-522f" name="Shadow Masters" hidden="false">
-              <description>Models in your kill team are considered to be obscured to enemy models that target them if they are more than 12&quot; away from those models.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="c932-082e-d623-c11d" name="Raven Guard" hidden="false" targetId="dc4e-633e-b7e7-91fc" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3def-337a-a7ba-c60d" name="Black Templars" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="5c4c-c6c6-f664-6f32" name="Black Templars" hidden="false">
-              <description>You can re-roll charge rolls for models in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="4f05-fa51-35b9-c7ff" name="Black Templars" hidden="false" targetId="76f6-42a4-c0d7-01a1" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
@@ -4228,14 +4474,9 @@
         <entryLink id="0f6d-05fd-7274-37b6" name="Plasma cannon" hidden="false" collective="false" targetId="3b90-f949-81c3-e0ae" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="170b-c261-fa08-eb51" type="equalTo"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77cd-3383-52b2-a4e3" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6dc1-298a-5459-4a25" type="equalTo"/>
+              </conditions>
             </modifier>
           </modifiers>
         </entryLink>

--- a/T'au Empire.cat
+++ b/T'au Empire.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7ac4-f90b-e0a6-ae72" name="T&apos;au Empire" revision="15" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7ac4-f90b-e0a6-ae72" name="T&apos;au Empire" revision="16" battleScribeVersion="2.02" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="580b-8df1-70dc-452b" name="Drone" hidden="false"/>
     <categoryEntry id="fd6f-ea1b-53af-11ab" name="Battlesuit" hidden="false"/>
@@ -10,6 +10,12 @@
     <categoryEntry id="138d-868c-de29-1351" name="DS8 Tactical Support Turret" hidden="false"/>
     <categoryEntry id="66f2-ed47-c749-e425" name="XV8 Crisis Battlesuit" hidden="false"/>
     <categoryEntry id="053c-2b80-e82e-db20" name="Darkstrider" hidden="false"/>
+    <categoryEntry id="c830-fd11-7cc5-b88b" name="Bork&apos;an Sept" hidden="false"/>
+    <categoryEntry id="00f6-59fc-8b40-ca1c" name="Dal&apos;yth Sept" hidden="false"/>
+    <categoryEntry id="739b-2a62-fe3c-f12f" name="Farsight Enclaves" hidden="false"/>
+    <categoryEntry id="68d1-4795-69e2-2300" name="Sa&apos;cea Sept" hidden="false"/>
+    <categoryEntry id="f4ce-9f2e-40d5-46bb" name="T&apos;au Sept" hidden="false"/>
+    <categoryEntry id="d2b1-0562-1a1a-fb68" name="Vior&apos;la Sept" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="4340-dab1-7330-f462" name="XV25 Stealth Battlesuit Shas&apos;ui" hidden="false" collective="false" targetId="7fa5-5063-e682-a11a" type="selectionEntry">
@@ -362,8 +368,129 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="52f9-c98a-e3ce-c039" name="Darkstrider" hidden="false" collective="false" targetId="e8e4-13b9-f87f-33b1" type="selectionEntry"/>
-    <entryLink id="db87-8905-3c21-61c9" name="Sept Tenet" hidden="false" collective="false" targetId="8d18-a2bc-34c6-408c" type="selectionEntry"/>
   </entryLinks>
+  <rules>
+    <rule id="38b4-5a35-39d0-dfc3" name="Superior Craftsmanship" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c830-fd11-7cc5-b88b" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00f6-59fc-8b40-ca1c" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="739b-2a62-fe3c-f12f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="68d1-4795-69e2-2300" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4ce-9f2e-40d5-46bb" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2b1-0562-1a1a-fb68" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ac0-ccb7-5170-d235" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team do not suffer the penalty to hit rolls for their attacks that target enemy models at long range.</description>
+    </rule>
+    <rule id="3570-5c27-79c1-8e1f" name="Adaptive Camouflage" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00f6-59fc-8b40-ca1c" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c830-fd11-7cc5-b88b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="739b-2a62-fe3c-f12f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="68d1-4795-69e2-2300" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4ce-9f2e-40d5-46bb" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2b1-0562-1a1a-fb68" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ac0-ccb7-5170-d235" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>If a model in your kill team does not move in the Movement phase, for the remainder of the battle round it is considered to be obscured to enemy models that target it.</description>
+    </rule>
+    <rule id="0446-c032-e2a4-2655" name="Devastating Counter-strike" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="739b-2a62-fe3c-f12f" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c830-fd11-7cc5-b88b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00f6-59fc-8b40-ca1c" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="68d1-4795-69e2-2300" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4ce-9f2e-40d5-46bb" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2b1-0562-1a1a-fb68" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ac0-ccb7-5170-d235" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Re-roll hit and wound rolls of 1 for shooting attacks made by models in your kill team that target an enemy model that is within 6&quot; of the firing model.</description>
+    </rule>
+    <rule id="5543-2652-4943-3dc0" name="Calm Discipline" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="68d1-4795-69e2-2300" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c830-fd11-7cc5-b88b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00f6-59fc-8b40-ca1c" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="739b-2a62-fe3c-f12f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4ce-9f2e-40d5-46bb" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2b1-0562-1a1a-fb68" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ac0-ccb7-5170-d235" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Add 1 to the Leadership characteristic of models in your kill team. In addition, you can re-roll hit rolls of 1 for shooting attacks made by models in your kill team.</description>
+    </rule>
+    <rule id="7d82-a3ba-8fc3-5b46" name="Coordinated Fire Arcs" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4ce-9f2e-40d5-46bb" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c830-fd11-7cc5-b88b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00f6-59fc-8b40-ca1c" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="739b-2a62-fe3c-f12f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="68d1-4795-69e2-2300" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2b1-0562-1a1a-fb68" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ac0-ccb7-5170-d235" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When a model in your kill team uses their For the Greater Good ability, or when they fire Overwatch whilst they are within 6&quot; of a friendly model, they successfully hit on a roll of 5 or 6.</description>
+    </rule>
+    <rule id="f4dc-04ab-b156-21d7" name="Strike Fast" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2b1-0562-1a1a-fb68" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c830-fd11-7cc5-b88b" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00f6-59fc-8b40-ca1c" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="739b-2a62-fe3c-f12f" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="68d1-4795-69e2-2300" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4ce-9f2e-40d5-46bb" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ac0-ccb7-5170-d235" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team can shoot Rapid Fire weapons as if they were Assault weapons in the Shooting phase of a battle round in which they Advanced (e.g. a Rapid Fire 1 weapon would be used as if it were an Assault 1 weapon). In addition, these models do not suffer the penalty to their hit rolls for shooting Assault weapons during a battle round in which they Advanced.</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
     <selectionEntry id="e5a8-5953-c927-081d" name="Fire Warrior Shas&apos;la" hidden="false" collective="false" type="model">
       <profiles>
@@ -420,6 +547,7 @@
             <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="f746-e3c2-5345-f429" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="fc67-38bd-8595-0bcd" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -486,6 +614,7 @@
         <entryLink id="cb6a-761d-26ac-0517" name="Photon grenade" hidden="false" collective="false" targetId="1f76-6a16-1e9d-e519" type="selectionEntry"/>
         <entryLink id="3258-9c93-e977-241c" name="Markerlight" hidden="false" collective="false" targetId="6038-3ed8-159d-da29" type="selectionEntry"/>
         <entryLink id="050b-928e-8985-ca1b" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
+        <entryLink id="d404-5f6f-f67c-fff0" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -576,6 +705,7 @@
           </constraints>
         </entryLink>
         <entryLink id="6fcf-1827-82cb-807d" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
+        <entryLink id="276f-ab4c-15c0-e8e6" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="6.0"/>
@@ -634,6 +764,7 @@
       <entryLinks>
         <entryLink id="a827-c22d-42e3-2e0a" name="Photon grenade" hidden="false" collective="false" targetId="1f76-6a16-1e9d-e519" type="selectionEntry"/>
         <entryLink id="ef62-4b7f-c511-707f" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
+        <entryLink id="54ec-4cbb-d113-fc7f" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
@@ -685,6 +816,7 @@
           </constraints>
         </entryLink>
         <entryLink id="bc8b-0f49-f8d2-ec2e" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
+        <entryLink id="877b-bbda-648b-64f2" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
@@ -738,6 +870,7 @@
           </constraints>
         </entryLink>
         <entryLink id="d1ce-cf6b-814b-39f0" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
+        <entryLink id="595f-c96e-bc11-32c0" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -803,6 +936,7 @@
         <entryLink id="baa6-e751-57ec-c6ff" name="Photon grenade" hidden="false" collective="false" targetId="1f76-6a16-1e9d-e519" type="selectionEntry"/>
         <entryLink id="93fb-8347-2bc9-9b80" name="Markerlight" hidden="false" collective="false" targetId="6038-3ed8-159d-da29" type="selectionEntry"/>
         <entryLink id="8b79-acbf-261a-29e8" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
+        <entryLink id="ff52-dfbd-48b0-0b5e" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="8.0"/>
@@ -842,6 +976,7 @@
       <entryLinks>
         <entryLink id="c50f-46b4-2145-0467" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
         <entryLink id="6569-8b18-ada1-cf36" name="XV25 Weapon" hidden="false" collective="false" targetId="95ea-1a6d-a402-7f86" type="selectionEntryGroup"/>
+        <entryLink id="cba0-609c-0b1a-a657" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="20.0"/>
@@ -892,6 +1027,7 @@
         <entryLink id="9da7-39af-7eee-3b48" name="Markerlight &amp; Target lock" hidden="false" collective="false" targetId="e93a-f5dc-7257-da20" type="selectionEntry"/>
         <entryLink id="42b6-e00f-897d-5af5" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
         <entryLink id="eb5e-9d50-6c26-7a49" name="XV25 Weapon" hidden="false" collective="false" targetId="95ea-1a6d-a402-7f86" type="selectionEntryGroup"/>
+        <entryLink id="5ac5-5fd0-4577-892a" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="20.0"/>
@@ -935,6 +1071,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fc0-ce9c-183b-90d6" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="5788-68a0-05cf-c198" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
@@ -987,6 +1124,9 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <entryLinks>
+        <entryLink id="d7dd-ce67-9ea5-a6ba" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
       </costs>
@@ -1030,6 +1170,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6c7-00b0-4f63-42a9" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="8dc7-5592-9d5b-10c5" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
@@ -1042,7 +1183,7 @@
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c0f7-c442-b695-bf07" type="atLeast"/>
           </conditions>
         </modifier>
-        <modifier type="increment" field="9e05-1722-0482-1c46" value="1">
+        <modifier type="increment" field="9e05-1722-0482-1c46" value="1.0">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
@@ -1096,6 +1237,9 @@
         <categoryLink id="15a7-9594-a32d-c193" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true"/>
         <categoryLink id="1909-70da-39d8-f96a" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="ae0b-a853-9b59-e783" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
       </costs>
@@ -1154,6 +1298,9 @@
         <categoryLink id="20dc-2a7c-f17f-bb3c" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true"/>
         <categoryLink id="4cb0-c901-f491-2c51" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="84be-ef35-a05f-13a2" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
       </costs>
@@ -1212,6 +1359,9 @@
         <categoryLink id="e297-1ac7-7000-5428" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true"/>
         <categoryLink id="a4e1-c1ee-52ab-7b7d" name="Model" hidden="false" targetId="50dd-a755-e02d-1c30" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="9ff1-fc2c-72d7-2c8c" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
       </costs>
@@ -1277,6 +1427,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7891-023e-ceea-6b89" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="c93d-bf13-3cc8-c242" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="7.0"/>
@@ -1667,6 +1818,7 @@
         </entryLink>
         <entryLink id="9699-1de5-de75-953b" name="Photon grenade" hidden="false" collective="false" targetId="1f76-6a16-1e9d-e519" type="selectionEntry"/>
         <entryLink id="e546-61c3-6b89-9168" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
+        <entryLink id="0e31-bf67-21b4-f8ec" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="23.0"/>
@@ -1805,6 +1957,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="6473-c162-bbdb-423b" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
+        <entryLink id="ca49-25c3-ac79-e411" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="18.0"/>
@@ -2124,6 +2277,7 @@
         <entryLink id="8f73-e562-a0d2-7c12" name="XV8 Wargear" hidden="false" collective="false" targetId="5ea6-4b62-937b-652a" type="selectionEntryGroup"/>
         <entryLink id="9d0f-c8cb-b5ca-7d02" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
         <entryLink id="6848-789b-b6ae-f7e3" name="XV8-02 Crisis Iridium Battlesuit" hidden="false" collective="false" targetId="adc9-e68c-54a2-bff8" type="selectionEntry"/>
+        <entryLink id="7b64-f54c-d1dc-235b" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="33.0"/>
@@ -2202,6 +2356,7 @@
         <entryLink id="d327-b224-3eff-3633" name="XV8 Wargear" hidden="false" collective="false" targetId="5ea6-4b62-937b-652a" type="selectionEntryGroup"/>
         <entryLink id="ef61-bba4-bb1b-a20a" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
         <entryLink id="63f1-237e-3042-af60" name="XV8-02 Crisis Iridium Battlesuit" hidden="false" collective="false" targetId="adc9-e68c-54a2-bff8" type="selectionEntry"/>
+        <entryLink id="f4c6-c9f9-c96d-2f54" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="32.0"/>
@@ -2269,6 +2424,7 @@
       <entryLinks>
         <entryLink id="0b99-c92b-22cd-8938" name="Specialism" hidden="false" collective="false" targetId="a33d-4f89-1be1-c88b" type="selectionEntryGroup"/>
         <entryLink id="8ea9-c317-1c12-d567" name="XV85 Wargear" hidden="false" collective="false" targetId="6ab7-73ce-a8d5-d4fa" type="selectionEntryGroup"/>
+        <entryLink id="edce-44ef-e092-4679" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="62.0"/>
@@ -2367,24 +2523,10 @@
           </constraints>
         </entryLink>
         <entryLink id="a7ee-69ca-1136-56a5" name="Photon grenade" hidden="false" collective="false" targetId="1f76-6a16-1e9d-e519" type="selectionEntry"/>
+        <entryLink id="eed7-da98-b76b-32e4" name="Sept" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="39.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8d18-a2bc-34c6-408c" name="Sept Tenet" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0b7f-2600-a082-0398" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0269-db51-27a1-dc1e" type="max"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="eed0-808b-cba1-d624" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="4a92-c8ef-b234-59d8" name="Sept Tenets" hidden="false" collective="false" targetId="b174-5a4a-deb1-047f" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -2873,73 +3015,61 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="b174-5a4a-deb1-047f" name="Sept Tenet" hidden="false" collective="false" defaultSelectionEntryId="0ac0-ccb7-5170-d235">
+    <selectionEntryGroup id="b174-5a4a-deb1-047f" name="Sept" hidden="false" collective="false" defaultSelectionEntryId="0ac0-ccb7-5170-d235">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e6a-863c-9c69-af0f" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ac6-7f82-c44b-9f8c" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="0ac0-ccb7-5170-d235" name="*No Tenet*" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0ac0-ccb7-5170-d235" name="*No Sept*" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e84c-9fed-66bc-9668" name="T&apos;au Sept" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="d22d-dc28-4520-1c5d" name="Coordinated Fire Arcs" hidden="false">
-              <description>When a model in your kill team uses their For the Greater Good ability, or when they fire Overwatch whilst they are within 6&quot; of a friendly model, they successfully hit on a roll of 5 or 6.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="629d-afa9-07b7-30a4" name="T&apos;au Sept" hidden="false" targetId="f4ce-9f2e-40d5-46bb" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5508-bc7b-236a-1e3a" name="Vior&apos;la Sept" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="7081-26cf-463a-7f32" name="Strike Fast" hidden="false">
-              <description>Models in your kill team can shoot Rapid Fire weapons as if they were Assault weapons in the Shooting phase of a battle round in which they Advanced (e.g. a Rapid Fire 1 weapon would be used as if it were an Assault 1 weapon). In addition, these models do not suffer the penalty to their hit rolls for shooting Assault weapons during a battle round in which they Advanced.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="e277-1520-452c-5124" name="Vior&apos;la Sept" hidden="false" targetId="d2b1-0562-1a1a-fb68" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ea5c-4ebe-4b62-502f" name="Bork&apos;an Sept" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="6d38-401a-5a86-12ba" name="Superior Craftsmanship" hidden="false">
-              <description>Models in your kill team do not suffer the penalty to hit rolls for their attacks that target enemy models at long range.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="eac9-1f0f-3187-54e0" name="Bork&apos;an Sept" hidden="false" targetId="c830-fd11-7cc5-b88b" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f1dc-acba-cd3d-bae7" name="Dal&apos;yth Sept" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="b956-ef90-9f27-dc82" name="Adaptive Camouflage" hidden="false">
-              <description>If a model in your kill team does not move in the Movement phase, for the remainder of the battle round it is considered to be obscured to enemy models that target it.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="912e-16ed-72ef-de53" name="Dal&apos;yth Sept" hidden="false" targetId="00f6-59fc-8b40-ca1c" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4632-f834-c51a-e265" name="Sa&apos;cea Sept" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="f0c6-868c-04d5-103e" name="Calm Discipline" hidden="false">
-              <description>Add 1 to the Leadership characteristic of models in your kill team. In addition, you can re-roll hit rolls of 1 for shooting attacks made by models in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="41a7-7db3-7380-9378" name="Sa&apos;cea Sept" hidden="false" targetId="68d1-4795-69e2-2300" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ef73-364e-5834-e9a8" name="Farsight Enclaves" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="54e6-89b7-0f16-5b99" name="Devastating Counter-strike" hidden="false">
-              <description>Re-roll hit and wound rolls of 1 for shooting attacks made by models in your kill team that target an enemy model that is within 6&quot; of the firing model.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="d4f4-41be-524e-6f55" name="Farsight Enclaves" hidden="false" targetId="739b-2a62-fe3c-f12f" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>

--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a8de-fa3a-9163-0c20" name="Tyranids" revision="9" battleScribeVersion="2.02" authorName="GenWilhelm" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a8de-fa3a-9163-0c20" name="Tyranids" revision="10" battleScribeVersion="2.02" authorName="GenWilhelm" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="a8de-fa3a-pubN66768" name="Core Manual"/>
     <publication id="a8de-fa3a-pubN71688" name="Commanders"/>
@@ -15,6 +15,13 @@
     <categoryEntry id="c707-511f-6e84-ecd1" name="Tyrant Guard" hidden="false"/>
     <categoryEntry id="139e-01f2-210e-b274" name="Hive Guard" hidden="false"/>
     <categoryEntry id="d87d-fb2f-78f8-8447" name="Ravener" hidden="false"/>
+    <categoryEntry id="bca2-6c3a-92b2-8ccf" name="Behemoth" hidden="false"/>
+    <categoryEntry id="c85d-39c3-27f6-f9df" name="Gorgon" hidden="false"/>
+    <categoryEntry id="bbf6-926b-e887-1650" name="Hydra" hidden="false"/>
+    <categoryEntry id="6b1f-79a4-c2d4-d507" name="Jormungandr" hidden="false"/>
+    <categoryEntry id="9b63-9b67-13f1-07a8" name="Kraken" hidden="false"/>
+    <categoryEntry id="e154-46b6-c5d3-c972" name="Kronos" hidden="false"/>
+    <categoryEntry id="3c51-799a-5820-1b29" name="Leviathan" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="f581-051a-81e1-f3c4" name="Termagant" hidden="false" collective="false" targetId="cf37-0d24-cf30-6e28" type="selectionEntry">
@@ -301,8 +308,156 @@
         <categoryLink id="e7f2-5834-05da-d3dc" name="New CategoryLink" hidden="false" targetId="79c6-76fc-47ee-c005" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a804-7bce-4d6a-1de6" name="Hive Fleet Adaptation" hidden="false" collective="false" targetId="84b2-566b-2160-2f01" type="selectionEntry"/>
   </entryLinks>
+  <rules>
+    <rule id="a26c-dc4c-48f0-e5f3" name="Hyper-aggression" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bca2-6c3a-92b2-8ccf" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c85d-39c3-27f6-f9df" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbf6-926b-e887-1650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b1f-79a4-c2d4-d507" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b63-9b67-13f1-07a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e154-46b6-c5d3-c972" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c51-799a-5820-1b29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b0e2-0a55-9394-7dce" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll charge rolls for models in your kill team.</description>
+    </rule>
+    <rule id="5c06-9bf5-340e-fcea" name="Adaptive Toxins" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c85d-39c3-27f6-f9df" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bca2-6c3a-92b2-8ccf" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbf6-926b-e887-1650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b1f-79a4-c2d4-d507" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b63-9b67-13f1-07a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e154-46b6-c5d3-c972" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c51-799a-5820-1b29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b0e2-0a55-9394-7dce" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll wound rolls for 1 in the Fight phase for attacks made by models in your kill team.</description>
+    </rule>
+    <rule id="0448-d3fe-ba1b-bd1e" name="Swarming Instincts" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbf6-926b-e887-1650" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bca2-6c3a-92b2-8ccf" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c85d-39c3-27f6-f9df" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b1f-79a4-c2d4-d507" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b63-9b67-13f1-07a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e154-46b6-c5d3-c972" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c51-799a-5820-1b29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b0e2-0a55-9394-7dce" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>You can re-roll hit rolls in the Fight phase for attacks made by models in your kill team that target an enemy that is within 1&quot; of another model from your kill team.</description>
+    </rule>
+    <rule id="1776-351f-ef40-8e35" name="Tunnel Networks" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b1f-79a4-c2d4-d507" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bca2-6c3a-92b2-8ccf" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c85d-39c3-27f6-f9df" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbf6-926b-e887-1650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b63-9b67-13f1-07a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e154-46b6-c5d3-c972" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c51-799a-5820-1b29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b0e2-0a55-9394-7dce" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Models in your kill team (other than models that can FLY) are considered to be obscured to enemy models that target them. If the model Advances or charges, however, it loses this benefit until the end of the battle round.</description>
+    </rule>
+    <rule id="9c02-2cc0-ef0e-c2e6" name="Questing Tendrils" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b63-9b67-13f1-07a8" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bca2-6c3a-92b2-8ccf" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c85d-39c3-27f6-f9df" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbf6-926b-e887-1650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b1f-79a4-c2d4-d507" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e154-46b6-c5d3-c972" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c51-799a-5820-1b29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b0e2-0a55-9394-7dce" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>When a model from your kill team Advances, roll three D6 instead of one and pick the highest roll to add to the Move characteristic of that model for that Movement phase. In addition, if a model from your kill team started the Movement phase within 1&quot; of an enemy model, but when you pick it to move there are no enemy models within 1&quot;, that model can make a charge attempt instead of Falling Back or remaining stationary.</description>
+    </rule>
+    <rule id="0294-2de4-8ad3-89b5" name="Bio-barrage" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e154-46b6-c5d3-c972" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bca2-6c3a-92b2-8ccf" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c85d-39c3-27f6-f9df" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbf6-926b-e887-1650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b1f-79a4-c2d4-d507" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b63-9b67-13f1-07a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c51-799a-5820-1b29" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b0e2-0a55-9394-7dce" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Re-roll unmodified hit rolls of 1 in the Shooting phase for models in your kill team if they have not moved in this battle round.</description>
+    </rule>
+    <rule id="da94-cbb1-5537-2c1f" name="Synaptic Imperative" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c51-799a-5820-1b29" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bca2-6c3a-92b2-8ccf" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c85d-39c3-27f6-f9df" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbf6-926b-e887-1650" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b1f-79a4-c2d4-d507" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b63-9b67-13f1-07a8" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e154-46b6-c5d3-c972" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b0e2-0a55-9394-7dce" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <description>Roll a D6 each time a model in your kill team loses a wound whilst it is within 6&quot; of a friendly SYNAPSE model. On a 6, the damage is ignored and the model does not lose a wound. In addition, models in your kill team that are within 6&quot; of a friendly SYNAPSE model do not suffer the penalty to their hit rolls from one flesh wound they have suffered.</description>
+    </rule>
+  </rules>
   <sharedSelectionEntries>
     <selectionEntry id="1648-632a-e780-49a5" name="Barbed strangler" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -364,6 +519,7 @@
         <entryLink id="92e0-aa07-ff59-166b" name="Adrenal Glands" hidden="false" collective="false" targetId="e0c1-3064-250d-2497" type="selectionEntry"/>
         <entryLink id="51ee-7baa-dc5b-1d29" name="Toxin Sacs" hidden="false" collective="false" targetId="664f-0750-337d-2461" type="selectionEntry"/>
         <entryLink id="3444-5cfd-1af9-cc7d" name="Specialism" hidden="false" collective="false" targetId="69a0-bab5-203e-78c2" type="selectionEntryGroup"/>
+        <entryLink id="f44b-7b75-c618-d7d7" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="4.0"/>
@@ -637,6 +793,7 @@
           </constraints>
         </entryLink>
         <entryLink id="6b2f-d5fe-75e1-e75c" name="Specialism" hidden="false" collective="false" targetId="69a0-bab5-203e-78c2" type="selectionEntryGroup"/>
+        <entryLink id="e4a7-0b32-3f00-dfd8" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="4.0"/>
@@ -690,6 +847,7 @@
           </constraints>
         </entryLink>
         <entryLink id="6b6d-2899-b19a-6747" name="Specialism" hidden="false" collective="false" targetId="69a0-bab5-203e-78c2" type="selectionEntryGroup"/>
+        <entryLink id="1d71-18bb-e5f9-babf" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="25.0"/>
@@ -779,6 +937,7 @@
         <entryLink id="41b9-7961-d6ba-727d" name="Toxin Sacs" hidden="false" collective="false" targetId="664f-0750-337d-2461" type="selectionEntry"/>
         <entryLink id="49b8-0204-59ab-2686" name="Flesh Hooks" hidden="false" collective="false" targetId="301d-3fbf-9314-5ab0" type="selectionEntry"/>
         <entryLink id="3dc3-84f1-fcb0-ec89" name="Specialism" hidden="false" collective="false" targetId="69a0-bab5-203e-78c2" type="selectionEntryGroup"/>
+        <entryLink id="da29-a4c8-144c-ab83" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="20.0"/>
@@ -903,6 +1062,7 @@
           </constraints>
         </entryLink>
         <entryLink id="a5bf-480e-356c-792c" name="Specialism" hidden="false" collective="false" targetId="69a0-bab5-203e-78c2" type="selectionEntryGroup"/>
+        <entryLink id="a349-565d-6be9-a998" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="11.0"/>
@@ -1004,6 +1164,7 @@
         <entryLink id="4523-cb89-22ae-9dd7" name="Toxin Sacs" hidden="false" collective="false" targetId="664f-0750-337d-2461" type="selectionEntry"/>
         <entryLink id="d196-e55e-bc1f-9d28" name="Flesh Hooks" hidden="false" collective="false" targetId="301d-3fbf-9314-5ab0" type="selectionEntry"/>
         <entryLink id="4f6d-4046-34ef-3910" name="Specialism" hidden="false" collective="false" targetId="69a0-bab5-203e-78c2" type="selectionEntryGroup"/>
+        <entryLink id="82d2-da00-9947-2574" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="20.0"/>
@@ -1272,6 +1433,7 @@
           </modifiers>
         </entryLink>
         <entryLink id="b12e-8623-a9bf-c00d" name="Commander Specialism" hidden="false" collective="false" targetId="f8fe-1d50-4f98-0d6e" type="selectionEntryGroup"/>
+        <entryLink id="5241-c95f-51b3-ffe2" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="50.0"/>
@@ -1367,6 +1529,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b75a-e7f7-1136-5cf2" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="b4c2-4301-4154-bb03" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="131.0"/>
@@ -1454,6 +1617,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aeb-7d9e-bedd-5841" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="1cb5-4993-2402-d465" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="70.0"/>
@@ -1547,6 +1711,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="690e-6dea-fe3c-c946" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="7aa0-9cd7-1d12-8572" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="32.0"/>
@@ -1657,6 +1822,7 @@
           </constraints>
         </entryLink>
         <entryLink id="26f2-a6b7-fcd2-a2c1" name="Specialism" hidden="false" collective="false" targetId="69a0-bab5-203e-78c2" type="selectionEntryGroup"/>
+        <entryLink id="8ba6-d3e4-fff6-8b8a" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="35.0"/>
@@ -1755,6 +1921,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="fca9-4f3e-ee38-df96" name="Specialism" hidden="false" collective="false" targetId="69a0-bab5-203e-78c2" type="selectionEntryGroup"/>
+        <entryLink id="780a-ebf7-2f65-51c1" name="Hive Fleet" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="15.0"/>
@@ -1778,21 +1945,6 @@
           </constraints>
         </entryLink>
         <entryLink id="4677-9d93-b434-715c" name="Fire Team Advances" hidden="false" collective="false" targetId="ed6d-4175-51ed-c1d3" type="selectionEntry"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="84b2-566b-2160-2f01" name="Hive Fleet Adaptation" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c88-8a06-c01e-9018" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0ac7-cae3-3461-47ff" type="max"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="64be-cbe5-5f57-de8e" name="New CategoryLink" hidden="false" targetId="f868-bdfd-567c-3eac" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="b47f-aeb9-bde9-5391" name="Hive Fleet Adaptation" hidden="false" collective="false" targetId="402f-e863-cba2-206b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
@@ -1997,83 +2149,69 @@
         <entryLink id="4f90-122e-3524-6635" name="Commander Psychic Powers" hidden="false" collective="false" targetId="f1f5-3b33-9be9-6aec" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="402f-e863-cba2-206b" name="Hive Fleet Adaptation" hidden="false" collective="false" defaultSelectionEntryId="b0e2-0a55-9394-7dce">
+    <selectionEntryGroup id="402f-e863-cba2-206b" name="Hive Fleet" hidden="false" collective="false" defaultSelectionEntryId="b0e2-0a55-9394-7dce">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2aad-0d33-6b41-f976" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bfc-afee-6abe-b280" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="b0e2-0a55-9394-7dce" name="*No Adaptation*" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="b0e2-0a55-9394-7dce" name="*No Hive Fleet*" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9ec0-724a-a6fb-24f3" name="Behemoth" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="12fc-2076-ea68-325f" name="Hyper-aggression" hidden="false">
-              <description>You can re-roll charge rolls for models in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="8c1d-a79f-c863-91bc" name="Behemoth" hidden="false" targetId="bca2-6c3a-92b2-8ccf" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1229-562f-beca-6928" name="Kraken" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="43dd-c2f1-fe53-b43c" name="Questing Tendrils" hidden="false">
-              <description>When a model from your kill team Advances, roll three D6 instead of one and pick the highest roll to add to the Move characteristic of that model for that Movement phase. In addition, if a model from your kill team started the Movement phase within 1&quot; of an enemy model, but when you pick it to move there are no enemy models within 1&quot;, that model can make a charge attempt instead of Falling Back or remaining stationary.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="f5a8-ba6c-4a8c-580d" name="Kraken" hidden="false" targetId="9b63-9b67-13f1-07a8" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="48ab-2ada-5822-05c6" name="Leviathan" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="7dfc-d911-3e54-c0ac" name="Synaptic Imperative" hidden="false">
-              <description>Roll a D6 each time a model in your kill team loses a wound whilst it is within 6&quot; of a friendly SYNAPSE model. On a 6, the damage is ignored and the model does not lose a wound. In addition, models in your kill team that are within 6&quot; of a friendly SYNAPSE model do not suffer the penalty to their hit rolls from one flesh wound they have suffered.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="bf7f-195d-4263-ac43" name="Leviathan" hidden="false" targetId="3c51-799a-5820-1b29" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bbea-8cb0-6390-d802" name="Gorgon" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="a8b4-52ab-e1aa-d0d4" name="Adaptive Toxins" hidden="false">
-              <description>You can re-roll wound rolls for 1 in the Fight phase for attacks made by models in your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="dc0c-9ab8-4030-87f0" name="Gorgon" hidden="false" targetId="c85d-39c3-27f6-f9df" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a0dd-8fec-125d-d63c" name="Jormungandr" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="b57f-0223-50a8-3336" name="Tunnel Networks" hidden="false">
-              <description>Models in your kill team (other than models that can FLY) are considered to be obscured to enemy models that target them. If the model Advances or charges, however, it loses this benefit until the end of the battle round.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="47d8-b682-23ff-c2f7" name="Jormungandr" hidden="false" targetId="6b1f-79a4-c2d4-d507" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6d34-a33e-7dae-2577" name="Hydra" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="5006-056d-2d62-fe4e" name="Swarming Instincts" hidden="false">
-              <description>You can re-roll hit rolls in the Fight phase for attacks made by models in your kill team that target an enemy that is within 1&quot; of another model from your kill team.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="cc53-8209-7da0-8bf8" name="Hydra" hidden="false" targetId="bbf6-926b-e887-1650" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="796a-bcd3-5743-f0cf" name="Kronos" hidden="false" collective="false" type="upgrade">
-          <rules>
-            <rule id="c142-68dd-14fb-26fc" name="Bio-barrage" hidden="false">
-              <description>Re-roll unmodified hit rolls of 1 in the Shooting phase for models in your kill team if they have not moved in this battle round.</description>
-            </rule>
-          </rules>
+          <categoryLinks>
+            <categoryLink id="055e-8bc9-6d32-4944" name="Kronos" hidden="false" targetId="e154-46b6-c5d3-c972" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
           </costs>

--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -1686,7 +1686,7 @@
           </selectionEntries>
           <entryLinks>
             <entryLink id="6d6a-8aa2-3eb2-98df" name="Scything talons" hidden="false" collective="false" targetId="df0f-99d3-5fe4-c953" type="selectionEntry"/>
-            <entryLink id="8669-dab2-a742-78af" name="Lash whip and Bonesword" hidden="false" collective="false" targetId="6a54-e258-ff05-eebe" type="selectionEntry"/>
+            <entryLink id="8669-dab2-a742-78af" name="Lash whip and bonesword" hidden="false" collective="false" targetId="6a54-e258-ff05-eebe" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -1890,6 +1890,9 @@
               </constraints>
             </entryLink>
             <entryLink id="c370-7887-d1fe-462d" name="Rending claws" hidden="false" collective="false" targetId="04e7-1dc8-de3b-6ac4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="5291-dc2c-cfa5-a77f" value="1.0"/>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab92-b0eb-c5dd-d942" type="max"/>
               </constraints>


### PR DESCRIPTION
All subfaction selection is now done on models, rather than the whole roster. Subfaction rules appear if the roster qualifies for them, i.e. if all models have the same subfaction selected.

Closes #327 