### PR TITLE
Q4 2023 Balance Dataslate

### DIFF
--- a/2021 - Chaos Cult.cat
+++ b/2021 - Chaos Cult.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ffe8-3458-e886-e647" name="Chaos Cult" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ffe8-3458-e886-e647" name="Chaos Cult" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry name="CHAOS CULT" hidden="false" id="e46b-36ed-7952-7323"/>
     <categoryEntry name="Dark Commune" hidden="false" id="3b98-6793-b4e5-c927"/>
@@ -532,12 +532,15 @@ This operative’s melee weapons gain the Reap 1 critical hit rule, or Reap 2 if
 - If it’s a MUTANT operative, turn it into a TORMENT operative.
 - It can regain D3+1 lost wounds.
 
+
+If the operative was mutated into a new operative, the new operative has the same wounds remaining as the preceding operative but then regains D3+1 wounds if it’s now a MUTANT operative or D3+3 if it’s now a TORMENT operative; in either case, it cannot go above its maximum wounds.
+
 An operative cannot mutate more than once per Turning Point. In addition, you can never have more than five MUTANT operatives and three TORMENT operatives at once.
 When an operative mutates into another operative, it’s still the same DEVOTEE operative on your roster/dataslate, so has the same Battle Honours and is the same operative for any Tac Ops it has already been selected for, etc. The operative is simply a new operative type and will use that new type’s miniature and datacard rules. It will revert back to its original DEVOTEE miniature and datacard after the battle.
 
 You can mutate friendly operatives as follows:
 - Once in each Strategy phase, when it is your turn to use a Strategic Ploy or pass, you can instead mutate a number of friendly CHAOS CULT operatives equal to the Turning Point number.
-- At the end of a combat in which a friendly DEVOTEE operative inflicted damage and was not incapacitated.
+- At the end of a combat in which a friendly DEVOTEE operative incapacitated an enemy operative and was not incapacitated.
 - When a friendly CULT DEMAGOGUE operative performs the Accursed Benediction action (see Cult Demagogue datacard).
 
 When a friendly operative mutates into a new operative:

--- a/2021 - Exaction Squad.cat
+++ b/2021 - Exaction Squad.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eee3-50f4-51f9-cede" name="Exaction Squad" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="eee3-50f4-51f9-cede" name="Exaction Squad" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="2340-12c8-a052-142e" name="EXACTION SQUAD" hidden="false"/>
     <categoryEntry id="314e-1833-e85a-2256" name="Adeptus Arbites" hidden="false"/>
@@ -117,7 +117,7 @@
 • When determining control of an objective marker your Nuncio-aquila token (or this operative if that token has not been placed) is within ⬛ of, treat enemy operatives&apos; total APL as being 1 less. Note that this is not a modifier.</characteristic>
           </characteristics>
         </profile>
-        <profile id="22e9-ab95-a029-4c5d" name="Deploy Nuncio-Aquila (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
+        <profile id="22e9-ab95-a029-4c5d" name="Deploy Nuncio-Aquila (0AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
           <characteristics>
             <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">The first time this operative performs this action during a battle, place one of your Nuncio-aquila tokens within ⬟ horizontally and any distance vertically of this operative. Each time this operative performs this action thereafter, you can move that Nuncio-aquila token up to ⬟ horizontally and up to any distance vertically. This operative cannot perform this action while within Engagement Range of an enemy operative.</characteristic>
           </characteristics>
@@ -154,29 +154,11 @@
               <profiles>
                 <profile id="77ab-2025-5bb3-d445" name="⚔ Dominator maul &amp; assault shield" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
                   <characteristics>
-                    <characteristic name="A" typeId="5f37-25bb-661b-5c9c">-</characteristic>
-                    <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">-</characteristic>
-                    <characteristic name="D" typeId="337a-2e5b-e4e3-f489">-</characteristic>
-                    <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Each time this weapon is selected to fight in combat with, select one of the profiles below to use:</characteristic>
-                    <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
-                  </characteristics>
-                </profile>
-                <profile id="2a48-33f7-72fe-3fa6" name="⚔ Dominator maul &amp; assault shield - Offensive" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
-                  <characteristics>
                     <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
                     <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">3+</characteristic>
                     <characteristic name="D" typeId="337a-2e5b-e4e3-f489">4/4</characteristic>
-                    <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Lethal 5+</characteristic>
+                    <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Repress*, Shield*, Lethal 5+</characteristic>
                     <characteristic name="!" typeId="c495-8d08-b6b8-b434">Stun</characteristic>
-                  </characteristics>
-                </profile>
-                <profile id="5696-29b7-de1f-4537" name="⚔ Dominator maul &amp; assault shield - Defensive" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
-                  <characteristics>
-                    <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
-                    <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">3+</characteristic>
-                    <characteristic name="D" typeId="337a-2e5b-e4e3-f489">4/4</characteristic>
-                    <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Repress*, Shield*</characteristic>
-                    <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="882c-39e4-4fa8-65eb" name="Assault Shield" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -936,29 +918,11 @@
           <profiles>
             <profile id="b013-a078-2bf7-befb" name="⚔ Shock maul &amp; assault shield" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
               <characteristics>
-                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">-</characteristic>
-                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">-</characteristic>
-                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">-</characteristic>
-                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Each time this weapon is selected to fight in combat with, select one of the profiles below to use:</characteristic>
-                <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="dee7-9b66-f859-62b0" name="⚔ Shock maul &amp; assault shield - Offensive" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
-              <characteristics>
-                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
-                <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">4+</characteristic>
-                <characteristic name="D" typeId="337a-2e5b-e4e3-f489">4/4</characteristic>
-                <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">-</characteristic>
-                <characteristic name="!" typeId="c495-8d08-b6b8-b434">Stun</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="4b07-393f-f938-3d57" name="⚔ Shock maul &amp; assault shield - Defensive" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
-              <characteristics>
                 <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
                 <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">4+</characteristic>
                 <characteristic name="D" typeId="337a-2e5b-e4e3-f489">4/4</characteristic>
                 <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Repress*, Shield*</characteristic>
-                <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
+                <characteristic name="!" typeId="c495-8d08-b6b8-b434">Stun</characteristic>
               </characteristics>
             </profile>
           </profiles>

--- a/2021 - Farstalker Kinband.cat
+++ b/2021 - Farstalker Kinband.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3cd3-7d31-f105-e415" name="Farstalker Kinband" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3cd3-7d31-f105-e415" name="Farstalker Kinband" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="53d9-aee4-991f-1f73" name="FARSTALKER KINBAND" hidden="false"/>
     <categoryEntry id="0b91-407c-2178-9392" name="Kroot" hidden="false"/>
@@ -20,19 +20,19 @@
         <categoryLink id="fbaf-25a5-2242-ee23" name="Reference" hidden="false" targetId="322e-38ea-bf3e-c785" primary="false"/>
         <categoryLink id="b765-c123-fbd9-2d4c" name="Leader" hidden="false" targetId="3198-c1ce-dfd0-fb4f" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="947f-1292-0435-2ced" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0efe-1666-4c45-575e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="947f-1292-0435-2ced" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0efe-1666-4c45-575e" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="bba6-4b7d-98e5-b779" name="Operative" hidden="false" targetId="f98b-0289-0f1f-b233" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d6c-e8b2-2b8e-1e53" type="min"/>
-            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b3-83e7-dbd9-c267" type="max"/>
+            <constraint field="selections" scope="parent" value="11" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d6c-e8b2-2b8e-1e53" type="min"/>
+            <constraint field="selections" scope="parent" value="11" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b3-83e7-dbd9-c267" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="0241-7d97-f3ab-1289" name="Heavy Gunner" hidden="false" targetId="0e59-07ae-65c2-2de6" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7c0-ba7d-416c-7ca0" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7c0-ba7d-416c-7ca0" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -53,7 +53,10 @@
         </profile>
         <profile id="57d4-b00b-c0cf-be00" name="Call the Kill" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
           <characteristics>
-            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Once in each Strategy phase, when it is your turn to use a Strategic Ploy or pass, you can select one enemy operative Visible to this operative instead. Until the end of the Turning Point, each time a friendly FARSTALKER KINBAND operative fights in combat or makes a shooting attack against that enemy operative, in the Roll Attack Dice step of that combat or shooting attack, before rolling your attack dice, you can retain one as a successful normal hit without rolling it.</characteristic>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Once in each Strategy phase, when it is your turn to use a Strategic Ploy or pass, you can select one enemy operative in the killzone. Until the end of the Turning Point, each time a friendly FARSTALKER KINBAND operative fights in combat or makes a shooting attack against that enemy operative, in the Roll Attack Dice step of that combat or shooting attack, before rolling your attack dice, you can choose one of the following effects:
+- Retain one attack dice as a successful normal hit without rolling it
+- The weapon gains the Ceaseless special rule
+- The weapon gains the P1 critical hit rule</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -69,8 +72,8 @@
       <selectionEntries>
         <selectionEntry id="be69-1e30-e189-60c4" name="Blade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06ec-3e89-fa93-a530" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e051-05e2-2b51-ca83" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06ec-3e89-fa93-a530" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e051-05e2-2b51-ca83" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="513b-602f-bddb-5fe2" name="⚔ Blade" hidden="false" targetId="59f2-ce0d-aa90-437f" type="profile">
@@ -79,8 +82,8 @@
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="f9f1-33ec-cd5c-3ddb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0fa-ec54-1f66-18f2" type="equalTo"/>
-                        <condition field="selections" scope="f9f1-33ec-cd5c-3ddb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="388a-a1de-5673-35df" type="equalTo"/>
+                        <condition field="selections" scope="f9f1-33ec-cd5c-3ddb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0fa-ec54-1f66-18f2" type="equalTo"/>
+                        <condition field="selections" scope="f9f1-33ec-cd5c-3ddb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="388a-a1de-5673-35df" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -89,15 +92,15 @@
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3028-9903-0d72-bf58" name="Ranged weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea27-3f5e-a077-5642" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ba6-3625-6963-2e11" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea27-3f5e-a077-5642" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ba6-3625-6963-2e11" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="3d3b-362b-ebad-fbd7" name="Pulse rifle" hidden="false" collective="false" import="true" type="upgrade">
@@ -113,7 +116,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4145-22a6-1f4f-11b2" name="Pulse carbine" hidden="false" collective="false" import="true" type="upgrade">
@@ -137,7 +140,7 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -183,19 +186,19 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
         <entryLink id="aeb9-bd6b-384e-f103" name="Specialism" hidden="false" collective="false" import="true" targetId="d4ab-70eb-6d0f-e6c3" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3824-6dba-d69c-1786" name="Bow-hunter" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="038f-514f-e51c-38a4" value="1.0">
+        <modifier type="set" field="038f-514f-e51c-38a4" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="038f-514f-e51c-38a4" type="max"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="038f-514f-e51c-38a4" type="max"/>
       </constraints>
       <profiles>
         <profile id="89c4-f715-6d67-8856" name="Bow-hunter" hidden="false" typeId="350c-2ddd-8a24-377b" typeName="Operative">
@@ -226,8 +229,8 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
       <selectionEntries>
         <selectionEntry id="8d63-161e-3927-8e86" name="Accelerator bow" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8050-a38b-5347-8b32" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f2a-6365-cc02-d4a6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8050-a38b-5347-8b32" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f2a-6365-cc02-d4a6" type="max"/>
           </constraints>
           <profiles>
             <profile id="968a-e9ae-e031-1f59" name="⌖ Accelerator bow - Fused" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -264,7 +267,7 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
             <infoLink id="fc6c-6ae7-9550-b33f" name="Splash x" hidden="false" targetId="eab8-73f5-feed-5924" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -286,19 +289,19 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ed1e-c160-a2d0-1678" name="Cut-skin" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="f40c-013e-71bf-1397" value="1.0">
+        <modifier type="set" field="f40c-013e-71bf-1397" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f40c-013e-71bf-1397" type="max"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f40c-013e-71bf-1397" type="max"/>
       </constraints>
       <profiles>
         <profile id="2416-d571-5c07-cc85" name="Cut-skin" hidden="false" typeId="350c-2ddd-8a24-377b" typeName="Operative">
@@ -334,8 +337,8 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
       <selectionEntries>
         <selectionEntry id="41f9-c466-23bf-288b" name="Cut-skin&apos;s blades" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a432-e339-c8a4-670c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44b9-e8ae-1395-fef3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a432-e339-c8a4-670c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44b9-e8ae-1395-fef3" type="max"/>
           </constraints>
           <profiles>
             <profile id="9f48-f807-f7b6-a56b" name="⚔ Cut-skin&apos;s blades" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -353,7 +356,7 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
             <infoLink id="038d-1db7-4d51-803e" name="Lethal x" hidden="false" targetId="be29-25db-e215-b3b0" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -374,19 +377,19 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5357-ed37-80f2-4c15" name="Cold-blood" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="2714-a4ad-f6f1-df93" value="1.0">
+        <modifier type="set" field="2714-a4ad-f6f1-df93" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2714-a4ad-f6f1-df93" type="max"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2714-a4ad-f6f1-df93" type="max"/>
       </constraints>
       <profiles>
         <profile id="332b-563d-a516-efdb" name="Cold-blood" hidden="false" typeId="350c-2ddd-8a24-377b" typeName="Operative">
@@ -426,18 +429,18 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
         <entryLink id="9ea1-02ce-f59b-8bc5" name="Equipment" hidden="false" collective="false" import="true" targetId="141e-5b01-a4b4-e8ef" type="selectionEntryGroup"/>
         <entryLink id="c3ee-5aaf-0ac1-5444" name="Kroot rifle" hidden="false" collective="false" import="true" targetId="8255-2f10-816b-00fc" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ad3-525a-7135-fc2c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ad3-525a-7135-fc2c" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="243e-0800-7582-f63f" name="Specialism" hidden="false" collective="false" import="true" targetId="d4ab-70eb-6d0f-e6c3" type="selectionEntryGroup"/>
         <entryLink id="e73e-ac6b-1a85-bffc" name="Piercing Shot" hidden="false" collective="false" import="true" targetId="01ab-69e4-a4ae-7399" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52d5-7826-418e-7e53" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52d5-7826-418e-7e53" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="1738-19a9-5034-0059" name="Toxin Shot" hidden="false" collective="false" import="true" targetId="6d40-a875-1660-1b60" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="243e-94b1-4be2-6a79" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="243e-94b1-4be2-6a79" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="442c-696d-b070-f42e" name="Battle Honours - Marksman" hidden="false" collective="false" import="true" targetId="e84e-ae34-82a8-57b0" type="selectionEntryGroup">
