### PR TITLE
typo fix - necrons

### DIFF
--- a/2021 - Tomb World.cat
+++ b/2021 - Tomb World.cat
@@ -770,7 +770,7 @@
           <profiles>
             <profile id="716f-8908-78fd-3dbb" name="Starfire Core" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
               <characteristics>
-                <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time a friendly operative makes a shooting attack with this weapon, in the Roll Attack Dice step of that shooting attack, if you retian any critical hits, you can retain one of your failed hits as a successful normal hit.</characteristic>
+                <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time a friendly operative makes a shooting attack with this weapon, in the Roll Attack Dice step of that shooting attack, if you retain any critical hits, you can retain one of your failed hits as a successful normal hit.</characteristic>
               </characteristics>
             </profile>
           </profiles>


### PR DESCRIPTION
Fixes a typo on the starfire core equipment description