### PR TITLE
Fixes #853: Applies current Sicarian limits from Balance Dataslate

### DIFF
--- a/2021 - Hunter Clade.cat
+++ b/2021 - Hunter Clade.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="945a-0f25-eba7-691d" name="Hunter Clade" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="945a-0f25-eba7-691d" name="Hunter Clade" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <profileTypes>
     <profileType id="c7e7-80f7-a912-1eec" name="Doctrina Imperatives">
       <characteristicTypes>
@@ -45,7 +45,7 @@
           <modifiers>
             <modifier type="increment" value="1" field="a6eb-d72c-9d94-7c2b" id="ce2d-baa8-16c-5abe">
               <conditions>
-                <condition type="lessThan" value="4" field="selections" scope="force" childId="bf2c-0f37-ac1a-a88f" shared="true" id="1a07-2145-eb34-6a9e" includeChildSelections="true"/>
+                <condition type="lessThan" value="5" field="selections" scope="force" childId="bf2c-0f37-ac1a-a88f" shared="true" id="1a07-2145-eb34-6a9e" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -79,16 +79,6 @@
                 <repeat field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ead-29c6-f9b1-bdc8" repeats="1" roundUp="false"/>
                 <repeat field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5fa9-04a0-895d-4576" repeats="1" roundUp="false"/>
               </repeats>
-            </modifier>
-            <modifier type="decrement" field="853c-e29d-c172-b365" value="1">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5fa9-04a0-895d-4576" type="atLeast"/>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ead-29c6-f9b1-bdc8" type="atLeast"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>


### PR DESCRIPTION
The number of Sicarian operatives can be equal to the number of Vanguard and Ranger operatives combined, and you can have an extra Vanguard or Ranger (for a total of 11 operatives) if you have 4 or fewer Sicarian operatives.

Removed the previous "less than Vanguard and Ranger" check and increased the limit of Sicarians to get 11 operatives.