@@ -462,7 +465,7 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8b50-93bf-7739-5d71" name="Heavy Gunner w/ tribalest" hidden="false" collective="false" import="true" type="model">
@@ -490,8 +493,8 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
       <selectionEntries>
         <selectionEntry id="4265-b591-b94b-5d8c" name="Londaxi tribalest" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="546a-2524-ec6c-05bf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31d3-f6d6-0b82-594d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="546a-2524-ec6c-05bf" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31d3-f6d6-0b82-594d" type="max"/>
           </constraints>
           <profiles>
             <profile id="0ab9-9457-37f7-5b33" name="⌖ Londaxi tribalest" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -510,7 +513,7 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
             <infoLink id="ff2d-7251-9911-b7d0" name="*Cumbersome" hidden="false" targetId="a4b8-e5e1-a673-f0e3" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -532,7 +535,7 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f008-83d7-ef2c-e3d7" name="Hound" hidden="false" collective="false" import="true" type="model">
@@ -575,8 +578,8 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
       <selectionEntries>
         <selectionEntry id="fe99-e048-ff65-6028" name="Ripping fangs" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1ca-901a-be1c-78a6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ef-91cf-bb92-8345" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1ca-901a-be1c-78a6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ef-91cf-bb92-8345" type="max"/>
           </constraints>
           <profiles>
             <profile id="17f2-1a9b-4c2d-9671" name="Ripping fangs" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -593,7 +596,7 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
             <infoLink id="0163-fb55-5a9d-7dbf" name="Rending" hidden="false" targetId="0550-3332-7a93-ab5b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -623,19 +626,19 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="49ef-f7b0-1273-659f" name="Long-sight" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="be4c-cb6a-3bb4-e96e" value="1.0">
+        <modifier type="set" field="be4c-cb6a-3bb4-e96e" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be4c-cb6a-3bb4-e96e" type="max"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be4c-cb6a-3bb4-e96e" type="max"/>
       </constraints>
       <profiles>
         <profile id="ae68-0859-86f4-d092" name="Long-sight" hidden="false" typeId="350c-2ddd-8a24-377b" typeName="Operative">
@@ -672,8 +675,8 @@ This operative cannot perform this action while within Engagement Range of an en
       <selectionEntries>
         <selectionEntry id="61eb-72bc-7511-1700" name="Kroot hunting rifle" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9032-c397-4ca9-5ce4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="026e-e44b-4248-f03c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9032-c397-4ca9-5ce4" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="026e-e44b-4248-f03c" type="max"/>
           </constraints>
           <profiles>
             <profile id="054f-fbeb-11bb-bb35" name="⌖ Kroot hunting rifle" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -691,7 +694,7 @@ This operative cannot perform this action while within Engagement Range of an en
             <infoLink id="f5a7-8ede-1274-bec9" name="MWx" hidden="false" targetId="0d4b-7a76-d266-bcc1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -713,19 +716,19 @@ This operative cannot perform this action while within Engagement Range of an en
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a0c4-a33d-115f-e0da" name="Pistolier" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="caf7-ee39-ca59-5f60" value="1.0">
+        <modifier type="set" field="caf7-ee39-ca59-5f60" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="caf7-ee39-ca59-5f60" type="max"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="caf7-ee39-ca59-5f60" type="max"/>
       </constraints>
       <profiles>
         <profile id="d5f0-7543-4513-54ec" name="Pistolier" hidden="false" typeId="350c-2ddd-8a24-377b" typeName="Operative">
@@ -761,8 +764,8 @@ This operative cannot perform this action while within Engagement Range of an en
       <selectionEntries>
         <selectionEntry id="6d9c-1c6a-53ad-20a0" name="Dual Kroot pistols" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c88-3f1c-5de6-020c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbf6-7618-b799-3de1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c88-3f1c-5de6-020c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbf6-7618-b799-3de1" type="max"/>
           </constraints>
           <profiles>
             <profile id="6685-cfa1-ca77-25e5" name="⌖ Dual Kroot pistols" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -781,7 +784,7 @@ This operative cannot perform this action while within Engagement Range of an en
             <infoLink id="bf81-23b6-19aa-4c0f" name="Lethal x" hidden="false" targetId="be29-25db-e215-b3b0" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -813,19 +816,19 @@ This operative cannot perform this action while within Engagement Range of an en
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cae7-f392-994d-6506" name="Stalker" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="3b38-c77b-da7f-08a9" value="1.0">
+        <modifier type="set" field="3b38-c77b-da7f-08a9" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b38-c77b-da7f-08a9" type="max"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b38-c77b-da7f-08a9" type="max"/>
       </constraints>
       <profiles>
         <profile id="5b34-b003-aae8-31bc" name="Stalker" hidden="false" typeId="350c-2ddd-8a24-377b" typeName="Operative">
@@ -864,8 +867,8 @@ This operative cannot perform this action while within Engagement Range of an en
       <selectionEntries>
         <selectionEntry id="409d-b282-f06a-6216" name="Stalker&apos;s blade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2609-3b1e-5974-155e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f947-846b-2284-08f1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2609-3b1e-5974-155e" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f947-846b-2284-08f1" type="max"/>
           </constraints>
           <profiles>
             <profile id="9ca1-6887-2bc4-58ab" name="⚔ Stalker&apos;s blade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -883,7 +886,7 @@ This operative cannot perform this action while within Engagement Range of an en
             <infoLink id="86c7-6081-ad07-4c29" name="Rending" hidden="false" targetId="0550-3332-7a93-ab5b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -894,7 +897,7 @@ This operative cannot perform this action while within Engagement Range of an en
         <entryLink id="43a7-56d2-d2f5-9b8a" name="Specialism" hidden="false" collective="false" import="true" targetId="d4ab-70eb-6d0f-e6c3" type="selectionEntryGroup"/>
         <entryLink id="c98f-8ea2-8a13-0528" name="Kroot scattergun" hidden="false" collective="false" import="true" targetId="6f8e-6b58-5a73-00b9" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="113e-63ef-a2de-0634" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="113e-63ef-a2de-0634" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="76a5-286e-e7ce-30b9" name="Battle Honours - Combat" hidden="false" collective="false" import="true" targetId="ae2f-d9f3-a27c-cca6" type="selectionEntryGroup">
@@ -919,19 +922,19 @@ This operative cannot perform this action while within Engagement Range of an en
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4609-aade-c68a-1b72" name="Tracker" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="1b60-703d-6d32-1dec" value="1.0">
+        <modifier type="set" field="1b60-703d-6d32-1dec" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b60-703d-6d32-1dec" type="max"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b60-703d-6d32-1dec" type="max"/>
       </constraints>
       <profiles>
         <profile id="5eb1-3b0e-8552-71fe" name="Tracker" hidden="false" typeId="350c-2ddd-8a24-377b" typeName="Operative">
@@ -976,7 +979,7 @@ This operative cannot perform this action while within Engagement Range of an en
         <entryLink id="6927-e804-fec5-f282" name="Equipment" hidden="false" collective="false" import="true" targetId="141e-5b01-a4b4-e8ef" type="selectionEntryGroup"/>
         <entryLink id="4bbf-05ca-5afd-8677" name="Kroot rifle" hidden="false" collective="false" import="true" targetId="8255-2f10-816b-00fc" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ed-6cbb-fdfd-bef6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ed-6cbb-fdfd-bef6" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="07a7-77cd-f57c-8c59" name="Specialism" hidden="false" collective="false" import="true" targetId="d4ab-70eb-6d0f-e6c3" type="selectionEntryGroup"/>
@@ -1002,7 +1005,7 @@ This operative cannot perform this action while within Engagement Range of an en
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8516-9673-6cf6-40e5" name="Warrior w/ scattergun" hidden="false" collective="false" import="true" type="model">
@@ -1034,7 +1037,7 @@ This operative cannot perform this action while within Engagement Range of an en
         <entryLink id="abae-0c29-39ae-f022" name="Equipment" hidden="false" collective="false" import="true" targetId="141e-5b01-a4b4-e8ef" type="selectionEntryGroup"/>
         <entryLink id="7f41-50e7-aed7-c673" name="Kroot scattergun" hidden="false" collective="false" import="true" targetId="6f8e-6b58-5a73-00b9" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5795-6e87-c4ce-22e6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5795-6e87-c4ce-22e6" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="cb66-9e42-0185-086a" name="Specialism" hidden="false" collective="false" import="true" targetId="d4ab-70eb-6d0f-e6c3" type="selectionEntryGroup"/>
@@ -1070,7 +1073,7 @@ This operative cannot perform this action while within Engagement Range of an en
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="be6a-e2ce-78f6-cb3c" name="Warrior w/ rifle" hidden="false" collective="false" import="true" type="model">
@@ -1102,7 +1105,7 @@ This operative cannot perform this action while within Engagement Range of an en
         <entryLink id="392c-4cda-b622-aa7f" name="Equipment" hidden="false" collective="false" import="true" targetId="141e-5b01-a4b4-e8ef" type="selectionEntryGroup"/>
         <entryLink id="d534-4079-9e92-6731" name="Kroot rifle" hidden="false" collective="false" import="true" targetId="8255-2f10-816b-00fc" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="093c-1714-9045-8e1f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="093c-1714-9045-8e1f" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="3f05-a827-5ecb-57e1" name="Specialism" hidden="false" collective="false" import="true" targetId="d4ab-70eb-6d0f-e6c3" type="selectionEntryGroup"/>
@@ -1138,7 +1141,7 @@ This operative cannot perform this action while within Engagement Range of an en
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b8fc-697a-6454-4232" name="Heavy Gunner w/ skinner" hidden="false" collective="false" import="true" type="model">
@@ -1166,8 +1169,8 @@ This operative cannot perform this action while within Engagement Range of an en
       <selectionEntries>
         <selectionEntry id="266f-7dae-f1ab-d3d1" name="Dvorgita skinner" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f76c-41bd-d33c-b756" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0bb-cb48-91ff-5591" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f76c-41bd-d33c-b756" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0bb-cb48-91ff-5591" type="max"/>
           </constraints>
           <profiles>
             <profile id="3b88-596b-ed5f-d550" name="⌖ Dvorgita skinner" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1187,7 +1190,7 @@ This operative cannot perform this action while within Engagement Range of an en
             <infoLink id="6ec1-fd5c-0382-e938" name="*Cumbersome" hidden="false" targetId="a4b8-e5e1-a673-f0e3" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1209,26 +1212,26 @@ This operative cannot perform this action while within Engagement Range of an en
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntries>
     <selectionEntry id="4097-0a14-2867-79f2" name="Blade" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2284-1910-7c6d-01c2" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8567-8b64-4d5c-5b3c" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2284-1910-7c6d-01c2" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8567-8b64-4d5c-5b3c" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="1c2c-d44f-3c23-0dfc" name="⚔ Blade" hidden="false" targetId="59f2-ce0d-aa90-437f" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8255-2f10-816b-00fc" name="Kroot rifle" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0768-6eb7-aff3-2f1d" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0768-6eb7-aff3-2f1d" type="max"/>
       </constraints>
       <profiles>
         <profile id="ff95-bca3-2af1-4faf" name="⌖ Kroot rifle" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1237,8 +1240,8 @@ This operative cannot perform this action while within Engagement Range of an en
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6467-0adb-e2d5-46aa" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b9a4-31a5-b4ed-b4c7" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6467-0adb-e2d5-46aa" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b9a4-31a5-b4ed-b4c7" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1254,12 +1257,12 @@ This operative cannot perform this action while within Engagement Range of an en
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6f8e-6b58-5a73-00b9" name="Kroot scattergun" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9c7-db05-d4b0-6a9f" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9c7-db05-d4b0-6a9f" type="max"/>
       </constraints>
       <profiles>
         <profile id="44f1-b855-4cf9-0ae4" name="⌖ Kroot scattergun" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1276,7 +1279,7 @@ This operative cannot perform this action while within Engagement Range of an en
         <infoLink id="a66b-7e12-8a63-8c9a" name="Rng x" hidden="false" targetId="92de-2ad3-3554-0b3e" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="01ab-69e4-a4ae-7399" name="Piercing Shot" hidden="false" collective="false" import="true" type="upgrade">
@@ -1285,16 +1288,16 @@ This operative cannot perform this action while within Engagement Range of an en
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8255-2f10-816b-00fc" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d9c-1c6a-53ad-20a0" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ab0-427c-bbbd-7906" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8255-2f10-816b-00fc" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d9c-1c6a-53ad-20a0" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ab0-427c-bbbd-7906" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ed6-84c6-fc21-2805" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ed6-84c6-fc21-2805" type="max"/>
       </constraints>
       <profiles>
         <profile id="3ab6-4045-7d6a-81d9" name="Piercing Shot" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1317,7 +1320,7 @@ This operative cannot perform this action while within Engagement Range of an en
         <infoLink id="e54b-05a8-3e0d-a9bd" name="Limited" hidden="false" targetId="1eb0-6ad3-3e5a-d8ec" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6d40-a875-1660-1b60" name="Toxin Shot" hidden="false" collective="false" import="true" type="upgrade">
