### PR TITLE
Fix Howling Banshee Movement Characteristic 

### DIFF
--- a/Asuryani.cat
+++ b/Asuryani.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a796-a947-905e-205c" name="Asuryani" revision="24" battleScribeVersion="2.03" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a796-a947-905e-205c" name="Asuryani" revision="25" battleScribeVersion="2.03" authorUrl="https://battlescribedata.appspot.com/#/repo/wh40k-killteam" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="efd1-273e-3910-f3e8" name="Warhost" hidden="false"/>
     <categoryEntry id="5bef-7545-be74-0e33" name="Guardian" hidden="false"/>

--- a/Asuryani.cat
+++ b/Asuryani.cat
@@ -2634,7 +2634,7 @@
       <profiles>
         <profile id="56d4-eb0f-55f7-731d" name="Howling Banshee" hidden="false" typeId="bb0a-aba1-abd0-beb3" typeName="Model">
           <characteristics>
-            <characteristic name="M" typeId="0a65-6cb0-f00d-e414">7&quot;</characteristic>
+            <characteristic name="M" typeId="0a65-6cb0-f00d-e414">8&quot;</characteristic>
             <characteristic name="WS" typeId="99d4-2590-8bac-3ad3">3+</characteristic>
             <characteristic name="BS" typeId="27ff-d5c5-5422-1614">3+</characteristic>
             <characteristic name="S" typeId="d474-89b0-047c-4f3a">3</characteristic>
@@ -2741,7 +2741,7 @@
       <profiles>
         <profile id="d08a-f080-8cbb-6566" name="Howling Banshee Exarch" hidden="false" typeId="bb0a-aba1-abd0-beb3" typeName="Model">
           <characteristics>
-            <characteristic name="M" typeId="0a65-6cb0-f00d-e414">7&quot;</characteristic>
+            <characteristic name="M" typeId="0a65-6cb0-f00d-e414">8&quot;</characteristic>
             <characteristic name="WS" typeId="99d4-2590-8bac-3ad3">3+</characteristic>
             <characteristic name="BS" typeId="27ff-d5c5-5422-1614">3+</characteristic>
             <characteristic name="S" typeId="d474-89b0-047c-4f3a">3</characteristic>


### PR DESCRIPTION
Updated Howling Banshee and Howling Banshee Exarch Movement to be 8 as is printed in the Elites Rulebook. 