### PR TITLE
Removed errant text in Castellan axe range value

### DIFF
--- a/Adeptus Custodes.cat
+++ b/Adeptus Custodes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="419c-04e4-1bb5-3f36" name="Adeptus Custodes" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="25" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="419c-04e4-1bb5-3f36" name="Adeptus Custodes" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="a467-5f42-d24c-6e5b" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="fd32-3cc0-f4c3-c5e1" name="Custodian Guard" hidden="false"/>
     <categoryEntry id="0426-fe12-c4a0-3395" name="Allarus Custodian" hidden="false"/>

--- a/Adeptus Custodes.cat
+++ b/Adeptus Custodes.cat
@@ -179,7 +179,7 @@
         </profile>
         <profile id="59b5-f29b-f5e0-ad8d" name="Castellan axe - ranged" hidden="false" typeId="c067-7929-f4dc-7825" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="5410-0b42-87cc-bbc6">Melee24&quot;</characteristic>
+            <characteristic name="Range" typeId="5410-0b42-87cc-bbc6">24&quot;</characteristic>
             <characteristic name="Type" typeId="38ea-c4e0-d3bb-d1e9">Rapid Fire 1</characteristic>
             <characteristic name="S" typeId="fcc6-35ea-38b6-f4ca">4</characteristic>
             <characteristic name="AP" typeId="fc0e-2874-184d-9f64">-1</characteristic>


### PR DESCRIPTION
Range value for the ranged profile only needs a numerical value. Erroneously had "melee" in the field as well.