@@ -1326,17 +1329,17 @@ This operative cannot perform this action while within Engagement Range of an en
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8255-2f10-816b-00fc" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d9c-1c6a-53ad-20a0" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ab0-427c-bbbd-7906" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8255-2f10-816b-00fc" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d9c-1c6a-53ad-20a0" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ab0-427c-bbbd-7906" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d45-cf5c-603d-c822" type="max"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fbd2-fa14-4c33-b702" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d45-cf5c-603d-c822" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fbd2-fa14-4c33-b702" type="max"/>
       </constraints>
       <profiles>
         <profile id="61d9-691b-5047-7172" name="Toxin Shot" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1360,32 +1363,32 @@ This operative cannot perform this action while within Engagement Range of an en
         <infoLink id="dfb0-53a8-909d-2aa4" name="Stun" hidden="false" targetId="a1e3-4e0b-f7c2-eb59" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="be1c-96a4-bfe1-1100" name="Ancient Flintlock [RARE]" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8255-2f10-816b-00fc" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6f8e-6b58-5a73-00b9" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ab0-427c-bbbd-7906" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d9c-1c6a-53ad-20a0" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8255-2f10-816b-00fc" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6f8e-6b58-5a73-00b9" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ab0-427c-bbbd-7906" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d9c-1c6a-53ad-20a0" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f78-bf35-d19e-aad7" type="max"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="58e8-a48e-186c-6c76" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f78-bf35-d19e-aad7" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="58e8-a48e-186c-6c76" type="max"/>
       </constraints>
       <profiles>
         <profile id="fadd-f69d-fc06-3209" name="Ancient Flintlock" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1398,12 +1401,12 @@ This operative cannot perform this action while within Engagement Range of an en
         <infoLink id="f4bb-5e5d-abf9-c104" name="Lethal x" hidden="false" targetId="be29-25db-e215-b3b0" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a06e-8b1c-45c9-3672" name="Farband 3 - Trapper" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b23c-dac8-4f58-ef96" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b23c-dac8-4f58-ef96" type="max"/>
       </constraints>
       <profiles>
         <profile id="42f3-38dd-8a87-15b6" name="Trapper" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1413,12 +1416,12 @@ This operative cannot perform this action while within Engagement Range of an en
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4489-beb0-1594-8ce1" name="Farband 2 - Eye on the Mark" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b5-c43d-2e76-56d7" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b5-c43d-2e76-56d7" type="max"/>
       </constraints>
       <profiles>
         <profile id="933c-ceda-5d9c-af7f" name="Eye on the Mark" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1428,12 +1431,12 @@ This operative cannot perform this action while within Engagement Range of an en
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b884-1b45-5612-27a7" name="Farband 4 - Wiry" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="260b-bc81-c97e-7bcf" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="260b-bc81-c97e-7bcf" type="max"/>
       </constraints>
       <profiles>
         <profile id="d5de-978b-7bfb-f8fd" name="Wiry" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1443,12 +1446,12 @@ This operative cannot perform this action while within Engagement Range of an en
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="703b-675b-938c-b495" name="Farband 5 - Leathery Hide" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94ec-92b6-3945-df23" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94ec-92b6-3945-df23" type="max"/>
       </constraints>
       <profiles>
         <profile id="b306-40df-455f-0062" name="Leathery Physiology" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1458,12 +1461,12 @@ This operative cannot perform this action while within Engagement Range of an en
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="54b8-70cb-8bde-ed7a" name="Farband 6 - Clandestine" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4239-32f9-fab4-0511" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4239-32f9-fab4-0511" type="max"/>
       </constraints>
       <profiles>
         <profile id="e96d-be3f-ade1-703b" name="Clandestine" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1473,12 +1476,12 @@ This operative cannot perform this action while within Engagement Range of an en
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6a78-4666-5697-5763" name="Farband 1 - Savage" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53a5-fe11-51ea-af4e" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53a5-fe11-51ea-af4e" type="max"/>
       </constraints>
       <profiles>
         <profile id="fbc9-e712-e69b-48d4" name="Savage" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1488,7 +1491,7 @@ This operative cannot perform this action while within Engagement Range of an en
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -1497,18 +1500,18 @@ This operative cannot perform this action while within Engagement Range of an en
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed6-3bbe-0269-a512" type="notInstanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="c61a-51a3-370d-bf55" scope="force" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="93b3-fb34-f37a-220c" type="max"/>
+        <constraint field="c61a-51a3-370d-bf55" scope="force" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="93b3-fb34-f37a-220c" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="11d1-e3d8-9dd6-4cb3" name="Quill Grenade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d86a-022b-9ee2-68fc" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="59f2-cb68-798b-1dcc" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d86a-022b-9ee2-68fc" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="59f2-cb68-798b-1dcc" type="max"/>
           </constraints>
           <profiles>
             <profile id="d9fc-9936-0c93-637f" name="⌖ Quill Grenade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1528,12 +1531,12 @@ This operative cannot perform this action while within Engagement Range of an en
             <infoLink id="8e2c-2dd7-3278-905f" name="Limited" hidden="false" targetId="1eb0-6ad3-3e5a-d8ec" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0ab0-427c-bbbd-7906" name="Kroot pistol" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="901d-9d25-5110-647f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="901d-9d25-5110-647f" type="max"/>
           </constraints>
           <profiles>
             <profile id="5cfd-cec4-c925-7cbc" name="⚔ Kroot pistol" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1550,12 +1553,12 @@ This operative cannot perform this action while within Engagement Range of an en
             <infoLink id="2ce6-3814-3a8f-cb50" name="Rng x" hidden="false" targetId="92de-2ad3-3554-0b3e" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7559-296f-bb1d-2e16" name="Meat" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf6a-0f75-7f1d-7b99" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf6a-0f75-7f1d-7b99" type="max"/>
           </constraints>
           <profiles>
             <profile id="3c73-ee3e-e72b-2efe" name="Meat" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1565,12 +1568,12 @@ This operative cannot perform this action while within Engagement Range of an en
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="05f9-adcb-ff8a-ee83" name="Trophy" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80e5-bebf-ab33-239a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80e5-bebf-ab33-239a" type="max"/>
           </constraints>
           <profiles>
             <profile id="2a8a-3142-027e-fcf6" name="Trophy" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1580,20 +1583,20 @@ This operative cannot perform this action while within Engagement Range of an en
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d0fa-ec54-1f66-18f2" name="Ritual Blade" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8849-52f5-8ddf-0699" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8849-52f5-8ddf-0699" type="notInstanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c3e-640f-86de-4f36" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dabf-7da3-605c-0df6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c3e-640f-86de-4f36" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dabf-7da3-605c-0df6" type="max"/>
           </constraints>
           <profiles>
             <profile id="a4cc-86ad-ada0-d766" name="⚔ Ritual blade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1607,25 +1610,25 @@ This operative cannot perform this action while within Engagement Range of an en
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="388a-a1de-5673-35df" name="Kinblade [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8849-52f5-8ddf-0699" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8849-52f5-8ddf-0699" type="notInstanceOf"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7ce-4fc4-4f70-2b5f" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1858-6eee-b2c3-32cc" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7ce-4fc4-4f70-2b5f" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1858-6eee-b2c3-32cc" type="max"/>
           </constraints>
           <profiles>
             <profile id="e593-2196-0451-c2ac" name="⚔ Kinblade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1643,20 +1646,20 @@ This operative cannot perform this action while within Engagement Range of an en
             <infoLink id="d7a4-39ef-673e-7227" name="Rending" hidden="false" targetId="0550-3332-7a93-ab5b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3dc0-22fb-7aea-1d62" name="Kroothawk Totem [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1e1-b263-9a60-16b9" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="92aa-9182-3b9f-ec3c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1e1-b263-9a60-16b9" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="92aa-9182-3b9f-ec3c" type="max"/>
           </constraints>
           <profiles>
             <profile id="e240-d56b-f6ac-2457" name="Kroothawk Totem" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1666,20 +1669,20 @@ This operative cannot perform this action while within Engagement Range of an en
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="70e1-ace3-baec-59c4" name="Kin Totem [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d348-7c0a-128b-90c1" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f46-a7c2-2663-eeea" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d348-7c0a-128b-90c1" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f46-a7c2-2663-eeea" type="max"/>
           </constraints>
           <profiles>
             <profile id="e198-9c22-61d9-c77c" name="Kin Totem" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1689,20 +1692,20 @@ This operative cannot perform this action while within Engagement Range of an en
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="61f8-976f-db84-f547" name="Windmark [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f101-8392-3d83-b4b7" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ebc-f1f8-0e03-8683" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f101-8392-3d83-b4b7" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ebc-f1f8-0e03-8683" type="max"/>
           </constraints>
           <profiles>
             <profile id="1bdd-1eca-dcb3-a8b0" name="Windmark" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1712,20 +1715,20 @@ This operative cannot perform this action while within Engagement Range of an en
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="434b-f91e-3949-0c4a" name="Knarloc Hide [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4ec-1351-a0dc-517e" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7fa5-fbf9-c6fb-6722" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4ec-1351-a0dc-517e" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7fa5-fbf9-c6fb-6722" type="max"/>
           </constraints>
           <profiles>
             <profile id="6396-7acb-f7e5-6bbd" name="Knarloc Hide" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1735,7 +1738,7 @@ This operative cannot perform this action while within Engagement Range of an en
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1746,24 +1749,24 @@ This operative cannot perform this action while within Engagement Range of an en
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5d2c-7ab8-c748-dc64" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5d2c-7ab8-c748-dc64" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </entryLink>
         <entryLink id="ac01-2d53-f441-3453" name="Toxin Shot" hidden="false" collective="false" import="true" targetId="6d40-a875-1660-1b60" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5d2c-7ab8-c748-dc64" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5d2c-7ab8-c748-dc64" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </entryLink>
         <entryLink id="443e-976d-48a3-8499" name="Ancient Flintlock [RARE]" hidden="false" collective="false" import="true" targetId="be1c-96a4-bfe1-1100" type="selectionEntry"/>
@@ -1773,12 +1776,12 @@ This operative cannot perform this action while within Engagement Range of an en
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+            <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a4b-be7c-59cd-54a7" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a4b-be7c-59cd-54a7" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="bd2a-2042-9322-b5ef" name="Combat" hidden="false" collective="false" import="true" targetId="97d8-19ec-143d-8aad" type="selectionEntry">
@@ -1787,11 +1790,11 @@ This operative cannot perform this action while within Engagement Range of an en
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5040-f504-79ae-64e6" type="notInstanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1e70-e101-e63b-776e" type="notInstanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8849-52f5-8ddf-0699" type="notInstanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3d4d-360e-fa8f-785e" type="notInstanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b9a4-31a5-b4ed-b4c7" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5040-f504-79ae-64e6" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1e70-e101-e63b-776e" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8849-52f5-8ddf-0699" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3d4d-360e-fa8f-785e" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b9a4-31a5-b4ed-b4c7" type="notInstanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1804,9 +1807,9 @@ This operative cannot perform this action while within Engagement Range of an en
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5040-f504-79ae-64e6" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1e70-e101-e63b-776e" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3d4d-360e-fa8f-785e" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5040-f504-79ae-64e6" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1e70-e101-e63b-776e" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3d4d-360e-fa8f-785e" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1817,7 +1820,7 @@ This operative cannot perform this action while within Engagement Range of an en
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5d2c-7ab8-c748-dc64" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5d2c-7ab8-c748-dc64" type="notInstanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1828,11 +1831,11 @@ This operative cannot perform this action while within Engagement Range of an en
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5d2c-7ab8-c748-dc64" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1e70-e101-e63b-776e" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f25f-97c7-f917-9943" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0e59-07ae-65c2-2de6" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f8cc-9240-278b-7bae" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5d2c-7ab8-c748-dc64" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1e70-e101-e63b-776e" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f25f-97c7-f917-9943" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0e59-07ae-65c2-2de6" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f8cc-9240-278b-7bae" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1860,15 +1863,15 @@ In addition, each time a shooting attack is made against this operative, the No 
         <characteristic name="APL" typeId="c84a-a042-6fe6-519b">⬤</characteristic>
         <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">⬛</characteristic>
         <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">⬟</characteristic>
-        <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">⌖ </characteristic>
-        <characteristic name="W" typeId="db11-738c-048c-759e">⚔ </characteristic>
+        <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">⌖</characteristic>
+        <characteristic name="W" typeId="db11-738c-048c-759e">⚔</characteristic>
       </characteristics>
     </profile>
     <profile id="59f2-ce0d-aa90-437f" name="⚔ Blade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
       <modifiers>
         <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8849-52f5-8ddf-0699" type="instanceOf"/>
+            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8849-52f5-8ddf-0699" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/2021 - Fellgor Ravager.cat
+++ b/2021 - Fellgor Ravager.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="56b-12e-6b2c-bd26" name="Fellgor Ravager" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="56b-12e-6b2c-bd26" name="Fellgor Ravager" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry name="FELLGOR RAVAGER" hidden="false" id="6e8e-58e2-50ef-c8d9"/>
     <categoryEntry name="Ironhorn" hidden="false" id="e74b-bc55-d419-a22e"/>
@@ -581,13 +581,13 @@
     <rule name="Frenzy" hidden="false" id="a133-d150-90da-5549">
       <description>Each time a friendly FELLGOR RAVAGER operative without a Frenzy token would be incapacitated, it gains a Frenzy token instead. If it was fighting in combat, all remaining attack dice (including your opponent’s) are discarded. If it has a Conceal order, change it to Engage.
 
-
 While a friendly FELLGOR RAVAGER operative has a Frenzy token:
 - It’s only incapacitated as specified below.
 - It cannot have a Conceal order.
 - It’s injured.
 - It cannot perform mission actions or the Pick Up action.
-- It is ignored for the purposes of determining control (e.g. objective markers).
+
+- Treat its APL characteristic as 1 (after all modifiers) for the purposes of determining control (e.g. objective markers).
 
 
 A friendly FELLGOR RAVAGER operative with a Frenzy token is incapacitated when one of the following conditions is met:
@@ -595,7 +595,8 @@ A friendly FELLGOR RAVAGER operative with a Frenzy token is incapacitated when o
 - An enemy operative strikes it with a critical hit in combat.
 - An enemy operative strikes it a second time with a normal hit in combat. Note that this can be strikes from two different combats.
 - The battle ends.
-- Critical damage is inflicted on it in a shooting attack.
+
+- Critical damage is inflicted on it in a subsequent shooting attack (i.e. not the same shooting attack in which it gained a Frenzy token).
 
 
 Your opponent treats a FELLGOR RAVAGER operative as being incapacitated (instead of when it would be incapacitated normally) when it gains a Frenzy token for the following purposes:

--- a/2021 - Kasrkin.cat
+++ b/2021 - Kasrkin.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="13e2-04bc-4cc1-0c53" name="Kasrkin" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="13e2-04bc-4cc1-0c53" name="Kasrkin" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="a241-be0f-4dae-b452" name="KASRKIN" hidden="false"/>
     <categoryEntry id="d954-d36e-32d4-e53e" name="Kasrkin Sergeant" hidden="false"/>
@@ -774,7 +774,7 @@
         </profile>
         <profile id="76dd-4a9c-2d71-f9a0" name="Warden Auspex (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
           <characteristics>
