### PR TITLE
Fixes #856: Strike Force Justian Kill Team

### DIFF
--- a/2021 - Strike Force Justian.cat
+++ b/2021 - Strike Force Justian.cat
@@ -1,0 +1,665 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue library="false" id="cf38-3ba4-6a60-835a" name="Strike Force Justian" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <sharedProfiles>
+    <profile name="Shape Reference" hidden="false" id="6ef3-2679-f642-90d6" typeId="350c-2ddd-8a24-377b" typeName="Operative">
+      <characteristics>
+        <characteristic name="M" typeId="c36f-3952-a91d-5a06">▲</characteristic>
+        <characteristic name="APL" typeId="c84a-a042-6fe6-519b">⬤</characteristic>
+        <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">⬛</characteristic>
+        <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">⬟</characteristic>
+        <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">⌖</characteristic>
+        <characteristic name="W" typeId="db11-738c-048c-759e">⚔</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Bolter Discipline" hidden="false" id="a147-46ae-6229-e21b" typeId="f52d-76ec-b279-093b" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">This operative can perform two Shoot actions during its activation.</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Shock Assault" typeId="f52d-76ec-b279-093b" typeName="Abilities" hidden="false" id="d97a-4141-35e3-8cb">
+      <characteristics>
+        <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">This operative can perform two Fight actions during its activation.</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+  <categoryEntries>
+    <categoryEntry name="STRIKE FORCE JUSTIAN" hidden="false" id="6522-db10-1f5b-91aa"/>
+    <categoryEntry name="Adeptus Astartes" hidden="false" id="6113-1db-8aaa-2c75"/>
+    <categoryEntry name="Captain Justian" hidden="false" id="ea30-81f3-4c34-6ddb"/>
+    <categoryEntry name="Sergeant Marius" hidden="false" id="bd3e-9a95-3f84-bfe8"/>
+    <categoryEntry name="Brother Flavian" hidden="false" id="8b13-9c0c-ddc2-792c"/>
+    <categoryEntry name="Brother Acules" hidden="false" id="1949-ed3-5ec1-2b92"/>
+    <categoryEntry name="Brother Vignius" hidden="false" id="f942-ae61-9b25-f222"/>
+    <categoryEntry name="Brother Decian" hidden="false" id="69b6-6727-46b-9705"/>
+    <categoryEntry name="Brother Thysor" hidden="false" id="42ed-4b6b-16f5-77fb"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry name="Strike Force Justian Kill Team" hidden="false" id="f5b3-3cf0-fd65-59bc">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="ca9f-a279-58ea-ad41" targetId="fb89-efb1-54e4-59c5" type="category"/>
+        <categoryLink name="Reference" hidden="false" id="d8f3-4a3e-1916-1679" targetId="322e-38ea-bf3e-c785" type="category"/>
+        <categoryLink name="Operative" hidden="false" id="ddc7-11a7-29d3-aac8" targetId="f98b-0289-0f1f-b233" type="category">
+          <constraints>
+            <constraint type="min" value="6" field="selections" scope="parent" shared="true" id="3697-9b8f-ef90-241a-min"/>
+            <constraint type="max" value="6" field="selections" scope="parent" shared="true" id="3697-9b8f-ef90-241a-max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink name="Brother Acules" hidden="false" id="b48-6f92-c3d6-71c8" targetId="1949-ed3-5ec1-2b92" type="category">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8dbc-5ace-171a-791"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink name="Brother Decian" hidden="false" id="7611-26ed-edb0-6f15" targetId="69b6-6727-46b-9705" type="category">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d9a7-4538-f594-8719"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink name="Brother Flavian" hidden="false" id="76ac-50cc-db1c-a197" targetId="8b13-9c0c-ddc2-792c" type="category">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="38c5-5dd5-5c0e-3902"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink name="Brother Vignius" hidden="false" id="c79c-add-37b-e628" targetId="f942-ae61-9b25-f222" type="category">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ba3c-4572-2d39-9410"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink name="Sergeant Marius" hidden="false" id="7291-226e-5ba0-7f17" targetId="bd3e-9a95-3f84-bfe8" type="category">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c946-a19c-7931-fa84"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink name="Brother Thysor" hidden="false" id="1707-7057-849-ec71" targetId="42ed-4b6b-16f5-77fb" type="category">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ea9f-9e2-35d8-59ba"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink name="Captain Justian" hidden="false" id="7730-4de4-cf75-46c2" targetId="ea30-81f3-4c34-6ddb" type="category">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="85e6-70c7-a8c3-8f7"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink name="Leader" hidden="false" id="c9ee-6feb-482e-c3ee" targetId="3198-c1ce-dfd0-fb4f" type="category">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d56d-7e22-a1f9-b2de-min" includeChildSelections="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d56d-7e22-a1f9-b2de-max" includeChildSelections="true"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <sharedSelectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Fists" hidden="false" id="95ac-6515-9758-afc2">
+      <profiles>
+        <profile name="⚔ Fists" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="7146-2ada-d362-b541">
+          <characteristics>
+            <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
+            <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">3+</characteristic>
+            <characteristic name="D" typeId="337a-2e5b-e4e3-f489">3/4</characteristic>
+            <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">-</characteristic>
+            <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8d85-92f6-e751-755d-min"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8d85-92f6-e751-755d-max"/>
+      </constraints>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Bolt Rifle" hidden="false" id="b3c0-4e18-899d-4dd5">
+      <profiles>
+        <profile name="⌖ Bolt Rifle" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="fcb0-70dc-21e-bc0">
+          <characteristics>
+            <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
+            <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">3+</characteristic>
+            <characteristic name="D" typeId="337a-2e5b-e4e3-f489">3/4</characteristic>
+            <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">-</characteristic>
+            <characteristic name="!" typeId="c495-8d08-b6b8-b434">P1</characteristic>
+          </characteristics>
+          <modifiers>
+            <modifier type="set" value="2+" field="32b4-9a0e-e740-6031">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="bd3e-9a95-3f84-bfe8" shared="true" id="2c7d-e729-aba6-8348"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c01b-1019-d8e7-63f-min"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c01b-1019-d8e7-63f-max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="Px" hidden="false" type="rule" id="eda2-ceb7-ca13-afa6" targetId="1f11-c169-2746-13cf"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Leader" hidden="false" id="989e-918a-23e9-99c1">
+      <categoryLinks>
+        <categoryLink targetId="3198-c1ce-dfd0-fb4f" id="e843-9d2c-3d97-a997" primary="false" name="Leader"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c3cd-da7e-fc56-b651"/>
+      </constraints>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <selectionEntries>
+    <selectionEntry type="model" import="true" name="Captain Justian" hidden="false" id="52cf-d7e2-8a78-50f9">
+      <profiles>
+        <profile name="Captain Justian" typeId="350c-2ddd-8a24-377b" typeName="Operative" hidden="false" id="6277-bea8-f116-7d9e">
+          <characteristics>
+            <characteristic name="M" typeId="c36f-3952-a91d-5a06">3⬤</characteristic>
+            <characteristic name="APL" typeId="c84a-a042-6fe6-519b">3</characteristic>
+            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
+            <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">3+</characteristic>
+            <characteristic name="W" typeId="db11-738c-048c-759e">15</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Rites of Battle" typeId="f52d-76ec-b279-093b" typeName="Abilities" hidden="false" id="9639-1560-f021-c820">
+          <characteristics>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">In the Generate Command Points step of each Strategy phase, if a friendly operative with this ability is in the killzone, add one additional Command point to your pool.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Iron Halo" typeId="f52d-76ec-b279-093b" typeName="Abilities" hidden="false" id="515b-e6aa-1075-6a67">
+          <characteristics>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">This operative has a 4+ invulnerable save.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink targetId="6522-db10-1f5b-91aa" id="e706-f45e-3914-7f60" primary="false" name="STRIKE FORCE JUSTIAN"/>
+        <categoryLink targetId="6113-1db-8aaa-2c75" id="840f-1a5f-a91-e63f" primary="false" name="Adeptus Astartes"/>
+        <categoryLink targetId="ea30-81f3-4c34-6ddb" id="9eaf-e3f2-ba92-966b" primary="false" name="Captain Justian"/>
+        <categoryLink targetId="f98b-0289-0f1f-b233" id="bf0d-2cbf-b570-dd87" primary="true" name="Operative"/>
+        <categoryLink targetId="15ae-553e-01d1-23a9" id="e147-7ba3-b1bb-c544" primary="false" name="Imperium"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Plasma Pistol" hidden="false" id="be02-dac2-9503-5f2">
+          <profiles>
+            <profile name="⌖ Plasma Pistol - Standard" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="bb3f-f30-2cc5-fff5">
+              <characteristics>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
+                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">2+</characteristic>
+                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">5/6</characteristic>
+                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Rng ⬟, AP1</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="⌖ Plasma Pistol - Supercharge" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="9f2b-303d-c5-98ef">
+              <characteristics>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
+                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">2+</characteristic>
+                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">5/6</characteristic>
+                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Rng ⬟, AP2, Hot</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Rng x" hidden="false" type="rule" id="9e6f-48ec-3fbf-6759" targetId="92de-2ad3-3554-0b3e"/>
+            <infoLink name="Hot" hidden="false" type="rule" id="8f6b-ac5a-f697-79fd" targetId="83c3-fce7-8ac1-9872"/>
+            <infoLink name="APx" hidden="false" type="rule" id="e886-85e1-dbac-bbee" targetId="db98-339e-d0a2-e042"/>
+          </infoLinks>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="740a-43c0-b9b5-7e2c-min"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="740a-43c0-b9b5-7e2c-max"/>
+          </constraints>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Power Fist" hidden="false" id="9b20-9426-cc0e-65a6">
+          <profiles>
+            <profile name="⚔ Power Fist" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="7a87-91e2-19a-e618">
+              <characteristics>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">5</characteristic>
+                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">3+</characteristic>
+                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">5/7</characteristic>
+                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Brutal</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Brutal" hidden="false" type="rule" id="faca-56a0-d066-626e" targetId="16e9-a975-03a1-91c0"/>
+          </infoLinks>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4f-a884-bb2c-80a1-min"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4f-a884-bb2c-80a1-max"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
+      <infoLinks>
+        <infoLink name="Shock Assault" hidden="false" type="profile" id="c33a-e1bc-e2bc-5b7c" targetId="d97a-4141-35e3-8cb"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink import="true" name="Battle Honours - Combat" hidden="false" type="selectionEntryGroup" id="d01-49a4-d4ca-bc2b" targetId="ae2f-d9f3-a27c-cca6"/>
+        <entryLink import="true" name="Battle Honours - Staunch" hidden="false" type="selectionEntryGroup" id="4790-76e0-9ef9-7ed0" targetId="93ec-2874-675e-b46e"/>
+        <entryLink import="true" name="XP" hidden="false" type="selectionEntry" id="adbc-150a-b08b-85ea" targetId="82af-b9b8-518f-aaf1"/>
+        <entryLink import="true" name="Battle Scars" hidden="false" type="selectionEntryGroup" id="aa4-59a6-720b-7baa" targetId="d5ae-a34b-acc2-dfe7"/>
+        <entryLink import="true" name="Specialism" hidden="false" type="selectionEntryGroup" id="c2c8-44ef-41c1-931d" targetId="6b02-b612-4414-56ea"/>
+        <entryLink import="true" name="Leader" hidden="false" type="selectionEntry" id="9475-e980-2092-d6dd" targetId="989e-918a-23e9-99c1"/>
+        <entryLink import="true" name="Equipment" hidden="false" type="selectionEntryGroup" id="9c7d-458e-762f-4a64" targetId="37d7-cac5-9871-e20b"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Sergeant Marius" hidden="false" id="2317-8f4c-3a3d-f9d7">
+      <profiles>
+        <profile name="Sergeant Marius" typeId="350c-2ddd-8a24-377b" typeName="Operative" hidden="false" id="93d8-73db-b69-b3d4">
+          <characteristics>
+            <characteristic name="M" typeId="c36f-3952-a91d-5a06">3⬤</characteristic>
+            <characteristic name="APL" typeId="c84a-a042-6fe6-519b">3</characteristic>
+            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
+            <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">3+</characteristic>
+            <characteristic name="W" typeId="db11-738c-048c-759e">15</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink targetId="15ae-553e-01d1-23a9" id="b439-a56b-e7f1-1b5b" primary="false" name="Imperium"/>
+        <categoryLink targetId="f98b-0289-0f1f-b233" id="ca9e-4031-e3a4-fd1e" primary="true" name="Operative"/>
+        <categoryLink targetId="6113-1db-8aaa-2c75" id="efae-e73-c6f4-44af" primary="false" name="Adeptus Astartes"/>
+        <categoryLink targetId="bd3e-9a95-3f84-bfe8" id="b9ee-9c76-c9cd-dd41" primary="false" name="Sergeant Marius"/>
+        <categoryLink targetId="6522-db10-1f5b-91aa" id="2eaa-de13-c436-7560" primary="false" name="STRIKE FORCE JUSTIAN"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Bolt Rifle" hidden="false" type="selectionEntry" id="d4a4-6baf-eb0c-9d14" targetId="b3c0-4e18-899d-4dd5"/>
+        <entryLink import="true" name="Fists" hidden="false" type="selectionEntry" id="d4e7-4f4b-a78e-9ecb" targetId="95ac-6515-9758-afc2"/>
+        <entryLink import="true" name="Battle Honours - Staunch" hidden="false" type="selectionEntryGroup" id="5302-59b6-2f50-94bb" targetId="93ec-2874-675e-b46e"/>
+        <entryLink import="true" name="Battle Honours - Marksman" hidden="false" type="selectionEntryGroup" id="17f2-2c88-3da7-8e24" targetId="e84e-ae34-82a8-57b0"/>
+        <entryLink import="true" name="XP" hidden="false" type="selectionEntry" id="7cda-659-6cb9-6144" targetId="82af-b9b8-518f-aaf1"/>
+        <entryLink import="true" name="Battle Scars" hidden="false" type="selectionEntryGroup" id="2c07-3a16-2295-c318" targetId="d5ae-a34b-acc2-dfe7"/>
+        <entryLink import="true" name="Specialism" hidden="false" type="selectionEntryGroup" id="84f1-e935-b489-9e62" targetId="6b02-b612-4414-56ea"/>
+        <entryLink import="true" name="Leader" hidden="false" type="selectionEntry" id="1a8e-f69f-aaf2-f85e" targetId="989e-918a-23e9-99c1"/>
+        <entryLink import="true" name="Equipment" hidden="false" type="selectionEntryGroup" id="54db-c82c-fdf3-ea0d" targetId="37d7-cac5-9871-e20b"/>
+      </entryLinks>
+      <infoLinks>
+        <infoLink name="Bolter Discipline" hidden="false" type="profile" id="2694-2077-4d1c-a1f7" targetId="a147-46ae-6229-e21b"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Brother Flavian" hidden="false" id="61fb-df03-996a-c193">
+      <profiles>
+        <profile name="Brother Flavian" typeId="350c-2ddd-8a24-377b" typeName="Operative" hidden="false" id="f405-599a-59d9-4de8">
+          <characteristics>
+            <characteristic name="M" typeId="c36f-3952-a91d-5a06">3⬤</characteristic>
+            <characteristic name="APL" typeId="c84a-a042-6fe6-519b">3</characteristic>
+            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
+            <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">5+</characteristic>
+            <characteristic name="W" typeId="db11-738c-048c-759e">12</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Camo Cloak" typeId="f52d-76ec-b279-093b" typeName="Abilities" hidden="false" id="d83f-e316-2962-fc35">
+          <characteristics>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time a shooting attack is made against this operative, in the Roll Defence Dice step of that shooting attack, before rolling your defence dice, if it is in Cover, one additional dice can be retained as a successful normal save as a result of Cover.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Adjust Optics (1AP)" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions" hidden="false" id="d96b-dcc-8961-df63">
+          <characteristics>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Until the end of the Turning Point, when determining Line of Sight for this operative, enemy operatives are not Obscured.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <entryLinks>
+        <entryLink import="true" name="Fists" hidden="false" type="selectionEntry" id="6a69-b6ac-57c2-3f11" targetId="95ac-6515-9758-afc2"/>
+        <entryLink import="true" name="Battle Honours - Marksman" hidden="false" type="selectionEntryGroup" id="f54b-ded7-2d47-a8ed" targetId="e84e-ae34-82a8-57b0"/>
+        <entryLink import="true" name="Battle Honours - Scout" hidden="false" type="selectionEntryGroup" id="ba44-7e46-77d5-29ff" targetId="94bd-d409-fda3-9f9f"/>
+        <entryLink import="true" name="XP" hidden="false" type="selectionEntry" id="4eb7-f281-bd91-5b12" targetId="82af-b9b8-518f-aaf1"/>
+        <entryLink import="true" name="Battle Scars" hidden="false" type="selectionEntryGroup" id="bea1-3c91-267a-31f9" targetId="d5ae-a34b-acc2-dfe7"/>
+        <entryLink import="true" name="Specialism" hidden="false" type="selectionEntryGroup" id="8793-4ef2-bef8-ea29" targetId="6b02-b612-4414-56ea"/>
+        <entryLink import="true" name="Equipment" hidden="false" type="selectionEntryGroup" id="a4f4-34ba-ae3a-67f1" targetId="37d7-cac5-9871-e20b"/>
+      </entryLinks>
+      <categoryLinks>
+        <categoryLink targetId="15ae-553e-01d1-23a9" id="89cb-92ec-4a3e-145b" primary="false" name="Imperium"/>
+        <categoryLink targetId="6522-db10-1f5b-91aa" id="bfb3-9c82-c4e9-832e" primary="false" name="STRIKE FORCE JUSTIAN"/>
+        <categoryLink targetId="f98b-0289-0f1f-b233" id="3f2c-252f-9d24-341c" primary="true" name="Operative"/>
+        <categoryLink targetId="6113-1db-8aaa-2c75" id="bad-c4db-2851-b345" primary="false" name="Adeptus Astartes"/>
+        <categoryLink targetId="8b13-9c0c-ddc2-792c" id="ac35-e72f-e9ec-7321" primary="false" name="Brother Flavian"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Bolt Sniper Rifle" hidden="false" id="77f3-6fda-36a5-461b">
+          <profiles>
+            <profile name="⌖ Bolt Sniper Rifle - Executioner" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="3cd6-3e40-3264-3345">
+              <characteristics>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
+                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">2+</characteristic>
+                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">3/4</characteristic>
+                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Balanced, Heavy, No Cover, Silent</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="⌖ Bolt Sniper Rifle - Hyperfrag" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="3026-a1dc-1125-1999">
+              <characteristics>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
+                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">2+</characteristic>
+                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">2/4</characteristic>
+                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Blast ▲, Heavy, Silent</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="⌖ Bolt Sniper Rifle - Mortis" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="d5ae-8d05-ae28-a516">
+              <characteristics>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
+                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">2+</characteristic>
+                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">3/3</characteristic>
+                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">AP1, Heavy, Silent</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">MW3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Balanced" hidden="false" type="rule" id="1cc2-16ce-7d9f-e40f" targetId="547c-e6e5-64d4-a519"/>
+            <infoLink name="Heavy" hidden="false" type="rule" id="6e22-afe3-bfe3-e9db" targetId="1e77-6974-cf90-6008"/>
+            <infoLink name="No Cover" hidden="false" type="rule" id="6fb5-86eb-3fa3-643c" targetId="c091-97f7-8640-5e56"/>
+            <infoLink name="Silent" hidden="false" type="rule" id="2a86-e1e6-c73a-af66" targetId="ce60-8109-69c9-3908"/>
+            <infoLink name="Blast x" hidden="false" type="rule" id="8c22-d2bf-4d85-a14d" targetId="d848-be09-6d6d-4708"/>
+            <infoLink name="APx" hidden="false" type="rule" id="9c0a-c980-c59e-9c33" targetId="db98-339e-d0a2-e042"/>
+            <infoLink name="MWx" hidden="false" type="rule" id="ca15-93ac-14d3-b9cc" targetId="0d4b-7a76-d266-bcc1"/>
+          </infoLinks>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3c3d-2a1c-b08-35bd-min"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3c3d-2a1c-b08-35bd-max"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Brother Acules" hidden="false" id="2821-2be3-1e8d-35ee">
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Heavy Bolter" hidden="false" id="8016-ce85-a5f6-25c7">
+          <profiles>
+            <profile name="⌖ Heavy Bolter" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="58fa-872d-5dc6-972">
+              <characteristics>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
+                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">3+</characteristic>
+                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">4/5</characteristic>
+                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Heavy, Fusillade</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">P1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Heavy" hidden="false" type="rule" id="d8c6-128f-daf2-707b" targetId="1e77-6974-cf90-6008"/>
+            <infoLink name="Fusillade" hidden="false" type="rule" id="82cd-5392-25f1-d672" targetId="e2ae-574a-94ab-3550"/>
+            <infoLink name="Px" hidden="false" type="rule" id="c4a1-1fdd-900f-fb2a" targetId="1f11-c169-2746-13cf"/>
+          </infoLinks>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4130-3605-aed9-38f1-min"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4130-3605-aed9-38f1-max"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink import="true" name="Fists" hidden="false" type="selectionEntry" id="7a22-29d0-9755-7874" targetId="95ac-6515-9758-afc2"/>
+        <entryLink import="true" name="Battle Honours - Staunch" hidden="false" type="selectionEntryGroup" id="cbe3-d718-9ee5-9648" targetId="93ec-2874-675e-b46e"/>
+        <entryLink import="true" name="Battle Honours - Marksman" hidden="false" type="selectionEntryGroup" id="1bba-94c1-3686-89ee" targetId="e84e-ae34-82a8-57b0"/>
+        <entryLink import="true" name="XP" hidden="false" type="selectionEntry" id="c8c1-fca1-34c4-c4c5" targetId="82af-b9b8-518f-aaf1"/>
+        <entryLink import="true" name="Battle Scars" hidden="false" type="selectionEntryGroup" id="2938-d9f4-54a6-cd7e" targetId="d5ae-a34b-acc2-dfe7"/>
+        <entryLink import="true" name="Specialism" hidden="false" type="selectionEntryGroup" id="9556-6e83-256-b394" targetId="6b02-b612-4414-56ea"/>
+        <entryLink import="true" name="Equipment" hidden="false" type="selectionEntryGroup" id="a9db-e30a-d1ff-3f0d" targetId="37d7-cac5-9871-e20b"/>
+      </entryLinks>
+      <profiles>
+        <profile name="Brother Acules" typeId="350c-2ddd-8a24-377b" typeName="Operative" hidden="false" id="2366-9b33-3352-56d1">
+          <characteristics>
+            <characteristic name="M" typeId="c36f-3952-a91d-5a06">2⬤</characteristic>
+            <characteristic name="APL" typeId="c84a-a042-6fe6-519b">3</characteristic>
+            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
+            <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">3+</characteristic>
+            <characteristic name="W" typeId="db11-738c-048c-759e">18</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink targetId="15ae-553e-01d1-23a9" id="883a-8853-cf01-97f4" primary="false" name="Imperium"/>
+        <categoryLink targetId="f98b-0289-0f1f-b233" id="cf6d-81d7-2ea2-1bdd" primary="true" name="Operative"/>
+        <categoryLink targetId="6522-db10-1f5b-91aa" id="f323-a549-9a54-6f63" primary="false" name="STRIKE FORCE JUSTIAN"/>
+        <categoryLink targetId="6113-1db-8aaa-2c75" id="9e56-2ad2-9d68-ab9f" primary="false" name="Adeptus Astartes"/>
+        <categoryLink targetId="1949-ed3-5ec1-2b92" id="60d3-55a4-eacb-ab61" primary="false" name="Brother Acules"/>
+      </categoryLinks>
+      <infoLinks>
+        <infoLink name="Bolter Discipline" hidden="false" type="profile" id="23c2-ed72-e0da-62b8" targetId="a147-46ae-6229-e21b"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Brother Vignus" hidden="false" id="5ba5-bb0e-b232-d185">
+      <categoryLinks>
+        <categoryLink targetId="15ae-553e-01d1-23a9" id="66af-85a0-ea85-a72a" primary="false" name="Imperium"/>
+        <categoryLink targetId="f98b-0289-0f1f-b233" id="68d8-d198-be90-ce2f" primary="true" name="Operative"/>
+        <categoryLink targetId="6113-1db-8aaa-2c75" id="301b-bb96-7c71-a97b" primary="false" name="Adeptus Astartes"/>
+        <categoryLink targetId="f942-ae61-9b25-f222" id="7289-7a82-a3e8-5673" primary="false" name="Brother Vignius"/>
+        <categoryLink targetId="6522-db10-1f5b-91aa" id="7ab6-403e-ba9c-cd71" primary="false" name="STRIKE FORCE JUSTIAN"/>
+      </categoryLinks>
+      <profiles>
+        <profile name="Brother Vignus" typeId="350c-2ddd-8a24-377b" typeName="Operative" hidden="false" id="b172-3662-94c4-c966">
+          <characteristics>
+            <characteristic name="M" typeId="c36f-3952-a91d-5a06"/>
+            <characteristic name="APL" typeId="c84a-a042-6fe6-519b"/>
+            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b"/>
+            <characteristic name="DF" typeId="4a18-41c1-51f2-c88c"/>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2"/>
+            <characteristic name="W" typeId="db11-738c-048c-759e"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <entryLinks>
+        <entryLink import="true" name="Fists" hidden="false" type="selectionEntry" id="70e0-6090-4ca5-f41a" targetId="95ac-6515-9758-afc2"/>
+        <entryLink import="true" name="Battle Honours - Staunch" hidden="false" type="selectionEntryGroup" id="384-d5d2-8bc7-7b36" targetId="93ec-2874-675e-b46e"/>
+        <entryLink import="true" name="Battle Honours - Marksman" hidden="false" type="selectionEntryGroup" id="151c-1048-3371-fdc7" targetId="e84e-ae34-82a8-57b0"/>
+        <entryLink import="true" name="XP" hidden="false" type="selectionEntry" id="80a3-f6c2-13a0-c55f" targetId="82af-b9b8-518f-aaf1"/>
+        <entryLink import="true" name="Battle Scars" hidden="false" type="selectionEntryGroup" id="a61f-e66c-dfa3-38fa" targetId="d5ae-a34b-acc2-dfe7"/>
+        <entryLink import="true" name="Specialism" hidden="false" type="selectionEntryGroup" id="5e23-880c-5eb1-3497" targetId="6b02-b612-4414-56ea"/>
+        <entryLink import="true" name="Equipment" hidden="false" type="selectionEntryGroup" id="df7-610b-c479-632f" targetId="37d7-cac5-9871-e20b"/>
+      </entryLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Auto bolt rifle" hidden="false" id="d31f-e7bd-c778-2666">
+          <profiles>
+            <profile name="⌖ Auto bolt rifle" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="eaec-3524-16bb-f67e">
+              <characteristics>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
+                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">3+</characteristic>
+                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">3/4</characteristic>
+                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Ceaseless</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Ceaseless" hidden="false" type="rule" id="f190-57ce-c246-c948" targetId="ce9a-aa0d-7b46-3d04"/>
+          </infoLinks>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="546e-7e1f-4872-bc1d-min"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="546e-7e1f-4872-bc1d-max"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
+      <infoLinks>
+        <infoLink name="Bolter Discipline" hidden="false" type="profile" id="42e5-37ac-c755-92be" targetId="a147-46ae-6229-e21b"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Brother Thysor" hidden="false" id="c94d-541d-ce62-f8b8">
+      <categoryLinks>
+        <categoryLink targetId="15ae-553e-01d1-23a9" id="454-d1fa-1033-ff2c" primary="false" name="Imperium"/>
+        <categoryLink targetId="f98b-0289-0f1f-b233" id="e299-c03c-e190-f0c1" primary="true" name="Operative"/>
+        <categoryLink targetId="42ed-4b6b-16f5-77fb" id="bf9-11af-8cda-53ce" primary="false" name="Brother Thysor"/>
+        <categoryLink targetId="6522-db10-1f5b-91aa" id="4fac-2042-2848-3d18" primary="false" name="STRIKE FORCE JUSTIAN"/>
+        <categoryLink targetId="6113-1db-8aaa-2c75" id="81a9-faf4-884-39e9" primary="false" name="Adeptus Astartes"/>
+      </categoryLinks>
+      <profiles>
+        <profile name="Brother Thysor" typeId="350c-2ddd-8a24-377b" typeName="Operative" hidden="false" id="8ae2-e40c-48d1-88ad">
+          <characteristics>
+            <characteristic name="M" typeId="c36f-3952-a91d-5a06">3⬤</characteristic>
+            <characteristic name="APL" typeId="c84a-a042-6fe6-519b">3</characteristic>
+            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
+            <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">3+</characteristic>
+            <characteristic name="W" typeId="db11-738c-048c-759e">14</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Smoke Grenade (1AP)" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions" hidden="false" id="2d53-62af-d4ab-612">
+          <characteristics>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Place the centre of one of your Smoke tokens within ⬟ of this operative. That token creates an area of smoke with a ⬤ radius and unlimited upward height (but not below). Until the end of the Turning Point, an operative is Obscured if every Cover line drawn to it crosses an area of smoke. This operative can only perform this action once, and cannot perform this action while within Engagement Range of enemy operative.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <entryLinks>
+        <entryLink import="true" name="Bolt Rifle" hidden="false" type="selectionEntry" id="4672-513a-a041-b12b" targetId="b3c0-4e18-899d-4dd5"/>
+        <entryLink import="true" name="Fists" hidden="false" type="selectionEntry" id="b952-9eb5-e37c-7d6" targetId="95ac-6515-9758-afc2"/>
+        <entryLink import="true" name="Battle Honours - Staunch" hidden="false" type="selectionEntryGroup" id="a7c1-3cd0-93f5-6871" targetId="93ec-2874-675e-b46e"/>
+        <entryLink import="true" name="Battle Honours - Marksman" hidden="false" type="selectionEntryGroup" id="378f-dd3f-46ef-e5a1" targetId="e84e-ae34-82a8-57b0"/>
+        <entryLink import="true" name="XP" hidden="false" type="selectionEntry" id="c621-17e6-f43e-4928" targetId="82af-b9b8-518f-aaf1"/>
+        <entryLink import="true" name="Battle Scars" hidden="false" type="selectionEntryGroup" id="bbec-a529-e396-83a8" targetId="d5ae-a34b-acc2-dfe7"/>
+        <entryLink import="true" name="Specialism" hidden="false" type="selectionEntryGroup" id="364e-354a-e036-e579" targetId="6b02-b612-4414-56ea"/>
+        <entryLink import="true" name="Equipment" hidden="false" type="selectionEntryGroup" id="c0ab-283-f03d-d0b8" targetId="37d7-cac5-9871-e20b"/>
+      </entryLinks>
+      <infoLinks>
+        <infoLink name="Bolter Discipline" hidden="false" type="profile" id="21c8-8b6a-2d42-b9e7" targetId="a147-46ae-6229-e21b"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Brother Decian" hidden="false" id="68f4-5a00-a993-30bb">
+      <profiles>
+        <profile name="Brother Decian" typeId="350c-2ddd-8a24-377b" typeName="Operative" hidden="false" id="50f7-ffe5-f6c4-6b83">
+          <characteristics>
+            <characteristic name="M" typeId="c36f-3952-a91d-5a06">3⬤</characteristic>
+            <characteristic name="APL" typeId="c84a-a042-6fe6-519b">3</characteristic>
+            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
+            <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">3+</characteristic>
+            <characteristic name="W" typeId="db11-738c-048c-759e">14</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink name="Shock Assault" hidden="false" type="profile" id="d895-d022-769a-5bc2" targetId="d97a-4141-35e3-8cb"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Chainsword" hidden="false" id="c926-bd2b-7364-4f71">
+          <profiles>
+            <profile name="⚔ Chainsword" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="556-8619-5137-25da">
+              <characteristics>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">5</characteristic>
+                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">3+</characteristic>
+                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">4/5</characteristic>
+                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">-</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5863-5199-2a14-2a0d-min"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5863-5199-2a14-2a0d-max"/>
+          </constraints>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Heavy bolt pistol" hidden="false" id="ab52-94c-bf3-cead">
+          <profiles>
+            <profile name="⌖ Heavy bolt pistol" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons" hidden="false" id="11bd-6d1d-4776-f920">
+              <characteristics>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
+                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">3+</characteristic>
+                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">3/4</characteristic>
+                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Rng ⬟</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">P1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Rng x" hidden="false" type="rule" id="d26b-b88e-ab75-8646" targetId="92de-2ad3-3554-0b3e"/>
+            <infoLink name="Px" hidden="false" type="rule" id="9b9c-38ce-dd24-bcb4" targetId="1f11-c169-2746-13cf"/>
+          </infoLinks>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="794a-c7a7-9a12-3874-min"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="794a-c7a7-9a12-3874-max"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
+      <categoryLinks>
+        <categoryLink targetId="15ae-553e-01d1-23a9" id="cc85-e2ad-4524-d5ae" primary="false" name="Imperium"/>
+        <categoryLink targetId="f98b-0289-0f1f-b233" id="d753-5d0c-d361-5371" primary="true" name="Operative"/>
+        <categoryLink targetId="6113-1db-8aaa-2c75" id="855b-f80e-cbfb-6606" primary="false" name="Adeptus Astartes"/>
+        <categoryLink targetId="6522-db10-1f5b-91aa" id="444d-4bb0-7e2e-4da1" primary="false" name="STRIKE FORCE JUSTIAN"/>
+        <categoryLink targetId="69b6-6727-46b-9705" id="293e-abeb-2354-b3a7" primary="false" name="Brother Decian"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Battle Honours - Combat" hidden="false" type="selectionEntryGroup" id="fa1d-8482-c7e6-ebd6" targetId="ae2f-d9f3-a27c-cca6"/>
+        <entryLink import="true" name="Battle Honours - Staunch" hidden="false" type="selectionEntryGroup" id="4cb-b46e-fbfe-c0df" targetId="93ec-2874-675e-b46e"/>
+        <entryLink import="true" name="XP" hidden="false" type="selectionEntry" id="e7da-cf0e-14bf-f106" targetId="82af-b9b8-518f-aaf1"/>
+        <entryLink import="true" name="Battle Scars" hidden="false" type="selectionEntryGroup" id="398f-b98b-1026-7b21" targetId="d5ae-a34b-acc2-dfe7"/>
+        <entryLink import="true" name="Specialism" hidden="false" type="selectionEntryGroup" id="a6bf-303a-da8d-a609" targetId="6b02-b612-4414-56ea"/>
+        <entryLink import="true" name="Equipment" hidden="false" type="selectionEntryGroup" id="30a1-7d38-7174-f4d5" targetId="37d7-cac5-9871-e20b"/>
+      </entryLinks>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup name="Specialism" hidden="false" id="6b02-b612-4414-56ea">
+      <entryLinks>
+        <entryLink id="94ed-50ec-9bef-134b" name="Combat" hidden="false" collective="false" import="true" targetId="97d8-19ec-143d-8aad" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="ea30-81f3-4c34-6ddb" shared="true"/>
+                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="69b6-6727-46b-9705" shared="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="e7c8-8cd6-5670-b179" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="ea30-81f3-4c34-6ddb" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="69b6-6727-46b-9705" shared="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="7d0f-fe84-e7cf-4e23" name="Scout" hidden="false" collective="false" import="true" targetId="9118-a98b-0ffe-9e3d" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="8b13-9c0c-ddc2-792c" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="67b7-aa09-c953-5f72" name="Staunch" hidden="false" collective="false" import="true" targetId="eb50-055a-4cd2-e1d5" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8b13-9c0c-ddc2-792c" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b692-ded1-483e-cb81" type="max"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Equipment" hidden="false" id="37d7-cac5-9871-e20b">
+      <constraints>
+        <constraint type="max" value="10" field="c61a-51a3-370d-bf55" scope="force" shared="true" id="f5f1-f0de-5447-ba18"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="true" field="hidden">
+          <conditions>
+            <condition type="notInstanceOf" value="1" field="forces" scope="force" childId="f5b3-3cf0-fd65-59bc" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Melee Weapons Rare Equipment" hidden="false" type="selectionEntryGroup" id="b149-351d-f01-39b9" targetId="d419-7a47-04c4-e1d9"/>
+        <entryLink import="true" name="Ranged Weapons Rare Equipment" hidden="false" type="selectionEntryGroup" id="6cc5-a8c9-e03-ce9b" targetId="aaad-f73a-1e28-248c"/>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+</catalogue>


### PR DESCRIPTION
Narrative equipment rules have not been released, only includes core Spec Ops equipment. Uses the printed English value for Heavy Boltor attacks.