### PR TITLE
Fix Greenskin Boss Nob Save Value  (6 -> 4)  #632

### DIFF
--- a/2021 - Greenskin.cat
+++ b/2021 - Greenskin.cat
@@ -420,7 +420,7 @@
             <characteristic name="APL" typeId="c84a-a042-6fe6-519b">2</characteristic>
             <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
             <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
-            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">6</characteristic>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">4</characteristic>
             <characteristic name="W" typeId="db11-738c-048c-759e">13</characteristic>
           </characteristics>
         </profile>

--- a/2021 - Greenskin.cat
+++ b/2021 - Greenskin.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="07b1-fbc0-d4da-9e11" name="Greenskin" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="07b1-fbc0-d4da-9e11" name="Greenskin" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="f1d6-69ab-df7c-6595" name="Greenskin" hidden="false"/>
     <categoryEntry id="0759-cc30-4a68-3fe1" name="Ork" hidden="false"/>
@@ -420,7 +420,7 @@
             <characteristic name="APL" typeId="c84a-a042-6fe6-519b">2</characteristic>
             <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
             <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
-            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">4</characteristic>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">4+</characteristic>
             <characteristic name="W" typeId="db11-738c-048c-759e">13</characteristic>
           </characteristics>
         </profile>


### PR DESCRIPTION
The Boss Nob save value should be 4, not 6, according to the new compendium

This is fix for #632 