-            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative. Until the end of the Turning Point, each time a friendly KASRKIN operative makes a shooting attack against that enemy operative, the ranged weapon that friendly operative is equipped with gains the No Cover rule for that shooting attack, and that enemy operative is not treated as being in Cover for the specified Cover purposes of the Elimination Pattern Strategic Ploy and Neitralise Target Tactical Ploy. This operative cannot perform this action while within Engagement Range of an enemy operative.</characteristic>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative. Until the end of the Turning Point, each time a friendly KASRKIN operative makes a shooting attack, that enemy operative is not Obscured. This operative cannot perform this action while within Engagement Range of an enemy operative.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1364,9 +1364,25 @@ Long-range Scope: Each time a friendly operative makes a shooting attack with th
         <selectionEntry id="c655-2105-625e-42a6" name="Foregrip" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c211-3124-6df0-a1c6" type="equalTo"/>
-              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c211-3124-6df0-a1c6" type="equalTo"/>
+                    <condition type="notInstanceOf" value="1" field="selections" scope="parent" childId="edd9-40f5-94a6-9049" shared="true" includeChildSelections="false"/>
+                    <condition type="notInstanceOf" value="1" field="selections" scope="parent" childId="305f-96fb-eac9-fcc7" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" value="2" field="c61a-51a3-370d-bf55">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="edd9-40f5-94a6-9049" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="305f-96fb-eac9-fcc7" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
@@ -1375,7 +1391,9 @@ Long-range Scope: Each time a friendly operative makes a shooting attack with th
           <profiles>
             <profile id="2de4-9420-2aca-775f" name="Foregrip" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
               <characteristics>
-                <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time this operative performs an Overwatch action, for that action&apos;s shooting attack, do not worsen the Ballistic Skill characteristic of a hot-shot lasgun it is equipped with as a result of performing an Overwatch action.</characteristic>
+                <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time this operative performs an Overwatch action, for that action&apos;s shooting attack, do not worsen the Ballistic Skill characteristic of a hot-shot lasgun it is equipped with as a result of performing an Overwatch action.
+
+GUNNER and SHARPSHOOTER operatives can use this for any ranged weapon on their datacard.</characteristic>
               </characteristics>
             </profile>
           </profiles>

--- a/2021 - Pathfinder.cat
+++ b/2021 - Pathfinder.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="50fd-3b1c-0a95-233b" name="Pathfinder" revision="8" battleScribeVersion="2.03" authorName="Mad-Spy" authorUrl="https://bsdata.net" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="50fd-3b1c-0a95-233b" name="Pathfinder" revision="9" battleScribeVersion="2.03" authorName="Mad-Spy" authorUrl="https://bsdata.net" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <profileTypes>
     <profileType id="3394-cf2d-5727-164a" name="Markerlight Tokens">
       <characteristicTypes>
@@ -34,101 +34,89 @@
         <categoryLink id="584f-0735-d32a-76b5" name="Reference" hidden="false" targetId="322e-38ea-bf3e-c785" primary="false"/>
         <categoryLink id="5e46-cdeb-71db-41c1" name="Leader" hidden="false" targetId="3198-c1ce-dfd0-fb4f" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="274e-b035-e9d9-47ed" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea71-bdb2-c82d-f0a6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="274e-b035-e9d9-47ed" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea71-bdb2-c82d-f0a6" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="72ed-819f-85af-f8c9" name="Operative" hidden="false" targetId="f98b-0289-0f1f-b233" primary="false">
-          <modifiers>
-            <modifier type="decrement" field="c28e-24b4-4f70-bff7" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b44f-3991-99c6-f72b" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="decrement" field="4b15-3108-8578-8ac4" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b44f-3991-99c6-f72b" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
           <constraints>
-            <constraint field="selections" scope="roster" value="11.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c28e-24b4-4f70-bff7" type="max"/>
-            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b15-3108-8578-8ac4" type="min"/>
+            <constraint field="selections" scope="roster" value="11" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c28e-24b4-4f70-bff7" type="max"/>
+            <constraint field="selections" scope="parent" value="11" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b15-3108-8578-8ac4" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="f962-934b-dfb9-0b47" name="Shas&apos;la Pathfinder" hidden="false" targetId="0018-186d-a0f2-cd57" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf4-91c4-95d7-ed59" type="max"/>
+            <constraint field="selections" scope="roster" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf4-91c4-95d7-ed59" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="cd32-ef0b-9f87-e7dd" name="Communications Specialist Pathfinder" hidden="false" targetId="746d-205b-b5e2-b09b" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81d8-3f4b-3ce4-924a" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81d8-3f4b-3ce4-924a" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="16af-4e52-2310-fcdd" name="Drone Controller Pathfinder" hidden="false" targetId="11a4-0e45-640a-6376" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dff1-a2e3-a1e2-0105" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dff1-a2e3-a1e2-0105" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="37d2-4856-e333-03a1" name="Marksman Pathfinder" hidden="false" targetId="7707-b0da-22a2-c0aa" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc3-85b3-f70f-6391" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc3-85b3-f70f-6391" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="c8c9-2b8a-73d9-0ba4" name="Medical Technician Pathfinder" hidden="false" targetId="fdfa-b47d-d74e-e874" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1494-123d-ddea-8ad2" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1494-123d-ddea-8ad2" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="9354-019b-12aa-1d35" name="Transpectral Interference Pathfinder" hidden="false" targetId="6723-e2e2-45c5-22d8" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb6c-78be-da8f-3a4c" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb6c-78be-da8f-3a4c" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="91e6-cdf1-4875-f58e" name="Weapons Expert Pathfinder" hidden="false" targetId="3c95-fe6f-7405-6b46" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ca-8ace-c66a-d413" type="max"/>
+            <constraint field="selections" scope="roster" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ca-8ace-c66a-d413" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="6aa4-061a-ef32-42f8" name="Blooded Pathfinder" hidden="false" targetId="397e-ce2d-6add-9e7a" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c4d-7df0-7cea-2839" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c4d-7df0-7cea-2839" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="0b3c-c9f5-6eb6-9414" name="Assault Grenadier Pathfinder" hidden="false" targetId="6b2a-729a-d0c7-6e07" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ae3-d341-0648-fe69" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ae3-d341-0648-fe69" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="dedd-42f0-f848-bddd" name="MV33 Grav-inhibitor Drone" hidden="false" targetId="009b-539b-3f18-bdcb" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b271-277d-6bd2-35ac" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b271-277d-6bd2-35ac" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7418-2a69-ff14-dd9d" name="MV1 Gun Drone" hidden="false" targetId="2be6-45e6-393e-3756" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aa5-542f-fe90-3574" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aa5-542f-fe90-3574" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="df02-35dd-b9dc-a3da" name="MV31 Pulse Accelerator Drone" hidden="false" targetId="ea6f-c852-b66f-a45a" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0055-1308-b525-f4e0" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0055-1308-b525-f4e0" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="a793-c943-dd4b-0358" name="MV4 Shield Drone" hidden="false" targetId="40f4-3de2-0602-62d7" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9332-672b-f2fb-fc31" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9332-672b-f2fb-fc31" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b64d-e2f7-d9cc-4d0c" name="MV7 Marker Drone" hidden="false" targetId="e9c1-e605-4ab9-2205" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="435f-2e9c-6828-37de" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="435f-2e9c-6828-37de" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="ef22-6a09-5d29-d37f" name="MB3 Recon Drone" hidden="false" targetId="b44f-3991-99c6-f72b" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d052-253c-862d-6a0f" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d052-253c-862d-6a0f" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -164,6 +152,13 @@
       <categoryLinks>
         <categoryLink id="9fe4-7e1c-8395-badd" name="New CategoryLink" hidden="false" targetId="f98b-0289-0f1f-b233" primary="true"/>
       </categoryLinks>
+      <profiles>
+        <profile name="Focused EMP Override" typeId="f52d-76ec-b279-093b" typeName="Abilities" hidden="false" id="61cd-1a8c-ae32-33ea">
+          <characteristics>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">If this operative is in the killzone, friendly DRONE operatives can perform the Operate Hatch action (ignore the first bullet point of Artificial Intelligence to do so).</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
     </entryLink>
     <entryLink id="1d79-ee72-b5f8-c945" name="Weapons Expert Pathfinder" hidden="false" collective="false" import="true" targetId="ed2e-621f-02a0-9659" type="selectionEntry">
       <categoryLinks>
@@ -261,8 +256,8 @@
       <selectionEntries>
         <selectionEntry id="e580-8c09-4000-ee4b" name="Bonding knife" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0f1-1bae-fcdd-df4d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44c1-5bc6-eda0-3b70" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0f1-1bae-fcdd-df4d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44c1-5bc6-eda0-3b70" type="max"/>
           </constraints>
           <profiles>
             <profile id="597c-b0c8-6001-0c06" name="⚔ Bonding knife" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -279,7 +274,7 @@
             <infoLink id="1b0b-552f-ab0d-2977" name="Balanced" hidden="false" targetId="547c-e6e5-64d4-a519" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -288,12 +283,12 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="f810-2a42-1eb3-67fc" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="f810-2a42-1eb3-67fc" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9f5-a502-b352-1576" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9f5-a502-b352-1576" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="8983-84e9-b46a-2b56" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry"/>
@@ -328,20 +323,20 @@
         <entryLink id="d1bb-3893-07b3-9f56" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="421f-f3af-2c42-34fc" name="Pulse carbine" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ca4-86fd-6a57-2c36" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="598d-8e07-3c2d-9224" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ca4-86fd-6a57-2c36" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="598d-8e07-3c2d-9224" type="max"/>
       </constraints>
       <profiles>
         <profile id="b3eb-9ac5-cc2a-7cf6" name="⌖ Pulse carbine" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
           <modifiers>
             <modifier type="set" field="32b4-9a0e-e740-6031" value="3+">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bd2-268c-8eec-fdf6" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bd2-268c-8eec-fdf6" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -355,7 +350,7 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c72a-32d9-fe32-24c4" name="Reference - Markerlights" hidden="false" collective="false" import="true" type="upgrade">
@@ -394,7 +389,7 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d690-33e9-ec16-933b" name="Reference - Art of War" hidden="false" collective="false" import="true" type="upgrade">
@@ -411,27 +406,27 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3f4a-4246-779e-51c8" name="Pathfinder 1 - For the Greater Good" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7b0-00ac-a763-fe90" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7b0-00ac-a763-fe90" type="max"/>
       </constraints>
       <profiles>
         <profile id="b8f8-cfa3-236f-a104" name="For the Greater Good" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
           <characteristics>
-            <characteristic name="Battle Honour" typeId="0ca9-09c1-318a-cc7b">This operative can perform the Markerlight action twice during its activation. In addition, when this operative is incapacitated, it can perform a free Markerlight action, even if it is within Engagement Range of an enemy operative. If this operative cannot perform the Markerlight action, determine a different Battle Honour for it. </characteristic>
+            <characteristic name="Battle Honour" typeId="0ca9-09c1-318a-cc7b">This operative can perform the Markerlight action twice during its activation. In addition, when this operative is incapacitated, it can perform a free Markerlight action, even if it is within Engagement Range of an enemy operative. If this operative cannot perform the Markerlight action, determine a different Battle Honour for it.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c5bf-1300-bb1f-b3a6" name="Pathfinder 2 - Reliant Support" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e95-cebc-7578-ef5f" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e95-cebc-7578-ef5f" type="max"/>
       </constraints>
       <profiles>
         <profile id="3cca-c5bf-d1ea-013a" name="Reliant Support" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -441,12 +436,12 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bad2-07c1-af8d-5fce" name="Pathfinder 3 - Cunning Hunter" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fe9-a129-0e83-8a4e" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fe9-a129-0e83-8a4e" type="max"/>
       </constraints>
       <profiles>
         <profile id="084e-e8ce-ecc2-f1b9" name="Cunning Hunter" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -456,12 +451,12 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7d92-cd69-4f1a-50a5" name="Pathfinder 4 - Merciless Hunter" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4943-5234-794f-388a" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4943-5234-794f-388a" type="max"/>
       </constraints>
       <profiles>
         <profile id="c56a-b430-2e26-117f" name="Merciless Hunter" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -471,12 +466,12 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e35a-54fb-ae16-ac1e" name="Pathfinder 5 - Martial Philosopher" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b43-9fbf-da25-8252" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b43-9fbf-da25-8252" type="max"/>
       </constraints>
       <profiles>
         <profile id="ead0-55fc-2a3d-533e" name="Martial Philosopher" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -486,12 +481,12 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d920-19e2-bc81-cb3d" name="Pathfinder 6 - Capable Under Fire" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b284-d917-50dc-10d1" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b284-d917-50dc-10d1" type="max"/>
       </constraints>
       <profiles>
         <profile id="4428-67ef-c893-3690" name="Capable Under Fire" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -501,7 +496,7 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="be32-7240-8245-a05f" name="Shas&apos;la Pathfinder" hidden="false" collective="false" import="true" type="model">
@@ -519,12 +514,12 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5768-3685-e715-3dcf" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5768-3685-e715-3dcf" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="5d8f-479b-f540-df7f" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry"/>
@@ -560,13 +555,13 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
         <entryLink id="fa9e-246a-72ce-c260" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="211e-8056-1d46-0686" name="Fists" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bf9-27e8-91ca-010e" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73e8-c409-f53a-d200" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bf9-27e8-91ca-010e" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73e8-c409-f53a-d200" type="max"/>
       </constraints>
       <profiles>
         <profile id="cca8-b6b5-c061-e4c3" name="⚔ Fists" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -580,7 +575,7 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d53b-769d-268b-cf25" name="Blooded Pathfinder" hidden="false" collective="false" import="true" type="model">
@@ -607,8 +602,8 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
       <selectionEntries>
         <selectionEntry id="fb21-bbf4-aa32-3b07" name="Bionic arm" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad94-7128-0372-ea94" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1835-29b4-5b11-a953" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad94-7128-0372-ea94" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1835-29b4-5b11-a953" type="max"/>
           </constraints>
           <profiles>
             <profile id="e0bd-67d1-f192-2698" name="⚔ Bionic arm" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -622,13 +617,13 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0360-a69f-ad95-ba22" name="Suppressed pulse carbine" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb4e-d9f8-b137-6e70" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a260-b1db-3517-fd45" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb4e-d9f8-b137-6e70" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a260-b1db-3517-fd45" type="max"/>
           </constraints>
           <profiles>
             <profile id="34ab-4a71-caf3-738e" name="⌖ Suppressed pulse carbine" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -642,7 +637,7 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -651,12 +646,12 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="d53b-769d-268b-cf25" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="d53b-769d-268b-cf25" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2034-97a6-ebd2-48c4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2034-97a6-ebd2-48c4" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="94a4-b39f-6422-8cc3" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry"/>
