### PR TITLE
Remove numerical prefixes from Hive Mind Disciplines

### DIFF
--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -2169,12 +2169,12 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06b8-4f2e-1ab4-0c11" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="da63-1c63-e751-0dfc" name="1. Dominion" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="da63-1c63-e751-0dfc" name="Dominion" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d872-e21b-8902-6aa8" type="max"/>
               </constraints>
               <profiles>
-                <profile id="edc1-92f4-5ad9-2430" name="1. Dominion" publicationId="a8de-fa3a-pubN71688" page="89" hidden="false" typeId="7a97-314b-42a0-d52e" typeName="Psychic Power">
+                <profile id="edc1-92f4-5ad9-2430" name="Dominion" publicationId="a8de-fa3a-pubN71688" page="89" hidden="false" typeId="7a97-314b-42a0-d52e" typeName="Psychic Power">
                   <characteristics>
                     <characteristic name="Psychic Power" typeId="0722-c3c3-3039-c061">Dominion has a warp charge value of 4. If manifested, select a friendly model within 18&quot; of the psyker that has the Instinctive Behaviour ability. Until the start of the next Psychic phase, that model ignores its Instinctive Behaviour ability and automatically passes Nerve tests.</characteristic>
                   </characteristics>
@@ -2184,12 +2184,12 @@
                 <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d4fc-541e-9fa0-0301" name="2. Catalyst" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="d4fc-541e-9fa0-0301" name="Catalyst" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6803-2af2-50d7-4c5c" type="max"/>
               </constraints>
               <profiles>
-                <profile id="91df-338a-00da-2123" name="2. Catalyst" publicationId="a8de-fa3a-pubN71688" page="89" hidden="false" typeId="7a97-314b-42a0-d52e" typeName="Psychic Power">
+                <profile id="91df-338a-00da-2123" name="Catalyst" publicationId="a8de-fa3a-pubN71688" page="89" hidden="false" typeId="7a97-314b-42a0-d52e" typeName="Psychic Power">
                   <characteristics>
                     <characteristic name="Psychic Power" typeId="0722-c3c3-3039-c061">Catalyst has a warp charge value of 5. If manifested, select a friendly model within 18&quot; of the psyker. Until the start of the next Psychic phase, roll a D6 each time that model loses a wound. On a 5+ that wound is not lost. If the model already has an ability with a similar effect, you can choose which effect applies, and re-roll 1s when making these rolls.</characteristic>
                   </characteristics>
@@ -2199,12 +2199,12 @@
                 <cost name="pts" typeId="5291-dc2c-cfa5-a77f" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3fbf-b1ff-54a6-4223" name="3. The Horror" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="3fbf-b1ff-54a6-4223" name="The Horror" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3759-0047-53ab-ac25" type="max"/>
               </constraints>
               <profiles>
-                <profile id="1f05-15d0-2982-71f3" name="3. The Horror" publicationId="a8de-fa3a-pubN71688" page="89" hidden="false" typeId="7a97-314b-42a0-d52e" typeName="Psychic Power">
+                <profile id="1f05-15d0-2982-71f3" name="The Horror" publicationId="a8de-fa3a-pubN71688" page="89" hidden="false" typeId="7a97-314b-42a0-d52e" typeName="Psychic Power">
                   <characteristics>
                     <characteristic name="Psychic Power" typeId="0722-c3c3-3039-c061">The Horror has a warp charge value of 5. If manifested, select an enemy model within 18&quot; of and visible to the psyker. Until the start of the next Psychic phase, that model must subtract 1 from their hit rolls and Leadership characteristic.</characteristic>
                   </characteristics>


### PR DESCRIPTION
These numbers don't appear on other psychic power choices - they're just the suggested D3 rolls in the rulebook if you want to generate them randomly.