### PR TITLE
Resolves #430 (Update for Traitor Guard Gunner Profile from 2019 Annual)

### DIFF
--- a/Servants of the Abyss.cat
+++ b/Servants of the Abyss.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2321-ee3c-7ef0-5c40" name="Servants of the Abyss" revision="4" battleScribeVersion="2.03" authorName="MadSpy" authorContact="@Madspy" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2321-ee3c-7ef0-5c40" name="Servants of the Abyss" revision="5" battleScribeVersion="2.03" authorName="MadSpy" authorContact="@Madspy" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="da06-53d5-c2fd-0607" name="Traitor Guardsmen" hidden="false"/>
     <categoryEntry id="fe8d-496a-755e-de4d" name="Chaos Beastmen" hidden="false"/>
@@ -529,7 +529,7 @@
                 <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="3.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="dc64-9e28-48df-4b46" name="Lasgun and krak grenades" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="dc64-9e28-48df-4b46" name="Krak grenades" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="c47c-7cc3-8687-facb" name="Krak grenade" hidden="false" typeId="c067-7929-f4dc-7825" typeName="Weapon">
                   <characteristics>
@@ -542,9 +542,6 @@
                   </characteristics>
                 </profile>
               </profiles>
-              <infoLinks>
-                <infoLink id="11f9-76ca-0223-d9d1" name="Lasgun" hidden="false" targetId="024a-a875-af56-8a96" type="profile"/>
-              </infoLinks>
               <costs>
                 <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
               </costs>


### PR DESCRIPTION
Removes Lasgun when selecting Krak grenades for Traitor Guardsman Gunner