@@ -701,7 +696,7 @@ Each time a friendly PATHFINDER operative makes a shooting attack, it gains a nu
         <entryLink id="da6c-d043-88b5-bd07" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="99ec-8071-9b47-3c2d" name="Drone Controller Pathfinder" hidden="false" collective="false" import="true" type="model">
@@ -740,12 +735,12 @@ This operative cannot perform this action if it is within Engagement Range of an
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5681-1d53-dcc6-5871" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5681-1d53-dcc6-5871" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="fbfe-2ac7-7601-a80e" name="Staunch" hidden="false" collective="false" import="true" targetId="eb50-055a-4cd2-e1d5" type="selectionEntry"/>
@@ -781,7 +776,7 @@ This operative cannot perform this action if it is within Engagement Range of an
         <entryLink id="a5f8-a67c-792b-47b0" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2b20-a1a7-f9b4-fe8b" name="Transpectral Interference Pathfinder" hidden="false" collective="false" import="true" type="model">
@@ -815,12 +810,12 @@ This operative cannot perform this action if it is within Engagement Range of an
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8897-8b09-63fc-1545" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8897-8b09-63fc-1545" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="2683-e97c-6a5a-e39d" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry"/>
@@ -856,7 +851,7 @@ This operative cannot perform this action if it is within Engagement Range of an
         <entryLink id="683b-8e99-e383-26c4" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="97a4-eba8-936b-a6b2" name="Assault Grenadier Pathfinder" hidden="false" collective="false" import="true" type="model">
@@ -890,12 +885,12 @@ This operative cannot perform this action if it is within Engagement Range of an
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce52-a1e2-4e90-ee5e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce52-a1e2-4e90-ee5e" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="b9de-16dd-f7f5-6904" name="Staunch" hidden="false" collective="false" import="true" targetId="eb50-055a-4cd2-e1d5" type="selectionEntry"/>
@@ -930,29 +925,29 @@ This operative cannot perform this action if it is within Engagement Range of an
         <entryLink id="e670-04bb-58fe-f86a" name="Fists" hidden="false" collective="false" import="true" targetId="211e-8056-1d46-0686" type="selectionEntry"/>
         <entryLink id="5f12-3503-9127-11a1" name="EMP grenade" hidden="false" collective="false" import="true" targetId="7548-4ef8-745a-7772" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69a8-c70a-c27d-fe0c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69a8-c70a-c27d-fe0c" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="56c9-8705-ddda-14d4" name="Photon grenades" hidden="false" collective="false" import="true" targetId="0aed-a104-88c1-6e3e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba19-b6ef-ca21-c820" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba19-b6ef-ca21-c820" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="bceb-8a0a-91e8-db6e" name="Fusion grenades" hidden="false" collective="false" import="true" targetId="6552-81bf-a748-4431" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1afc-5ee5-49dc-d1b8" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1afc-5ee5-49dc-d1b8" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="5603-8da6-c8f8-cad1" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6552-81bf-a748-4431" name="Fusion Grenade" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1e9-025e-c575-a435" type="max"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6479-6ed8-d25b-1486" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1e9-025e-c575-a435" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6479-6ed8-d25b-1486" type="max"/>
       </constraints>
       <profiles>
         <profile id="d6f0-8292-b7b9-457d" name="Fusion grenade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -973,12 +968,12 @@ This operative cannot perform this action if it is within Engagement Range of an
         <infoLink id="f3d5-160c-2ce6-831a" name="MWx" hidden="false" targetId="0d4b-7a76-d266-bcc1" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0aed-a104-88c1-6e3e" name="Photon Grenade" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7e6-a692-8462-3748" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7e6-a692-8462-3748" type="max"/>
       </constraints>
       <profiles>
         <profile id="e579-6ce8-563f-2c23" name="Photon Grenade (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -992,13 +987,13 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7548-4ef8-745a-7772" name="EMP Grenade" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ea-4d8e-46ec-83d4" type="max"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ec4-5dc6-9529-40d0" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ea-4d8e-46ec-83d4" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ec4-5dc6-9529-40d0" type="max"/>
       </constraints>
       <profiles>
         <profile id="0f9b-351b-cf4d-83c5" name="EMP grenade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1023,7 +1018,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <infoLink id="7a5d-bba9-ace1-d292" name="Limited" hidden="false" targetId="1eb0-6ad3-3e5a-d8ec" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dd21-a771-1f5a-e066" name="Communications Specialist Pathfinder" hidden="false" collective="false" import="true" type="model">
@@ -1052,12 +1047,12 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3008-79da-9919-bfba" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3008-79da-9919-bfba" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="577e-122d-0beb-d441" name="Scout" hidden="false" collective="false" import="true" targetId="9118-a98b-0ffe-9e3d" type="selectionEntry"/>
@@ -1082,7 +1077,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <entryLink id="ed04-28dd-b348-73ad" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8c4e-c7ab-558a-1eff" name="Medical Technician Pathfinder" hidden="false" collective="false" import="true" type="model">
@@ -1117,12 +1112,12 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c698-122f-3b9e-fa60" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c698-122f-3b9e-fa60" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="577c-ff51-324f-d5c1" name="Scout" hidden="false" collective="false" import="true" targetId="9118-a98b-0ffe-9e3d" type="selectionEntry"/>
@@ -1158,7 +1153,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <entryLink id="5e1f-38ab-7437-8b90" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ed2e-621f-02a0-9659" name="Weapons Expert Pathfinder" hidden="false" collective="false" import="true" type="model">
@@ -1179,12 +1174,12 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5cf-201e-3522-1422" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5cf-201e-3522-1422" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="b2ab-ba7c-1e66-9b46" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry"/>
@@ -1192,8 +1187,8 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         </selectionEntryGroup>
         <selectionEntryGroup id="749d-21be-99b8-3205" name="Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5386-b290-32f2-5d61" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="359d-6783-dd54-cb42" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5386-b290-32f2-5d61" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="359d-6783-dd54-cb42" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="c402-3bd7-a12c-aaae" name="Rail rifle" hidden="false" collective="false" import="true" type="upgrade">
@@ -1214,7 +1209,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
                 <infoLink id="36c3-52de-fc52-37da" name="MWx" hidden="false" targetId="0d4b-7a76-d266-bcc1" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2434-3658-5e2f-1c2e" name="Ion rifle" hidden="false" collective="false" import="true" type="upgrade">
@@ -1233,7 +1228,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
                     <characteristic name="A" typeId="5f37-25bb-661b-5c9c">5</characteristic>
                     <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">4+</characteristic>
                     <characteristic name="D" typeId="337a-2e5b-e4e3-f489">5/6</characteristic>
-                    <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">AP1, Hot	</characteristic>
+                    <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">AP1, Hot</characteristic>
                     <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
                   </characteristics>
                 </profile>
@@ -1244,7 +1239,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
                 <infoLink id="4229-b556-7da8-b2fd" name="Hot" hidden="false" targetId="83c3-fce7-8ac1-9872" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1267,7 +1262,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <entryLink id="ea09-3486-adbf-5597" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e7b4-da2d-bab3-5ba6" name="Marksman Pathfinder" hidden="false" collective="false" import="true" type="model">
@@ -1293,8 +1288,8 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
       <selectionEntries>
         <selectionEntry id="4aa3-e15d-a8c5-27fe" name="Marksman rail rifle" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="446e-7903-6479-2c2a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4b3-ffc1-ee1b-a4b5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="446e-7903-6479-2c2a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4b3-ffc1-ee1b-a4b5" type="max"/>
           </constraints>
           <profiles>
             <profile id="ced7-84fa-918a-75fc" name="⌖ Marksman rail rifle - Standard" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1323,7 +1318,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             <infoLink id="6c1e-c3a7-d873-aef8" name="MWx" hidden="false" targetId="0d4b-7a76-d266-bcc1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1332,12 +1327,12 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0207-cf48-5f84-daea" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0207-cf48-5f84-daea" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="6a53-2fe5-0a9b-a9b0" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry"/>
@@ -1361,7 +1356,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <entryLink id="88ea-03d0-5200-88b8" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3d0f-31ba-0ed9-e72a" name="MB3 Recon Drone" hidden="false" collective="false" import="true" type="model">
@@ -1400,8 +1395,8 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
       <selectionEntries>
         <selectionEntry id="a1d1-14c3-f7af-358d" name="Burst cannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0db6-9a5c-f32d-1bd0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a53-aff1-0d48-1c87" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0db6-9a5c-f32d-1bd0" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a53-aff1-0d48-1c87" type="max"/>
           </constraints>
           <profiles>
             <profile id="8e86-b045-19c2-a075" name="Burst cannon" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1420,7 +1415,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             <infoLink id="559a-fcc7-242d-8479" name="Fusillade" hidden="false" targetId="e2ae-574a-94ab-3550" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1429,12 +1424,12 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f24-b043-af85-d91b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f24-b043-af85-d91b" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="d65d-b91e-48ae-1684" name="Staunch" hidden="false" collective="false" import="true" targetId="eb50-055a-4cd2-e1d5" type="selectionEntry"/>
@@ -1480,20 +1475,20 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <entryLink id="0c1d-6479-4899-315a" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3f54-555b-db29-90f2" name="Ram" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac70-c339-0cc3-1c62" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a8b-abed-d328-e0ee" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac70-c339-0cc3-1c62" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a8b-abed-d328-e0ee" type="max"/>
       </constraints>
       <profiles>
         <profile id="1461-0a61-d8bb-2ecb" name="⚔ Ram" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
           <modifiers>
             <modifier type="set" field="337a-2e5b-e4e3-f489" value="3/4">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b44f-3991-99c6-f72b" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b44f-3991-99c6-f72b" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1507,7 +1502,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2472-ac00-0203-3720" name="MV1 Gun Drone" hidden="false" collective="false" import="true" type="model">
@@ -1536,8 +1531,8 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
       <selectionEntries>
         <selectionEntry id="0100-c03b-5edf-baa6" name="Twin pulse carbine" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e40-5de4-5fa6-0af3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="240c-a53c-9478-3064" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e40-5de4-5fa6-0af3" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="240c-a53c-9478-3064" type="max"/>
           </constraints>
           <profiles>
             <profile id="80b7-be53-8c38-9979" name="Twin pulse carbine" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1554,7 +1549,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             <infoLink id="919d-592b-73e5-d5ba" name="Relentless" hidden="false" targetId="1875-9b07-2a07-aacc" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1563,12 +1558,12 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1f2-25f1-f2d7-cb2d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1f2-25f1-f2d7-cb2d" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="d45a-3b37-37d1-5678" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry"/>
@@ -1592,7 +1587,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <entryLink id="49b6-0023-e936-4119" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="75a5-d8a6-64ee-d989" name="MV4 Shield Drone" hidden="false" collective="false" import="true" type="model">
@@ -1628,12 +1623,12 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0937-0cc8-4ea3-7acc" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0937-0cc8-4ea3-7acc" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="0f16-aea5-9568-b9ac" name="Staunch" hidden="false" collective="false" import="true" targetId="eb50-055a-4cd2-e1d5" type="selectionEntry"/>
@@ -1657,7 +1652,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <entryLink id="ceae-b1ac-aa45-f8e9" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a8b5-a818-362b-8c75" name="MV7 Marker Drone" hidden="false" collective="false" import="true" type="model">
@@ -1694,12 +1689,12 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c475-1e29-bad3-8b71" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c475-1e29-bad3-8b71" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="03a5-7f31-c1b9-3548" name="Staunch" hidden="false" collective="false" import="true" targetId="eb50-055a-4cd2-e1d5" type="selectionEntry"/>
@@ -1734,7 +1729,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <entryLink id="196b-faa5-2e05-648b" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c215-e7f9-986f-273d" name="MV31 Pulse Accelerator Drone" hidden="false" collective="false" import="true" type="model">
@@ -1770,12 +1765,12 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd68-5c1f-0f13-df4f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd68-5c1f-0f13-df4f" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="ce0b-c2dd-e449-8c0b" name="Staunch" hidden="false" collective="false" import="true" targetId="eb50-055a-4cd2-e1d5" type="selectionEntry"/>
@@ -1810,7 +1805,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <entryLink id="bc9d-7d31-9edf-3b06" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9d70-5307-4f09-4053" name="MV33 Grav-inhibitor Drone" hidden="false" collective="false" import="true" type="model">
@@ -1827,7 +1822,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         </profile>
         <profile id="0618-1cb2-136d-e434" name="Grav-inhibitor" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
           <characteristics>
-            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time an enemy operative performs a Charge action, if it would move within ⬟ of this operative, only add ▲ to the additional distance it can move, instead of ⬤. Each time an enemy operative performs a Dash action, if it would move within ⬟ of this operative, it can only move up to ⬤, instead of up to ⬛. </characteristic>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time an enemy operative performs a Charge action, if it would move within ⬟ of this operative, only add ▲ to the additional distance it can move, instead of ⬤. Each time an enemy operative performs a Dash action, if it would move within ⬟ of this operative, it can only move up to ⬤, instead of up to ⬛.</characteristic>
           </characteristics>
         </profile>
         <profile id="db5d-6809-8297-1733" name="Grav Wave (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -1851,12 +1846,12 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80f8-c41a-ccb7-fea8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80f8-c41a-ccb7-fea8" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="b98c-588a-11fc-bfa1" name="Staunch" hidden="false" collective="false" import="true" targetId="eb50-055a-4cd2-e1d5" type="selectionEntry"/>
@@ -1891,7 +1886,7 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
         <entryLink id="f2c4-97a9-b5b4-31c5" name="Equipment" hidden="false" collective="false" import="true" targetId="7784-0737-ca59-f234" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -1900,34 +1895,34 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="43e5-75bb-298d-bec2" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="43e5-75bb-298d-bec2" type="notInstanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="c61a-51a3-370d-bf55" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0174-b1c1-c052-0021" type="max"/>
