### PR TITLE
[Novitiate] Fixed typo on Glorious Hymnal

### DIFF
--- a/2021 - Novitiate.cat
+++ b/2021 - Novitiate.cat
@@ -1508,7 +1508,7 @@ You cannot use Acts of Faith to change dice you’ve re-rolled.</characteristic>
         </profile>
         <profile id="29a1-c4e9-77f4-22b0" name="Glorious Hymnal (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
           <characteristics>
-            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Until the end of the Turning Point, each time a friendly NOVITIATE operative fights in combat, in the Roll Attack Dice step of that combatm, if it is within ⬟ of this operative, you can re-roll any or all of your dice results of 1 or 2.</characteristic>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Until the end of the Turning Point, each time a friendly NOVITIATE operative fights in combat, in the Roll Attack Dice step of that combat, if it is within ⬟ of this operative, you can re-roll any or all of your dice results of 1 or 2.</characteristic>
           </characteristics>
         </profile>
       </profiles>

--- a/2021 - Novitiate.cat
+++ b/2021 - Novitiate.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f8ef-a36f-f720-5f60" name="Novitiate" revision="8" battleScribeVersion="2.03" authorName="Mad-Spy" authorContact="" authorUrl="https://bsdata.net" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f8ef-a36f-f720-5f60" name="Novitiate" revision="9" battleScribeVersion="2.03" authorName="Mad-Spy" authorContact="" authorUrl="https://bsdata.net" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="0bd2-8527-d8d9-fc3b" name="Acts of Faith">
       <characteristicTypes>


### PR DESCRIPTION
## Summary

A typo was found on the Glorious Hymnal ability of the Novitiate Preceptor

## Approach

Change `combatm` to `combat`