+        <constraint field="c61a-51a3-370d-bf55" scope="roster" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0174-b1c1-c052-0021" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="f3a0-83b8-c115-2c57" name="Target Analysis Optic" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31be-2ec6-00c8-615a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31be-2ec6-00c8-615a" type="max"/>
           </constraints>
           <profiles>
             <profile id="b7c8-f3be-d56b-5971" name="Target Analysis" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1937,19 +1932,19 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8114-e688-b594-fd2b" name="High-intensity Markerlight" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e90-2b17-964b-43a5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e90-2b17-964b-43a5" type="max"/>
           </constraints>
           <profiles>
             <profile id="0394-2502-9ac1-f41a" name="High-intensity Markerlight" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1959,20 +1954,20 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3e83-b6ab-6308-e165" name="Orbital Survey Uplink*" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89e9-df4a-3023-71b1" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f12-7242-5b34-f7e7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89e9-df4a-3023-71b1" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f12-7242-5b34-f7e7" type="max"/>
           </constraints>
           <profiles>
             <profile id="4835-78b9-ff6a-db79" name="Orbital Scan (2AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -1982,19 +1977,19 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="046d-abb9-fee8-06a9" name="Drone Repair Kit" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="affb-b6e7-9894-1c5f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="affb-b6e7-9894-1c5f" type="max"/>
           </constraints>
           <profiles>
             <profile id="60b7-90e6-485c-e30b" name="Repair Drone (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -2004,19 +1999,19 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3a41-a0b7-fa8f-9775" name="Climbing Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1094-ff0c-00f8-f58d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1094-ff0c-00f8-f58d" type="max"/>
           </constraints>
           <profiles>
             <profile id="cc0d-0ead-2192-f246" name="Climbing Equipment" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -2029,25 +2024,25 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="69b6-8c35-f947-4bbf" name="Experimental Pulse Ammunition (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50e1-d538-b03c-fbd0" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5411-ccef-319f-3382" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50e1-d538-b03c-fbd0" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5411-ccef-319f-3382" type="max"/>
           </constraints>
           <profiles>
             <profile id="74c4-493c-dce5-6ab0" name="Experimental Pulse Ammunition" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -2059,30 +2054,30 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fff6-a21b-fb1f-2de7" name="Honour Blade (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bd2-268c-8eec-fdf6" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bd2-268c-8eec-fdf6" type="notInstanceOf"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbbd-c2e0-b024-b5bc" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d50a-5053-d086-4e50" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbbd-c2e0-b024-b5bc" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d50a-5053-d086-4e50" type="max"/>
           </constraints>
           <profiles>
             <profile id="1c59-bf7b-d78b-3667" name="Honour Blade" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -2094,25 +2089,25 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e88a-3940-255f-3864" name="Shield Generator (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1998-df5f-d589-e1ed" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a704-8943-4430-8070" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1998-df5f-d589-e1ed" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a704-8943-4430-8070" type="max"/>
           </constraints>
           <profiles>
             <profile id="f9e4-401e-4684-c15c" name="Shield Generator" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -2122,25 +2117,25 @@ On a 2+, that enemy operative gains a Photon token. While an operative has any P
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f17d-ee11-5e33-2cdf" name="Markerlight Grenade (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="633a-68f1-df3e-32fa" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6cd8-7099-22ae-2da9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="633a-68f1-df3e-32fa" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6cd8-7099-22ae-2da9" type="max"/>
           </constraints>
           <profiles>
             <profile id="2ebd-4f53-01dc-1606" name="Markerlight Grenade (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -2154,25 +2149,25 @@ On a 2+, that enemy operative gains 1 Markerlight token.</characteristic>
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6590-3f55-f976-3894" name="Projection Field (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bc8-607c-7582-8f8b" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78e2-21ad-ba77-1669" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bc8-607c-7582-8f8b" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78e2-21ad-ba77-1669" type="max"/>
           </constraints>
           <profiles>
             <profile id="ce32-6c0a-08c9-125e" name="Projection Field (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -2182,25 +2177,25 @@ On a 2+, that enemy operative gains 1 Markerlight token.</characteristic>
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d11a-9944-3988-d600" name="Advanced Cogitation Chip (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="notInstanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83ce-29e4-3c31-cb93" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="97b4-0fa3-0bbb-62c7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83ce-29e4-3c31-cb93" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="97b4-0fa3-0bbb-62c7" type="max"/>
           </constraints>
           <profiles>
             <profile id="2466-17e1-6b70-0d79" name="Advanced Cogitation Chip" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -2211,7 +2206,7 @@ On a 2+, that enemy operative gains 1 Markerlight token.</characteristic>
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2220,36 +2215,36 @@ On a 2+, that enemy operative gains 1 Markerlight token.</characteristic>
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="4.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="4"/>
           </costs>
         </entryLink>
         <entryLink id="e9ee-beec-305d-73ee" name="EMP Grenade" hidden="false" collective="false" import="true" targetId="7548-4ef8-745a-7772" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </entryLink>
         <entryLink id="854c-7609-2445-02c9" name="Photon Grenade" hidden="false" collective="false" import="true" targetId="0aed-a104-88c1-6e3e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c5c1-db85-5269-3c3c" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </entryLink>
         <entryLink id="508c-1e2c-63cf-2622" name="Melee Weapons Rare Equipment" hidden="false" collective="false" import="true" targetId="d419-7a47-04c4-e1d9" type="selectionEntryGroup"/>
@@ -2277,7 +2272,7 @@ On a 2+, that enemy operative gains 1 Markerlight token.</characteristic>
         <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">⬛</characteristic>
         <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">⬟</characteristic>
         <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">⌖ 
-⚔ </characteristic>
+⚔</characteristic>
         <characteristic name="W" typeId="db11-738c-048c-759e">💀</characteristic>
       </characteristics>
     </profile>

--- a/2021 - Wyrmblade.cat
+++ b/2021 - Wyrmblade.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="381a-c69a-a399-fbbc" name="Wyrmblade" revision="4" battleScribeVersion="2.03" authorName="Mad-Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="381a-c69a-a399-fbbc" name="Wyrmblade" revision="5" battleScribeVersion="2.03" authorName="Mad-Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="a223-4c7f-7c64-cdd1" name="Cult Agent" hidden="false"/>
     <categoryEntry id="06d8-a7f8-589c-a573" name="WYRMBLADE" hidden="false"/>
@@ -20,61 +20,61 @@
         <categoryLink id="e4e6-cdc8-0854-dd0d" name="Configuration" hidden="false" targetId="fb89-efb1-54e4-59c5" primary="false"/>
         <categoryLink id="a0a5-ef94-2b42-ddea" name="Leader" hidden="false" targetId="3198-c1ce-dfd0-fb4f" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e09-596f-ceed-5593" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="101e-b892-7ea4-eac0" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e09-596f-ceed-5593" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="101e-b892-7ea4-eac0" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d1b6-bd33-3dd5-fac2" name="Operative" hidden="false" targetId="f98b-0289-0f1f-b233" primary="false">
           <modifiers>
-            <modifier type="decrement" field="ea35-981f-385f-e07d" value="1.0">
+            <modifier type="decrement" field="ea35-981f-385f-e07d" value="1">
               <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a223-4c7f-7c64-cdd1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a223-4c7f-7c64-cdd1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="decrement" field="6a7b-a14d-a0cd-f3b0" value="1.0">
+            <modifier type="decrement" field="6a7b-a14d-a0cd-f3b0" value="1">
               <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a223-4c7f-7c64-cdd1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a223-4c7f-7c64-cdd1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="roster" value="13.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea35-981f-385f-e07d" type="max"/>
-            <constraint field="selections" scope="roster" value="13.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a7b-a14d-a0cd-f3b0" type="min"/>
+            <constraint field="selections" scope="roster" value="13" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea35-981f-385f-e07d" type="max"/>
+            <constraint field="selections" scope="roster" value="13" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a7b-a14d-a0cd-f3b0" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="501d-b7e0-a348-4d06" name="Cult Agent" hidden="false" targetId="a223-4c7f-7c64-cdd1" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="992f-87a3-393e-bad2" type="max"/>
+            <constraint field="selections" scope="roster" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="992f-87a3-393e-bad2" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d331-dcf7-1cf2-2c50" name="Heavy Gunner" hidden="false" targetId="0e59-07ae-65c2-2de6" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a43-053a-f215-3be9" type="max"/>
+            <constraint field="selections" scope="roster" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a43-053a-f215-3be9" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="f7b3-f752-3f88-111e" name="Gunner" hidden="false" targetId="ee8c-cc44-acc3-40f0" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7611-d5b7-f20a-6d0d" type="max"/>
+            <constraint field="selections" scope="roster" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7611-d5b7-f20a-6d0d" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="75e4-05b0-d93c-50b8" name="Icon Bearer" hidden="false" targetId="a59e-d71c-0bbb-2c70" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fef0-d607-0145-abc3" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fef0-d607-0145-abc3" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="ed25-cc4a-dddc-c520" name="Kelermorph" hidden="false" targetId="fd19-9eca-1c6d-a23b" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a58c-2143-a235-f1af" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a58c-2143-a235-f1af" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="756f-eee2-8c82-a57e" name="Sniper" hidden="false" targetId="7d9c-7959-e70e-a4a4" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c61f-d937-ed53-8ed0" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c61f-d937-ed53-8ed0" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7dc1-0880-e2d9-9995" name="Talon" hidden="false" targetId="5ff2-784e-8398-59ad" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d37d-6c0a-5373-8afe" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d37d-6c0a-5373-8afe" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -101,13 +101,13 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="0eb6-e21b-2cf4-470b" name="Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b966-8fd4-81fc-4175" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a359-7715-187b-94c3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b966-8fd4-81fc-4175" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a359-7715-187b-94c3" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="a5f5-faec-a5b9-8ca9" name="Seismic cannon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03f5-b53f-5fea-9f1b" type="max"/>
+                <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03f5-b53f-5fea-9f1b" type="max"/>
               </constraints>
               <profiles>
                 <profile id="f0ad-5ca4-b103-bc24" name="Seismic cannon - Long-wave" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -137,12 +137,12 @@
                 <infoLink id="ce84-8d8e-ef4f-d033" name="Blast x" hidden="false" targetId="d848-be09-6d6d-4708" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5e94-1634-cb1b-3f4e" name="Mining laser" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da04-de55-a2cb-82b1" type="max"/>
+                <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da04-de55-a2cb-82b1" type="max"/>
               </constraints>
               <profiles>
                 <profile id="1814-1dcc-63aa-8f77" name="⌖ Mining laser" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -160,7 +160,7 @@
                 <infoLink id="8524-fa0a-17fc-7eda" name="Heavy" hidden="false" targetId="1e77-6974-cf90-6008" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -172,7 +172,7 @@
       <entryLinks>
         <entryLink id="871e-d60d-7197-22b8" name="Gun butt" hidden="false" collective="false" import="true" targetId="cf40-531a-78c0-2384" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf6f-452c-d0d1-a4c7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf6f-452c-d0d1-a4c7" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="6a99-2d56-b829-0134" name="XP" hidden="false" collective="false" import="true" targetId="82af-b9b8-518f-aaf1" type="selectionEntry"/>
@@ -201,8 +201,15 @@
         <entryLink id="3d7e-b8df-bb18-e08b" name="Equipment" hidden="false" collective="false" import="true" targetId="2d37-d872-4dc9-ebc6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
+      <profiles>
+        <profile name="Suspensor System" typeId="f52d-76ec-b279-093b" typeName="Abilities" hidden="false" id="d811-d702-6b8a-7a48">
+          <characteristics>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">The Heavy special rule of ranged weapons the operative is equipped with is treated differently. Instead, an operative cannot move more than 3⬤ in the same activation in which it performs a Shoot action with any of those ranged weapons.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
     </selectionEntry>
     <selectionEntry id="e635-5406-aa1d-865b" name="Neophyte Icon Bearer" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -236,8 +243,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="33a8-830c-17bf-7db4" name="Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8758-e776-df77-a26a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20c1-b259-02c4-d450" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8758-e776-df77-a26a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20c1-b259-02c4-d450" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="357f-fa99-9858-76ea" name="Autogun" hidden="false" collective="false" import="true" targetId="b8df-5ac2-b786-d771" type="selectionEntry"/>
@@ -248,7 +255,7 @@
       <entryLinks>
         <entryLink id="8da3-e778-b826-aa97" name="Gun butt" hidden="false" collective="false" import="true" targetId="cf40-531a-78c0-2384" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6e1-1297-b82e-a9c6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6e1-1297-b82e-a9c6" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="73db-eab6-2d75-fe7e" name="XP" hidden="false" collective="false" import="true" targetId="82af-b9b8-518f-aaf1" type="selectionEntry"/>
@@ -267,7 +274,7 @@
         <entryLink id="4502-21bf-7775-46d4" name="Equipment" hidden="false" collective="false" import="true" targetId="2d37-d872-4dc9-ebc6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d7d2-511a-24c8-b727" name="Neophyte Brood Adept" hidden="false" collective="false" import="true" type="model">
@@ -297,8 +304,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="882b-5499-37cf-b89f" name="Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51a6-72c7-bd2e-a9e8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e29-f750-459c-3a37" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51a6-72c7-bd2e-a9e8" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e29-f750-459c-3a37" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="6a19-4141-07e3-549a" name="Autogun" hidden="false" collective="false" import="true" targetId="b8df-5ac2-b786-d771" type="selectionEntry"/>
@@ -309,7 +316,7 @@
       <entryLinks>
         <entryLink id="74e5-55aa-4378-e920" name="Gun butt" hidden="false" collective="false" import="true" targetId="cf40-531a-78c0-2384" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6af8-5cb6-7a61-20d1" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6af8-5cb6-7a61-20d1" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="87fa-e97f-b964-bb5d" name="XP" hidden="false" collective="false" import="true" targetId="82af-b9b8-518f-aaf1" type="selectionEntry"/>
@@ -338,7 +345,7 @@
         <entryLink id="e25d-b612-1be1-1384" name="Equipment" hidden="false" collective="false" import="true" targetId="2d37-d872-4dc9-ebc6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a726-5aba-8391-24aa" name="Neophyte Gunner" hidden="false" collective="false" import="true" type="model">
@@ -361,13 +368,13 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="ea6d-d201-cd87-a9c8" name="Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdf2-cb9b-2851-2816" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c844-27e3-a858-b206" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdf2-cb9b-2851-2816" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c844-27e3-a858-b206" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="bb2a-8e9c-2278-f8cf" name="Flamer" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f313-f00d-8f6e-b924" type="max"/>
+                <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f313-f00d-8f6e-b924" type="max"/>
               </constraints>
               <profiles>
                 <profile id="9c28-1a23-b23f-854f" name="⌖ Flamer" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -385,12 +392,12 @@
                 <infoLink id="d364-d727-05e5-07c3" name="Torrent x" hidden="false" targetId="ec4b-2d70-51a7-5653" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4573-0ff3-d503-ac2b" name="Grenade launcher" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8dfe-0ccc-127a-6be7" type="max"/>
+                <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8dfe-0ccc-127a-6be7" type="max"/>
               </constraints>
               <profiles>
                 <profile id="89ef-a894-ed62-ced7" name="⌖ Grenade launcher - Frag" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -417,12 +424,12 @@
                 <infoLink id="d31d-5b52-aae7-1603" name="APx" hidden="false" targetId="db98-339e-d0a2-e042" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7992-6827-cd78-7464" name="Webber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ae4-dfd6-e99e-2c25" type="max"/>
+                <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ae4-dfd6-e99e-2c25" type="max"/>
               </constraints>
               <profiles>
                 <profile id="b2dd-ad0a-9110-3e71" name="⌖ Webber" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -441,7 +448,7 @@
                 <infoLink id="85d0-db52-b28b-16e3" name="Stun" hidden="false" targetId="a1e3-4e0b-f7c2-eb59" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -450,7 +457,7 @@
       <entryLinks>
         <entryLink id="8113-c88f-d13c-208a" name="Gun butt" hidden="false" collective="false" import="true" targetId="cf40-531a-78c0-2384" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="490c-196b-9948-2abd" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="490c-196b-9948-2abd" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="ba9d-d3b4-40d7-e740" name="XP" hidden="false" collective="false" import="true" targetId="82af-b9b8-518f-aaf1" type="selectionEntry"/>
@@ -479,7 +486,7 @@
         <entryLink id="4f39-8e35-c60e-e4da" name="Equipment" hidden="false" collective="false" import="true" targetId="2d37-d872-4dc9-ebc6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2edc-c059-43a4-de5d" name="Neophyte Leader w/ ranged weapon" hidden="false" collective="false" import="true" type="model">
@@ -513,8 +520,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="f007-4cfd-368c-3505" name="Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c96-6930-c018-4bcc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca7d-a9ff-b3ea-d3b9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c96-6930-c018-4bcc" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca7d-a9ff-b3ea-d3b9" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="29c4-a0d8-5bc1-5b2e" name="Autogun" hidden="false" collective="false" import="true" targetId="b8df-5ac2-b786-d771" type="selectionEntry"/>
@@ -558,13 +565,13 @@
         <entryLink id="c729-38d8-28bd-208f" name="Specialism" hidden="false" collective="false" import="true" targetId="6bd1-70ea-ca66-03ed" type="selectionEntryGroup"/>
         <entryLink id="3c9a-4b7b-99ae-8db5" name="Gun butt" hidden="false" collective="false" import="true" targetId="cf40-531a-78c0-2384" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ba9-efc6-9299-854a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ba9-efc6-9299-854a" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="e091-9426-60e1-08d9" name="Equipment" hidden="false" collective="false" import="true" targetId="2d37-d872-4dc9-ebc6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="697b-e076-d404-c947" name="Neophyte Leader w/ pistol and melee weapon" hidden="false" collective="false" import="true" type="model">
@@ -598,8 +605,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="3b17-b211-7907-6b55" name="Pistol" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7a8-8489-40ab-51da" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8081-e780-4710-b49c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7a8-8489-40ab-51da" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8081-e780-4710-b49c" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="7ac1-3cfd-9e95-f518" name="Master-crafted autopistol" hidden="false" collective="false" import="true" type="upgrade">
@@ -620,7 +627,7 @@
                 <infoLink id="a199-3640-1319-ef21" name="Lethal x" hidden="false" targetId="be29-25db-e215-b3b0" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="68a8-673b-e8d6-3bb8" name="Web pistol" hidden="false" collective="false" import="true" type="upgrade">
@@ -640,7 +647,7 @@
                 <infoLink id="01d8-7abc-6fcc-f188" name="Stun" hidden="false" targetId="a1e3-4e0b-f7c2-eb59" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5804-3167-8476-1f9a" name="Bolt pistol" hidden="false" collective="false" import="true" type="upgrade">
@@ -659,15 +666,15 @@
                 <infoLink id="1238-97fb-1678-a710" name="Rng x" hidden="false" targetId="92de-2ad3-3554-0b3e" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="b5cd-5c69-e83f-a670" name="Melee weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb7f-0fbb-b287-75cd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bf4-016d-d759-8b8e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb7f-0fbb-b287-75cd" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bf4-016d-d759-8b8e" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="8ac5-6cea-967b-8e3c" name="Chainsword" hidden="false" collective="false" import="true" type="upgrade">
@@ -686,7 +693,7 @@
                 <infoLink id="406b-016e-a5d9-b4f0" name="Ceaseless" hidden="false" targetId="ce9a-aa0d-7b46-3d04" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64a1-4046-c5ab-f4de" name="Power maul" hidden="false" collective="false" import="true" type="upgrade">
@@ -705,7 +712,7 @@
                 <infoLink id="e30f-e3c3-f0b4-cab3" name="Stun" hidden="false" targetId="a1e3-4e0b-f7c2-eb59" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1052-6277-78e3-1439" name="Power pick" hidden="false" collective="false" import="true" type="upgrade">
@@ -724,7 +731,7 @@
                 <infoLink id="bfba-34f4-3c9c-ab5f" name="Rending" hidden="false" targetId="0550-3332-7a93-ab5b" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -767,7 +774,7 @@
         <entryLink id="05fc-62eb-f7fb-01d7" name="Equipment" hidden="false" collective="false" import="true" targetId="2d37-d872-4dc9-ebc6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="436d-42ed-0e14-54ab" name="Kelermorph" hidden="false" collective="false" import="true" type="model">
@@ -813,8 +820,8 @@
       <selectionEntries>
         <selectionEntry id="a670-7472-6922-33f6" name="Liberator autostubs" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a327-0ac3-78f0-547b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0bc-9c8a-cb21-3e33" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a327-0ac3-78f0-547b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0bc-9c8a-cb21-3e33" type="max"/>
           </constraints>
           <profiles>
             <profile id="d32c-c9b9-5637-af47" name="⌖ Liberator autostubs - Long range" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -842,13 +849,13 @@
             <infoLink id="7760-2899-e720-9041" name="Rending" hidden="false" targetId="0550-3332-7a93-ab5b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4c8c-c183-4265-c5e5" name="Kelermorph knife" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc18-7b0b-dade-8549" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4996-a0cb-bd90-bb27" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc18-7b0b-dade-8549" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4996-a0cb-bd90-bb27" type="max"/>
           </constraints>
           <profiles>
             <profile id="b78d-2230-9998-e523" name="⚔ Kelermorph knife" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -865,7 +872,7 @@
             <infoLink id="9bd0-fd54-5b67-872f" name="Rending" hidden="false" targetId="0550-3332-7a93-ab5b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -883,7 +890,7 @@
         </entryLink>
         <entryLink id="4da9-0a5c-98ef-4aaa" name="Battle Honours - Marksman" hidden="false" collective="false" import="true" targetId="e84e-ae34-82a8-57b0" type="selectionEntryGroup">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="551b-016b-e912-1c6d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="551b-016b-e912-1c6d" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="3f36-59d3-d30e-80e5" name="Wymblade 1 - Scurry" hidden="false" collective="false" import="true" targetId="6f08-77ef-c23e-5a6f" type="selectionEntry"/>
@@ -898,7 +905,7 @@
         <entryLink id="ec1d-cafa-1be0-8fac" name="Specialism" hidden="false" collective="false" import="true" targetId="6bd1-70ea-ca66-03ed" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6918-7dae-e72f-d509" name="Sanctus Sniper" hidden="false" collective="false" import="true" type="model">
@@ -923,8 +930,7 @@
             <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative. Until the end of the Turning Point,	 each time this operative makes a shooting attack against that enemy operative:
 - The Sanctus sniper rifle this operative is equipped with gains the No Cover special rule for that attack.
 - That enemy operative cannot be Obscured for that shooting attack.
-- Areas of smoke cannot prevent that enemy operative from being Visible for that shooting attack.
-</characteristic>
+- Areas of smoke cannot prevent that enemy operative from being Visible for that shooting attack.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -944,8 +950,8 @@
       <selectionEntries>
         <selectionEntry id="7ce6-292f-72be-d859" name="Sanctus sniper rifle" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c17-8a52-6c08-3041" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24c9-b59c-1a50-8789" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c17-8a52-6c08-3041" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24c9-b59c-1a50-8789" type="max"/>
           </constraints>
           <profiles>
             <profile id="3201-28f0-d1d4-bede" name="⌖ Sanctus sniper rifle" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -964,13 +970,13 @@
             <infoLink id="e0b9-d94a-f37f-bdfd" name="MWx" hidden="false" targetId="0d4b-7a76-d266-bcc1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fede-4429-2230-5597" name="Fists" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8acd-d3d4-3fbb-4abe" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a86-759c-ccac-1cc9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8acd-d3d4-3fbb-4abe" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a86-759c-ccac-1cc9" type="max"/>
           </constraints>
           <profiles>
             <profile id="da7d-7cbe-4367-27db" name="⚔ Fists" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -984,7 +990,7 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1004,7 +1010,7 @@
         <entryLink id="aab9-eaad-0ba6-bb31" name="Specialism" hidden="false" collective="false" import="true" targetId="6bd1-70ea-ca66-03ed" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8b09-0224-4a57-ab98" name="Sanctus Talon" hidden="false" collective="false" import="true" type="upgrade">
@@ -1026,8 +1032,10 @@
         </profile>
         <profile id="d573-238f-caa3-9014" name="Familiar&apos;s Soulsight (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
           <characteristics>
-            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative. Until the end of the Turning Point,	 each time this operative fights in combat with that enemy operative, the Sanctus bio-dagger this operative is equipped with gains the Brutal and Balanced special rules for that combat.
-</characteristic>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative. Until the end of the Turning Point, each time this operative fights in combat with that enemy operative, the Sanctus bio-dagger this operative is equipped with gains the Brutal and Balanced special rules for that combat.
+
+
+Until the end of the Turning Point, each time this operative fights in combat with that enemy operative, in the Resolve Successful Hits step of that combat, the first time you resolve one of your successful critical hits, you can immediately resolve one of your successful normal hits (or a successful critical hit if you have none).</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1047,8 +1055,8 @@
       <selectionEntries>
         <selectionEntry id="acd5-1139-cf71-7502" name="Sanctus bio-dagger" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2268-f51e-f4b1-465d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae0f-0faa-3c79-1c2f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2268-f51e-f4b1-465d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae0f-0faa-3c79-1c2f" type="max"/>
           </constraints>
           <profiles>
             <profile id="acc0-ef36-b9bc-fcb2" name="⚔ Sanctus bio-dagger" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1066,7 +1074,7 @@
             <infoLink id="4359-b476-10b8-1e26" name="Stun" hidden="false" targetId="a1e3-4e0b-f7c2-eb59" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1096,7 +1104,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="09e1-8e4b-d15a-95d2" name="Locus" hidden="false" collective="false" import="true" type="model">
@@ -1142,8 +1150,8 @@
       <selectionEntries>
         <selectionEntry id="866a-6581-4812-bff5" name="Barbed tail" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c286-c3db-6135-7ab5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3919-c4ba-100a-58ef" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c286-c3db-6135-7ab5" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3919-c4ba-100a-58ef" type="max"/>
           </constraints>
           <profiles>
             <profile id="d3f5-2777-f931-2796" name="⌖ Barbed tail" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1161,13 +1169,13 @@
             <infoLink id="a82d-9bfe-fc79-d6c1" name="Silent" hidden="false" targetId="ce60-8109-69c9-3908" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ad0c-ddbf-95f7-4a93" name="Locus blades" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b5-dcba-d7c5-abb1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb82-27d3-3c65-6516" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b5-dcba-d7c5-abb1" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb82-27d3-3c65-6516" type="max"/>
           </constraints>
           <profiles>
             <profile id="0ee3-672f-09b1-53ad" name="⚔ Locus blades" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1184,7 +1192,7 @@
             <infoLink id="1c9e-9972-bcd7-eb77" name="Lethal x" hidden="false" targetId="be29-25db-e215-b3b0" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1204,14 +1212,14 @@
         <entryLink id="9ba0-d1f8-1dff-6232" name="Specialism" hidden="false" collective="false" import="true" targetId="6bd1-70ea-ca66-03ed" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntries>
     <selectionEntry id="cf40-531a-78c0-2384" name="Gun butt" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1795-cf10-d5b8-5acd" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1795-cf10-d5b8-5acd" type="max"/>
       </constraints>
       <profiles>
         <profile id="df37-3dc0-6581-73b4" name="⚔ Gun butt" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1225,19 +1233,19 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b8df-5ac2-b786-d771" name="Autogun" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b641-6d09-4e9f-24ce" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b641-6d09-4e9f-24ce" type="max"/>
       </constraints>
       <profiles>
         <profile id="ab8a-87a2-f5bb-dc9b" name="⌖ Autogun" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
           <modifiers>
             <modifier type="set" field="32b4-9a0e-e740-6031" value="3+">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3198-c1ce-dfd0-fb4f" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3198-c1ce-dfd0-fb4f" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1251,19 +1259,19 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="39d0-96ff-f8fd-2661" name="Shotgun" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66fe-a264-5f06-64a3" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66fe-a264-5f06-64a3" type="max"/>
       </constraints>
       <profiles>
         <profile id="56ea-4fc8-ff80-62ff" name="⌖ Shotgun" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
           <modifiers>
             <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3198-c1ce-dfd0-fb4f" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3198-c1ce-dfd0-fb4f" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1277,12 +1285,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6f08-77ef-c23e-5a6f" name="Wymblade 1 - Scurry" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28ae-df0b-79d8-36a5" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28ae-df0b-79d8-36a5" type="max"/>
       </constraints>
       <profiles>
         <profile id="cee4-5a38-1108-62b7" name="Scurry" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1292,12 +1300,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2310-d66d-32a8-bb79" name="Wyrmblade 2 - Elusive" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28b6-1998-0251-dd26" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28b6-1998-0251-dd26" type="max"/>
       </constraints>
       <profiles>
         <profile id="f019-c894-be37-192f" name="Elusive" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1307,12 +1315,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="866d-89d5-5291-14b0" name="Wyrmblade 3 - Mercurial" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23dd-4c5e-b731-0286" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23dd-4c5e-b731-0286" type="max"/>
       </constraints>
       <profiles>
         <profile id="adc1-6ba6-a65d-e690" name="Mercurial" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1322,12 +1330,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="afb1-1fd8-254e-4fa8" name="Wyrmblade 5 - Stalker" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d9e-7e82-b401-5c86" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d9e-7e82-b401-5c86" type="max"/>
       </constraints>
       <profiles>
         <profile id="b666-9cc6-8ab1-087a" name="Stalker" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1337,12 +1345,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="442d-834d-3dd6-1cd5" name="Wyrmblade 4 - Prowler" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d14-d9b7-f050-d746" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d14-d9b7-f050-d746" type="max"/>
       </constraints>
       <profiles>
         <profile id="46c1-a3b8-5c39-31bf" name="Prowler" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1352,12 +1360,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2ef2-0719-0b04-9125" name="Wyrmblade 6 - Clandestine" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad2a-7d86-25e0-07c3" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad2a-7d86-25e0-07c3" type="max"/>
       </constraints>
       <profiles>
         <profile id="dbb7-0090-cfea-a76b" name="Clandestine" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1367,12 +1375,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d49a-f58a-d37b-d655" name="Heavy stubber" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="19bf-c0b4-92d3-9b34" type="max"/>
+        <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="19bf-c0b4-92d3-9b34" type="max"/>
       </constraints>
       <profiles>
         <profile id="e55e-577c-4839-271c" name="⌖ Heavy stubber" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1391,7 +1399,7 @@
         <infoLink id="756f-6477-c624-fcd7" name="Heavy" hidden="false" targetId="1e77-6974-cf90-6008" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -1400,12 +1408,12 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+            <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e34d-954e-0273-5ef6" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e34d-954e-0273-5ef6" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="c17e-0ea4-97d9-6cdd" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry">
@@ -1414,9 +1422,9 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a59e-d71c-0bbb-2c70" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5ff2-784e-8398-59ad" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="36da-13f0-dba0-2b08" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a59e-d71c-0bbb-2c70" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5ff2-784e-8398-59ad" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="36da-13f0-dba0-2b08" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1429,10 +1437,10 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0e59-07ae-65c2-2de6" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a59e-d71c-0bbb-2c70" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7d9c-7959-e70e-a4a4" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="36da-13f0-dba0-2b08" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0e59-07ae-65c2-2de6" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a59e-d71c-0bbb-2c70" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7d9c-7959-e70e-a4a4" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="36da-13f0-dba0-2b08" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1445,8 +1453,8 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0e59-07ae-65c2-2de6" type="notInstanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a59e-d71c-0bbb-2c70" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0e59-07ae-65c2-2de6" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a59e-d71c-0bbb-2c70" type="notInstanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1459,9 +1467,9 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5ff2-784e-8398-59ad" type="notInstanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3198-c1ce-dfd0-fb4f" type="notInstanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="36da-13f0-dba0-2b08" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5ff2-784e-8398-59ad" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3198-c1ce-dfd0-fb4f" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="36da-13f0-dba0-2b08" type="notInstanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1474,18 +1482,18 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7138-2b60-74ce-a90b" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7138-2b60-74ce-a90b" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="c61a-51a3-370d-bf55" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5021-c4ff-35a7-eeb6" type="max"/>
+        <constraint field="c61a-51a3-370d-bf55" scope="roster" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5021-c4ff-35a7-eeb6" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="871c-145d-bf4f-efae" name="Frag Grenade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c892-eaa1-4e1b-0096" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7c2b-03a8-c063-03c9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c892-eaa1-4e1b-0096" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7c2b-03a8-c063-03c9" type="max"/>
           </constraints>
           <profiles>
             <profile id="faa1-451e-f7ee-72eb" name="⌖ Frag grenade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1505,13 +1513,13 @@
             <infoLink id="5928-e42d-0dbd-ec5d" name="Indirect" hidden="false" targetId="653d-16a5-eefb-8b71" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8fc1-277f-8753-f9b9" name="Blasting Charge" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d52-5471-6059-9298" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dce8-ffd3-007d-1e4d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d52-5471-6059-9298" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dce8-ffd3-007d-1e4d" type="max"/>
           </constraints>
           <profiles>
             <profile id="f6cd-0945-d1a3-2155" name="⌖ Blasting charge" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1531,12 +1539,12 @@
             <infoLink id="4f56-d375-0dc6-0eba" name="Rng x" hidden="false" targetId="92de-2ad3-3554-0b3e" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d5a4-457e-4328-843c" name="Flash Visor" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea08-1bfc-2db5-9dc2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea08-1bfc-2db5-9dc2" type="max"/>
           </constraints>
           <profiles>
             <profile id="ce27-3f39-c50b-40c1" name="Flash Visor" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1546,12 +1554,12 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b450-718f-4eaf-c179" name="Spotlight" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a6-0fa0-778b-b113" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a6-0fa0-778b-b113" type="max"/>
           </constraints>
           <profiles>
             <profile id="89ef-eaba-91df-0d4b" name="Spotlight" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1561,12 +1569,12 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a67e-c2a7-574a-f55f" name="Cult Talisman" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97fe-9f91-1e41-d180" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97fe-9f91-1e41-d180" type="max"/>
           </constraints>
           <profiles>
             <profile id="129f-e86a-20d5-0b61" name="Cult Talisman" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1576,12 +1584,12 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7b26-8ec0-1e72-4b76" name="Climbing Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8400-03ca-f2b4-84bb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8400-03ca-f2b4-84bb" type="max"/>
           </constraints>
           <profiles>
             <profile id="9b26-323c-d72e-143a" name="Climbing Equipment" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1594,12 +1602,12 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4960-f944-40bc-5785" name="Cult Knife" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25fb-a136-4f32-59ba" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25fb-a136-4f32-59ba" type="max"/>
           </constraints>
           <profiles>
             <profile id="8608-8177-e1ca-e8ad" name="⚔ Cult knife" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1613,20 +1621,20 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7cc3-b24f-626f-0f91" name="Gene-brew [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="957c-f2c9-2838-0767" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c6a-2ee2-650e-8b0d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="957c-f2c9-2838-0767" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c6a-2ee2-650e-8b0d" type="max"/>
           </constraints>
           <profiles>
             <profile id="c5a1-8334-c29b-f45b" name="Gene-brew" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1641,20 +1649,20 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ec09-62f3-91a7-2145" name="Splinterworm Knife [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48e1-d940-32e7-94db" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2dba-bde7-d38d-2c35" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48e1-d940-32e7-94db" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2dba-bde7-d38d-2c35" type="max"/>
           </constraints>
           <profiles>
             <profile id="8a69-06e2-a889-1b95" name="⚔ Splinterworm knife [RARE]" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1668,36 +1676,36 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bd4f-8a3e-2544-e842" name="Ichor-infused Ammunition [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="c61a-51a3-370d-bf55" value="2.0">
+            <modifier type="set" field="c61a-51a3-370d-bf55" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d49a-f58a-d37b-d655" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d49a-f58a-d37b-d655" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39d0-96ff-f8fd-2661" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8df-5ac2-b786-d771" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d49a-f58a-d37b-d655" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39d0-96ff-f8fd-2661" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8df-5ac2-b786-d771" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d49a-f58a-d37b-d655" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="295d-54d6-2fa4-1503" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84ec-4972-f8f0-ce40" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="295d-54d6-2fa4-1503" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84ec-4972-f8f0-ce40" type="max"/>
           </constraints>
           <profiles>
             <profile id="f0fe-2013-8236-203c" name="Ichor-infused Ammunition" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1707,20 +1715,20 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f5eb-60be-7e8c-6f87" name="Shadowleap Cloak [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0786-25a9-5252-4b61" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3528-b037-43f7-b8e9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0786-25a9-5252-4b61" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3528-b037-43f7-b8e9" type="max"/>
           </constraints>
           <profiles>
             <profile id="c881-d4e8-2bb8-526c" name="Shadowleap Cloak" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1733,25 +1741,25 @@
             <categoryLink id="bed8-3f75-a1ca-a756" name="Fly" hidden="false" targetId="383e-c92a-c607-c7e1" primary="false"/>
           </categoryLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="87c7-602a-0fe7-ad31" name="Sire-blessed Icon [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a59e-d71c-0bbb-2c70" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a59e-d71c-0bbb-2c70" type="notInstanceOf"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f89-0d3a-9eb6-96b1" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf47-1b65-5944-28ad" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f89-0d3a-9eb6-96b1" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf47-1b65-5944-28ad" type="max"/>
           </constraints>
           <profiles>
             <profile id="2de2-17a9-10fc-40d8" name="Sire-blessed Icon" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1761,20 +1769,20 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="489d-710f-aed8-4ca6" name="Neural Shroud [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9db3-bcbc-f0a1-bac4" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="24a9-c1f2-2cbb-1424" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9db3-bcbc-f0a1-bac4" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="24a9-c1f2-2cbb-1424" type="max"/>
           </constraints>
           <profiles>
             <profile id="ed8f-9714-cd47-5ba7" name="Neural Shroud" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1784,7 +1792,7 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1804,7 +1812,7 @@
     <rule id="af15-09c9-71d0-68db" name="Cult Ambush" hidden="false">
       <description>During the first Turning Point, when this operative activated, you can change its order.
 
-The first time this operative performs either a Fight or Shoot action in each of its activations, if its order was changed from Conceal to Engage during that activation, in the Roll Attack Dice step of that combat or shooting attack, you can re-roll any or all of your attack dice results of one result (e.g. results of 2).</description>
+The first time this operative performs either a Fight or Shoot action in each of its activations, if its order was changed from Conceal to Engage during that activation, or it wasn&apos;t visible to every enemy operative at the start of that activation, in the Roll Attack Dice step of that combat or shooting attack, you can re-roll any or all of your attack dice results of one result (e.g. results of 2).</description>
     </rule>
     <rule id="2477-012d-2873-a3c3" name="Preternatural Assassin" hidden="false">
       <description>This operative cannot be equipped with equipment.
@@ -1834,7 +1842,7 @@ Each time a shooting attack is made against this operative, in the Roll Defence 
         <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">⬛</characteristic>
         <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">⬟</characteristic>
         <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">⌖ 
-⚔ </characteristic>
+⚔</characteristic>
         <characteristic name="W" typeId="db11-738c-048c-759e">💀</characteristic>
       </characteristics>
     </profile>


### PR DESCRIPTION
Link: https://www.warhammer-community.com/wp-content/uploads/2023/03/hjPWHBsQiYwmccLL.pdf

Pathfinder
- Operative selection: Selecting MB3 RECON DRONE operative no longer requires you to select 1 less operative.
- DRONE CONTROLLER PATHFINDER operative gains the following ability: 'Focused EMP Override: If this operative is in the killzone, friendly DRONE operatives can perform the Operate Hatch action (ignore the first bullet point of Artificial Intelligence to do so).'

Wyrmblade
- Change second paragraph of Cult Ambush ability to: 'The first time this operative performs either a Fight or Shoot action in each of its activations, if its order was changed from Conceal to Engage during that activation, or it wasn't visible to every enemy operative at the start of that activation, in the Roll Attack Dice step of that combat or shooting attack, you can re-roll any or all of your attack dice results of one result (e.g. results of 2).'
- Add the following to TALON operative's Familiar's Soulsight action: 'Until the end of the Turning Point, each time this operative fights in combat with that enemy operative, in the Resolve Successful Hits step of that combat, the first time you resolve one of your successful critical hits, you can immediately resolve one of your successful normal hits (or a successful critical hit if you have none).'
- HEAVY GUNNER operatives gain the following ability: 'Suspensor System: The Heavy special rule of ranged weapons the operative is equipped with is treated differently. Instead, an operative cannot move more than 3⬤ in the same activation in which it performs a Shoot action with any of those ranged weapons.'

Farstalker Kinband
- KILL-BROKER operative's Call the Kill ability: Select one enemy operative in the killzone (visibility is not required), and each time you use it select one of the following effects for that Turning Point instead: existing (i.e. auto-retain a normal hit), Ceaseless or P1.

Kasrkin
- Change second sentence of RECON-TROOPER operative's Warden Auspex action to: 'Until the end of the Turning Point, each time a friendly KASRKIN operative makes a shooting attack, that enemy operative is not Obscured.'
- Foregrip equipment: GUNNER and SHARPSHOOTER operatives can be equipped with this for 2EP, and it works for ranged weapons on their datacard.

Exaction Squad
- Following weapons now only have 1 profile instead of 2, with both of previous profiles' special rules and critical hit rules (i.e. not separated as offensive and defensive):
  - PROCTOR-EXACTANT operative's dominator maul & assault shield.
  - SUBDUCTOR operative's shock maul and assault shield.
- PROCTOR-EXACTANT operative's Deploy Nuncio-aquila action: 0AP.

Fellgor Ravager
- While a FELLGOR RAVAGER operative has a Frenzy token, treat its APL characteristic as 1 (after all modifiers) for the purposes of determining control (e.g. objective markers).
- Incapacitating a FELLGOR RAVAGER operative with a Frenzy token: Add the following bullet point: 'Critical damage is inflicted on it in a subsequent shooting attack (i.e. not the same shooting attack in which it gained a Frenzy token).'

Chaos Cult
- Friendly DEVOTEE operatives can mutate at the end of a combat in which they incapacitated an enemy operative and were not incapacitated themselves (they cannot do so just by inflicting damage).
- Mutation into a new operative: The new operative no longer has full wounds remaining. Instead, it has the same wounds remaining as the preceding operative did, but then regains D3+1 wounds if it’s now a MUTANT operative or D3+3 if it’s now a TORMENT operative; in either case, it cannot go above its maximum wounds.