### PR TITLE
Q1 2024 Balance Dataslate

### DIFF
--- a/2021 - Chaos Cult.cat
+++ b/2021 - Chaos Cult.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ffe8-3458-e886-e647" name="Chaos Cult" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ffe8-3458-e886-e647" name="Chaos Cult" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry name="CHAOS CULT" hidden="false" id="e46b-36ed-7952-7323"/>
     <categoryEntry name="Dark Commune" hidden="false" id="3b98-6793-b4e5-c927"/>
@@ -507,7 +507,6 @@ You can select Accursed Gifts from those presented below. You cannot select the 
 
 1. Winged
 Each time this operative performs an action in which it moves:
-- Ignore any or all modifiers to its Movement characteristic.
 - Ignore the first distance of ⬤ it travels for a climb, drop or traverse.
 
 2. Fleet
@@ -1015,7 +1014,7 @@ This operative cannot perform this action while it has a Conceal order or while 
         </entryLink>
       </entryLinks>
       <constraints>
-        <constraint type="min" value="10" field="selections" scope="parent" shared="true" id="d8df-2731-7bd8-7f23"/>
+        <constraint type="min" value="9" field="selections" scope="parent" shared="true" id="d8df-2731-7bd8-7f23"/>
         <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="97c4-d3c0-5a13-9ca"/>
       </constraints>
       <modifierGroups>
@@ -1026,7 +1025,7 @@ This operative cannot perform this action while it has a Conceal order or while 
                 <condition type="notInstanceOf" value="1" field="selections" scope="force" childId="8749-1e3-5f1b-5f7" shared="true"/>
               </conditions>
             </modifier>
-            <modifier type="set" value="10" field="97c4-d3c0-5a13-9ca">
+            <modifier type="set" value="9" field="97c4-d3c0-5a13-9ca">
               <conditions>
                 <condition type="instanceOf" value="1" field="selections" scope="force" childId="8749-1e3-5f1b-5f7" shared="true"/>
               </conditions>

--- a/2021 - Farstalker Kinband.cat
+++ b/2021 - Farstalker Kinband.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3cd3-7d31-f105-e415" name="Farstalker Kinband" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="3cd3-7d31-f105-e415" name="Farstalker Kinband" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="53d9-aee4-991f-1f73" name="FARSTALKER KINBAND" hidden="false"/>
     <categoryEntry id="0b91-407c-2178-9392" name="Kroot" hidden="false"/>
@@ -544,7 +544,7 @@ On a 2+, subtract ⬤ from that enemy operative&apos;s Movement characteristic a
           <characteristics>
             <characteristic name="M" typeId="c36f-3952-a91d-5a06">4⬤</characteristic>
             <characteristic name="APL" typeId="c84a-a042-6fe6-519b">2</characteristic>
-            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">2</characteristic>
+            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
             <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
             <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">5+</characteristic>
             <characteristic name="W" typeId="db11-738c-048c-759e">7</characteristic>
@@ -873,7 +873,7 @@ This operative cannot perform this action while within Engagement Range of an en
           <profiles>
             <profile id="9ca1-6887-2bc4-58ab" name="⚔ Stalker&apos;s blade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
               <characteristics>
-                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">3</characteristic>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
                 <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">3+</characteristic>
                 <characteristic name="D" typeId="337a-2e5b-e4e3-f489">3/4</characteristic>
                 <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">Balanced</characteristic>
@@ -954,12 +954,12 @@ This operative cannot perform this action while within Engagement Range of an en
         </profile>
         <profile id="7993-255a-1c8c-eb61" name="Marked for the Hunt (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
           <characteristics>
-            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative. Until the end of the Turning Point, while that enemy operative is within ⬟ horizontally and any distance vertically of your Pech&apos;ra token, it is marked for the hunt. Until the end of the Turning Point, each time a friendly FARSTALKER KINBAND operative within ⬟ horizontally and any distance vertically of your Pech&apos;ra token makes a shooting attack against an enemy operative marked for the hunt, that enemy operative cannot use Light terrain as Cover for that shooting attack. This operative cannot perform this action while within ⬟ of an enemy operative.</characteristic>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative. Until the end of the Turning Point, while that enemy operative is within ⬟ horizontally and any distance vertically of your Pech&apos;ra token, it is marked for the hunt. Until the end of the Turning Point, each time a friendly FARSTALKER KINBAND operative within ⬟ horizontally and any distance vertically of your Pech&apos;ra token makes a shooting attack against an enemy operative marked for the hunt, that enemy operative cannot use Light terrain as Cover for that shooting attack. This operative cannot perform this action while within Engagement Range of an enemy operative.</characteristic>
           </characteristics>
         </profile>
         <profile id="b1ea-77bb-91b0-f27e" name="From the Eye Above (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
           <characteristics>
-            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one friendly operative Visible to and within ⬟ of this operative. Add 1 to its APL. This operative cannot perform this action while within ⬟ of an enemy operative.</characteristic>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one friendly operative Visible to and within ⬟ of this operative. Add 1 to its APL. This operative cannot perform this action while within Engagement Range of an enemy operative.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1601,7 +1601,7 @@ This operative cannot perform this action while within Engagement Range of an en
           <profiles>
             <profile id="a4cc-86ad-ada0-d766" name="⚔ Ritual blade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
               <characteristics>
-                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">3</characteristic>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">4</characteristic>
                 <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">2+</characteristic>
                 <characteristic name="D" typeId="337a-2e5b-e4e3-f489">4/5</characteristic>
                 <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">-</characteristic>
@@ -1872,6 +1872,11 @@ In addition, each time a shooting attack is made against this operative, the No 
         <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
           <conditions>
             <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8849-52f5-8ddf-0699" type="instanceOf"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="4" field="5f37-25bb-661b-5c9c">
+          <conditions>
+            <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="8849-52f5-8ddf-0699" shared="true" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/2021 - Fellgor Ravager.cat
+++ b/2021 - Fellgor Ravager.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="56b-12e-6b2c-bd26" name="Fellgor Ravager" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="56b-12e-6b2c-bd26" name="Fellgor Ravager" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry name="FELLGOR RAVAGER" hidden="false" id="6e8e-58e2-50ef-c8d9"/>
     <categoryEntry name="Ironhorn" hidden="false" id="e74b-bc55-d419-a22e"/>
@@ -561,7 +561,7 @@
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="War Paint" hidden="false" id="2111-22f2-4971-ac1d">
           <costs>
-            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b6ea-1cf-3e62-cfb0"/>
@@ -652,7 +652,7 @@ Your opponent treats a FELLGOR RAVAGER operative as being incapacitated (instead
       <profiles>
         <profile name="Fellgor Ironhorn" typeId="350c-2ddd-8a24-377b" typeName="Operative" hidden="false" id="70cd-691b-29c1-4c57">
           <characteristics>
-            <characteristic name="M" typeId="c36f-3952-a91d-5a06">3</characteristic>
+            <characteristic name="M" typeId="c36f-3952-a91d-5a06">3⬤</characteristic>
             <characteristic name="APL" typeId="c84a-a042-6fe6-519b">2</characteristic>
             <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
             <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
@@ -662,7 +662,7 @@ Your opponent treats a FELLGOR RAVAGER operative as being incapacitated (instead
         </profile>
         <profile name="Call the Attack" typeId="f52d-76ec-b279-093b" typeName="Abilities" hidden="false" id="b9c4-7ca0-5e70-6bce">
           <characteristics>
-            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Once in each Strategy phase, when it is your turn to use a Strategic Ploy or pass, you can use this ability instead. If you do so, select one friendly FELLGOR RAVAGER operative Visible to this operative. That selected operative, and all friendly FELLGOR RAVAGER operatives Visible to and within ⬤ of it, can immediately perform a free Dash action.</characteristic>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Once in each Strategy phase, when it is your turn to use a Strategic Ploy or pass, you can use this ability instead. If you do so, select one friendly FELLGOR RAVAGER operative Visible to and within ⬟ of this operative. That selected operative, and all friendly FELLGOR RAVAGER operatives Visible to and within ⬤ of it, can immediately perform a free Dash action.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -816,7 +816,7 @@ Your opponent treats a FELLGOR RAVAGER operative as being incapacitated (instead
         </profile>
         <profile name="War Gong" typeId="f52d-76ec-b279-093b" typeName="Abilities" hidden="false" id="3411-e564-6e08-5a86">
           <characteristics>
-            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time an attack dice would inflict Critical Damage on a friendly FELLGOR RAVAGER operative within ⬛ of this operative, you can choose for that attack dice to inflict Normal Damage instead.</characteristic>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time an attack dice would inflict Critical Damage on a friendly FELLGOR RAVAGER operative within ⬛ of this operative, you can choose for that attack dice to inflict Normal Damage instead. This ability has no effect when this operative has a Frenzy token.</characteristic>
           </characteristics>
         </profile>
         <profile name="Gong Knell (1AP)" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions" hidden="false" id="54a5-d067-8a65-ed8f">
@@ -979,7 +979,7 @@ Your opponent treats a FELLGOR RAVAGER operative as being incapacitated (instead
         </profile>
         <profile name="Uncompromising Attack (1AP)" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions" hidden="false" id="ffdb-cf52-da73-8276">
           <characteristics>
-            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Perform a free Fight action with this operative, then a free Shoot action with this operative (or vice versa). It can perform that Shoot action while within Engagement Range of enemy operatives, but if it does so, it can and must target an enemy operative within its Engagement Range (even if other friendly operatives are within that enemy operative’s Engagement Range).</characteristic>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Perform a free Fight action with this operative, then a free Shoot action with this operative (or vice versa). It can perform that Shoot action while within Engagement Range of enemy operatives, but if it does so, it can and must target an enemy operative within its Engagement Range (even if other friendly operatives are within that enemy operative’s Engagement Range). You can only select an autopistol for this action&apos;s shooting attack.</characteristic>
           </characteristics>
         </profile>
       </profiles>

--- a/2021 - Hearthkyn Salvager.cat
+++ b/2021 - Hearthkyn Salvager.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="bbda-6aa-31b3-6a0b" name="Hearthkyn Salvager" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="bbda-6aa-31b3-6a0b" name="Hearthkyn Salvager" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="37e3-1049-f168-e39d" name="HEARTHKYN SALVAGER" hidden="false"/>
     <categoryEntry id="39f7-ddf3-d533-97e5" name="Votann" hidden="false"/>
@@ -264,7 +264,7 @@
         </profile>
         <profile id="1d7d-2965-606d-24c0" name="Knux Smash (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
           <characteristics>
-            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative within this operative’s Engagement Range. You can move that enemy operative up to ⬛, then it suffers D3+1 mortal wounds. If the D3 result is a 3, subtract 1 from that enemy operative’s APL in addition. For the move, the FLY keyword has no effect, and that enemy operative must finish in a location it can be placed. It cannot move over the edge of the killzone, through any part of another operative’s base, or through a terrain feature (unless it has the Insignificant trait).</characteristic>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative within this operative’s Engagement Range. You can move that enemy operative up to ⬛, then it suffers D3+1 mortal wounds. If the D3 result is a 3, subtract 1 from that enemy operative’s APL in addition. For the move, the FLY keyword has no effect, and that enemy operative must finish in a location it can be placed. It cannot move over the edge of the killzone, through any part of another operative’s base, or through a terrain feature (unless it has the Insignificant trait). This operative can then perform a free Charge action up to ⬛ (even if it&apos;s performed an action during this activation that prevents it from doing so).</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -999,12 +999,12 @@ This operative cannot perform this action while within Engagement Range of an en
       <profiles>
         <profile id="da43-43a3-3b1a-ca08" name="Early Detection" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
           <characteristics>
-            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">In the Set Up Operatives step, enemy operatives that are set up in the killzone cannot be outside of their drop zone (unless the mission specifies). In addition, enemy operatives cannot move before the battle begins (although your opponent can still select the Recon scouting option for the purpose of determining initiative).</characteristic>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">In the Set Up Operatives step, enemy operatives that are set up in the killzone cannot be outside of their drop zone (unless the mission specifies). In addition, enemy operatives cannot move before the battle begins (although your opponent can still select the Recon scouting option for the purpose of determining initiative). In addition, enemy operatives cannot move until the Firefight phase of the first Turning Point.</characteristic>
           </characteristics>
         </profile>
         <profile id="c963-3095-10e4-c37b" name="Pan Spectral Scan (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
           <characteristics>
-            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Place one of your Scan tokens in the killzone. Until the end of the Turning Point, each time a friendly HEARTHKYN SALVAGER operative makes a shooting attack against an enemy operative within ⬛ of that token, that friendly operative’s ranged weapon gains the No Cover special rule for that shooting attack. This operative cannot perform this action while within Engagement Range of an enemy operative.</characteristic>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Place one of your Scan tokens in the killzone. Until the end of the Turning Point, each time a friendly HEARTHKYN SALVAGER operative makes a shooting attack against an enemy operative within ⬛ of that token, that friendly operative’s ranged weapon gains the No Cover special rule for that shooting attack. This operative cannot perform this action while within Engagement Range of an enemy operative. In addition, that enemy operative is not Obscured for that shooting attack.</characteristic>
           </characteristics>
         </profile>
         <profile id="e671-6aee-1060-831" name="Hearthkyn Lokâtr" hidden="false" typeId="350c-2ddd-8a24-377b" typeName="Operative">

--- a/2021 - Hierotek Circle.cat
+++ b/2021 - Hierotek Circle.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="df2d-5e44-2aee-ee72" name="Hierotek Circle" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="df2d-5e44-2aee-ee72" name="Hierotek Circle" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="39d9-136e-171f-bc56" name="HIEROTEK CIRCLE" hidden="false"/>
     <categoryEntry id="607a-a5ee-346f-8aad" name="Necron" hidden="false"/>
@@ -24,36 +24,36 @@
         <categoryLink id="507e-1f56-ad21-7d08" name="Reference" hidden="false" targetId="322e-38ea-bf3e-c785" primary="false"/>
         <categoryLink id="2da9-758a-1182-c1e3" name="Leader" hidden="false" targetId="3198-c1ce-dfd0-fb4f" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9458-484f-6b99-32f4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daef-58e3-5a57-f992" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9458-484f-6b99-32f4" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daef-58e3-5a57-f992" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="cb8f-6e39-079e-2243" name="Operative" hidden="false" targetId="f98b-0289-0f1f-b233" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cca3-2e05-e60d-e2fc" type="min"/>
-            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2af7-9a68-07c4-30b6" type="max"/>
+            <constraint field="selections" scope="parent" value="7" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cca3-2e05-e60d-e2fc" type="min"/>
+            <constraint field="selections" scope="parent" value="7" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2af7-9a68-07c4-30b6" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="dd3f-9eef-92e3-9e22" name="Accelerator" hidden="false" targetId="e482-e38d-7df3-98ea" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e68-4fe3-dc92-6400" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28d0-20a8-ccdc-7ec8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e68-4fe3-dc92-6400" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28d0-20a8-ccdc-7ec8" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="c443-c114-0f9c-d267" name="Reanimator" hidden="false" targetId="f8ee-347a-4698-45c5" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dfc-3e82-d707-0c42" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d124-9b72-2120-7541" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dfc-3e82-d707-0c42" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d124-9b72-2120-7541" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="cc0f-4a38-88d1-a48b" name="Apprentek" hidden="false" targetId="3a89-f4f1-b4ac-caa1" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c8f-bc15-b8b4-18a5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c8f-bc15-b8b4-18a5" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="70f5-de7f-9c31-76f8" name="Despotek" hidden="false" targetId="44de-e3cb-d918-71d1" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9702-29fe-6ef3-05f9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9702-29fe-6ef3-05f9" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -91,8 +91,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="e27d-9635-be23-477e" name="Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d94-0375-4728-5e6e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3219-3bbb-ff6f-fc5d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d94-0375-4728-5e6e" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3219-3bbb-ff6f-fc5d" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="bccd-dca8-be13-7c57" name="Aeonstave" hidden="false" collective="false" import="true" type="upgrade">
@@ -122,7 +122,7 @@
                 <infoLink id="db75-9ede-2742-ad89" name="Stun" hidden="false" targetId="a1e3-4e0b-f7c2-eb59" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30ff-f59d-5770-5c25" name="Entropic lance" hidden="false" collective="false" import="true" type="upgrade">
@@ -151,7 +151,7 @@
                 <infoLink id="121b-b6d7-8406-4662" name="APx" hidden="false" targetId="db98-339e-d0a2-e042" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -160,22 +160,22 @@
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="284c-dd42-3a1b-ef7e" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="284c-dd42-3a1b-ef7e" type="equalTo"/>
               </conditions>
               <modifiers>
-                <modifier type="increment" field="b4db-d265-2780-4e5f" value="1.0"/>
-                <modifier type="increment" field="b4db-d265-2780-4e5f" value="1.0"/>
+                <modifier type="increment" field="b4db-d265-2780-4e5f" value="1"/>
+                <modifier type="increment" field="b4db-d265-2780-4e5f" value="1"/>
               </modifiers>
             </modifierGroup>
           </modifierGroups>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4db-d265-2780-4e5f" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1a2-2bb8-b618-0833" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4db-d265-2780-4e5f" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1a2-2bb8-b618-0833" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="40ca-3fa3-ee6f-6c45" name="Timesplinter" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52f9-c3c4-ac49-6efe" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52f9-c3c4-ac49-6efe" type="max"/>
               </constraints>
               <profiles>
                 <profile id="fb6c-a0b1-aa4b-ebd1" name="Timesplinter (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -185,27 +185,27 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ef5-1ca3-9d74-8c90" name="Countertemporal Nanomine" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d09e-c7d6-f114-8683" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d09e-c7d6-f114-8683" type="max"/>
               </constraints>
               <profiles>
                 <profile id="2112-1e32-ccb7-17fb" name="Countertemporal Nanomine (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
                   <characteristics>
-                    <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Cryptek action. Place one of your Countertemporal Nanomine tokens within ⬟ of this operative. Each time an enemy operative performs an action in which it moves, if it would move within ⬟ of that token, subtract ⬤ from the distance it can move during that action. At the start of this operative’s next activation, if it’s incapacitated, or if another friendly operative performs this action (whichever comes first), remove that token.</characteristic>
+                    <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Cryptek action. Place one of your Countertemporal Nanomine tokens within ⬟ of this operative. Each time an enemy operative performs an action in which it moves, if it would move within ⬛ of that token, subtract ⬤ from the distance it can move during that action (to a minimum of 2⬤). At the start of this operative’s next activation, if it’s incapacitated, or if another friendly operative performs this action (whichever comes first), remove that token.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1366-5604-680c-bfa4" name="Chronometron" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5a6-6daa-ee7d-c841" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5a6-6daa-ee7d-c841" type="max"/>
               </constraints>
               <profiles>
                 <profile id="d278-3270-2c9d-ddd4" name="Chronometron (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -217,7 +217,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -251,7 +251,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5c26-4058-c06a-cc15" name="Psychomancer" hidden="false" collective="false" import="true" type="model">
@@ -285,8 +285,8 @@
       <selectionEntries>
         <selectionEntry id="d870-93e8-dbe4-62d0" name="Abyssal lance" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d14b-4e3d-78bb-63d7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4a4-4802-d4b0-d202" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d14b-4e3d-78bb-63d7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4a4-4802-d4b0-d202" type="max"/>
           </constraints>
           <profiles>
             <profile id="8827-7817-9c95-6d2f" name="⚔ Abyssal lance" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -315,7 +315,7 @@
             <infoLink id="3dae-e9c7-c233-4e77" name="Reap x" hidden="false" targetId="bed1-0d23-de84-30a1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -324,22 +324,22 @@
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="284c-dd42-3a1b-ef7e" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="284c-dd42-3a1b-ef7e" type="equalTo"/>
               </conditions>
               <modifiers>
-                <modifier type="increment" field="2817-877c-a56d-61dd" value="1.0"/>
-                <modifier type="increment" field="8439-0208-b6b0-0423" value="1.0"/>
+                <modifier type="increment" field="2817-877c-a56d-61dd" value="1"/>
+                <modifier type="increment" field="8439-0208-b6b0-0423" value="1"/>
               </modifiers>
             </modifierGroup>
           </modifierGroups>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2817-877c-a56d-61dd" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8439-0208-b6b0-0423" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2817-877c-a56d-61dd" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8439-0208-b6b0-0423" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="42d7-1558-1422-f913" name="Nightmare Shroud" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6db1-4aef-2c51-a271" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6db1-4aef-2c51-a271" type="max"/>
               </constraints>
               <profiles>
                 <profile id="f8fb-f4b8-72af-d440" name="Nightmare Shroud (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -349,12 +349,12 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ce2-33b5-b1d1-5ddc" name="Harbinger of Despair" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5848-eced-00bf-3696" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5848-eced-00bf-3696" type="max"/>
               </constraints>
               <profiles>
                 <profile id="f93c-2d23-603c-d436" name="Harbinger of Despair (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -364,22 +364,22 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2257-9cee-721b-0c73" name="Conjure Trauma" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2c1-de0d-90c3-6707" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2c1-de0d-90c3-6707" type="max"/>
               </constraints>
               <profiles>
                 <profile id="da8a-f6e7-cb01-7276" name="Conjure Trauma (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
                   <characteristics>
-                    <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Cryptek action. Select one enemy operative Visible to this operative. Until the start of this operative’s next activation, if it’s incapacitated, or if another friendly operative performs this action (whichever comes first), that operative is treated as being injured, regardless of any rules that say it cannot be injured.</characteristic>
+                    <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Cryptek action. Select one enemy operative Visible to this operative. Until the start of this operative’s next activation, if it’s incapacitated, or if another friendly operative performs this action (whichever comes first), that operative is treated as being injured, regardless of any rules that say it cannot be injured. In addition, roll one D6. If the result is higher than that enemy operative&apos;s APL, subtract 1 from that enemy operative&apos;s APL.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -413,7 +413,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5d3e-afed-9ff1-9762" name="Technomancer" hidden="false" collective="false" import="true" type="model">
@@ -447,8 +447,8 @@
       <selectionEntries>
         <selectionEntry id="3626-0e65-0d4e-a6e1" name="Staff of light" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2243-5410-866b-86b6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d57e-b122-0614-a870" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2243-5410-866b-86b6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d57e-b122-0614-a870" type="max"/>
           </constraints>
           <profiles>
             <profile id="cecc-87fc-290d-e246" name="⚔ Staff of light" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -475,7 +475,7 @@
             <infoLink id="b63d-cfa5-d720-1681" name="Lethal x" hidden="false" targetId="be29-25db-e215-b3b0" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -484,42 +484,37 @@
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="284c-dd42-3a1b-ef7e" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="284c-dd42-3a1b-ef7e" type="equalTo"/>
               </conditions>
               <modifiers>
-                <modifier type="increment" field="0d07-7ce6-1582-057d" value="1.0"/>
-                <modifier type="increment" field="2e6d-a468-1d84-507c" value="1.0"/>
+                <modifier type="increment" field="0d07-7ce6-1582-057d" value="1"/>
+                <modifier type="increment" field="2e6d-a468-1d84-507c" value="1"/>
               </modifiers>
             </modifierGroup>
           </modifierGroups>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e6d-a468-1d84-507c" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d07-7ce6-1582-057d" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e6d-a468-1d84-507c" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d07-7ce6-1582-057d" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="be79-a4a5-3079-f6ba" name="Rites of Reanimation" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f3f-02e1-2793-6690" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f3f-02e1-2793-6690" type="max"/>
               </constraints>
               <profiles>
-                <profile id="1503-4832-aa43-0015" name="Rites of Reanimation (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
-                  <characteristics>
-                    <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Cryptek action. Until the start of this operative’s next activation, if it’s incapacitated, or if another friendly operative performs this action (whichever comes first), this operative gains the &quot;Rites of Reanimation&quot; ability.</characteristic>
-                  </characteristics>
-                </profile>
                 <profile id="c6ed-6369-19e4-2ccc" name="Rites of Reanimation" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Once in this Turning Point, when another friendly HIEROTEK CIRCLE operative would be incapacitated for the first time during the battle, if it is Visible to and within ⬟ of this operative, this operative can use this ability. If it does so, that friendly HIEROTEK CIRCLE operative attempts reanimation.</characteristic>
+                    <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Once in this Turning Point, when another friendly HIEROTEK CIRCLE operative would be incapacitated for the first time during the battle, if it is Visible to and within ⬟ of this operative, this operative can use this ability. If it does so, that friendly HIEROTEK CIRCLE operative attempts reanimation. Subtract 1 from this operative&apos;s APL if you use this ability.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="13e9-76f9-8adf-9151" name="Nanoscarab Repair Swarm" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="267d-5e9b-3607-1be0" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="267d-5e9b-3607-1be0" type="max"/>
               </constraints>
               <profiles>
                 <profile id="d1c8-c28d-ceaf-13d8" name="Nanoscarab Repair Swarm (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -529,12 +524,12 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b9c-01e8-53af-8d77" name="Canoptek Repair" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe9c-8c90-066c-291a" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe9c-8c90-066c-291a" type="max"/>
               </constraints>
               <profiles>
                 <profile id="74aa-38a0-1d16-35db" name="Canoptek Repair (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -544,7 +539,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+                <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -578,7 +573,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="423f-ceb4-e015-15f0" name="Plasmacyte Reanimator" hidden="false" collective="false" import="true" type="model">
@@ -627,7 +622,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="72a2-69ba-cff7-1fe3" name="Plasmacyte Accelerator" hidden="false" collective="false" import="true" type="model">
@@ -676,7 +671,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c4a8-633b-4cf2-639c" name="Apprentek" hidden="false" collective="false" import="true" type="model">
@@ -684,7 +679,7 @@
         <profile id="2768-8b3e-22ce-fdf3" name="Apprentek" hidden="false" typeId="350c-2ddd-8a24-377b" typeName="Operative">
           <characteristics>
             <characteristic name="M" typeId="c36f-3952-a91d-5a06">3⬤</characteristic>
-            <characteristic name="APL" typeId="c84a-a042-6fe6-519b">2</characteristic>
+            <characteristic name="APL" typeId="c84a-a042-6fe6-519b">3</characteristic>
             <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
             <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
             <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">3+</characteristic>
@@ -715,8 +710,8 @@
       <selectionEntries>
         <selectionEntry id="43d1-f621-9f8e-8470" name="Arcane conduit" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df14-26c8-de80-38b6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="522b-dce4-162c-ee5d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df14-26c8-de80-38b6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="522b-dce4-162c-ee5d" type="max"/>
           </constraints>
           <profiles>
             <profile id="a36a-ee40-8dd0-0623" name="⌖ Arcane conduit" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -742,7 +737,7 @@
             <infoLink id="844b-36d0-faf5-bb47" name="APx" hidden="false" targetId="db98-339e-d0a2-e042" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -767,7 +762,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aa0a-7d0d-00f6-9ccf" name="Deathmark" hidden="false" collective="false" import="true" type="model">
@@ -796,8 +791,8 @@
       <selectionEntries>
         <selectionEntry id="56de-96b5-2f99-6e77" name="Synaptic disintegrator" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eea-2ea0-ca79-6d90" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08fe-0022-741c-fe15" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eea-2ea0-ca79-6d90" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08fe-0022-741c-fe15" type="max"/>
           </constraints>
           <profiles>
             <profile id="304c-379b-5617-6bc1" name="⌖ Synaptic disintegrator" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -816,13 +811,13 @@
             <infoLink id="bcfe-9ede-4d95-b9e5" name="MWx" hidden="false" targetId="0d4b-7a76-d266-bcc1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="23ad-40f5-8c92-4ecd" name="Fists" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1732-cc6e-f7a1-19be" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0f7-9904-c9bf-cdd7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1732-cc6e-f7a1-19be" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0f7-9904-c9bf-cdd7" type="max"/>
           </constraints>
           <profiles>
             <profile id="1c80-c967-9b33-ba2b" name="⚔ Fists" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -836,7 +831,7 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -854,7 +849,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f950-d16a-6efc-e730" name="Immortal Despotek" hidden="false" collective="false" import="true" type="model">
@@ -889,8 +884,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="9291-0a89-1d0a-1e83" name="Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9db-4e92-d515-ed3d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8009-1bed-70da-798e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9db-4e92-d515-ed3d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8009-1bed-70da-798e" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="a1b9-5e5d-91d4-fc1c" name="Gauss blaster" hidden="false" collective="false" import="true" targetId="4fb7-6def-f7cc-808e" type="selectionEntry"/>
@@ -920,7 +915,7 @@
         <entryLink id="3a93-1968-092f-ca87" name="Bayonet" hidden="false" collective="false" import="true" targetId="a67c-07e9-e029-2d7a" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4f08-3085-66f5-e629" name="Immortal Guardian" hidden="false" collective="false" import="true" type="model">
@@ -950,8 +945,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="32ee-0627-894f-3b6b" name="Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fec-ea22-ccb6-26b0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0571-5879-d524-6be1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fec-ea22-ccb6-26b0" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0571-5879-d524-6be1" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="b725-5f66-e630-151d" name="Gauss blaster" hidden="false" collective="false" import="true" targetId="4fb7-6def-f7cc-808e" type="selectionEntry"/>
@@ -981,7 +976,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
@@ -989,7 +984,7 @@
     <rule id="494a-01d7-f284-f939" name="Reanimation Protocols" hidden="false">
       <description>Certain rules can allow friendly HIEROTEK CIRCLE operatives to attempt reanimation (e.g. Reanimation Beam). The first time each friendly HIEROTEK CIRCLE operative is incapacitated, if it attempts reanimation, before removing that operative from the killzone, place one of your Reanimation tokens underneath the operative as close as possible to the centre of its base and leave its order token next to it. Note that the second time each friendly HIEROTEK CIRCLE operative is incapacitated, it cannot attempt reanimation.
 
-In the Ready Operatives step fo each Turning Point, before resolving the Living Metal ability, roll one D6 for each of your Reanimation tokens. On a 1-2, leave that Reanimation token in the killzone. On a 3+, an operative is successfully reanimated.
+In the Ready Operatives step of each Turning Point, before resolving the Living Metal ability, roll one D6 for each of your Reanimation tokens. On a 1-2, leave that Reanimation token in the killzone. On a 2+, an operative is successfully reanimated.
 
 - Set up the operative that Reanimation token was placed for.
 - It must be placed within ⬛ of that Reanimation token and not within Engagement Range of enemy operatives.
@@ -1003,8 +998,8 @@ In narrative play, operatives that are successfully reanimated are not treated a
   <sharedSelectionEntries>
     <selectionEntry id="ea7b-f48d-00b8-c855" name="Spark" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad57-f65c-594d-f9ae" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c037-f62d-eeb7-c347" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad57-f65c-594d-f9ae" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c037-f62d-eeb7-c347" type="max"/>
       </constraints>
       <profiles>
         <profile id="26e6-0333-995c-7091" name="⌖ Spark" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1018,13 +1013,13 @@ In narrative play, operatives that are successfully reanimated are not treated a
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ece7-f4c5-78df-0d16" name="Claws" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ba6-7d61-916c-5c2b" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f54-7e61-d045-761e" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ba6-7d61-916c-5c2b" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f54-7e61-d045-761e" type="max"/>
       </constraints>
       <profiles>
         <profile id="2f54-7be7-3fbf-f521" name="⚔ Claws" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1038,7 +1033,7 @@ In narrative play, operatives that are successfully reanimated are not treated a
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4fb7-6def-f7cc-808e" name="Gauss blaster" hidden="false" collective="false" import="true" type="upgrade">
@@ -1047,7 +1042,7 @@ In narrative play, operatives that are successfully reanimated are not treated a
           <modifiers>
             <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f950-d16a-6efc-e730" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f950-d16a-6efc-e730" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1064,7 +1059,7 @@ In narrative play, operatives that are successfully reanimated are not treated a
         <infoLink id="faa3-a47c-d757-f118" name="APx" hidden="false" targetId="db98-339e-d0a2-e042" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4a5f-e486-22f1-8279" name="Tesla carbine" hidden="false" collective="false" import="true" type="upgrade">
@@ -1073,7 +1068,7 @@ In narrative play, operatives that are successfully reanimated are not treated a
           <modifiers>
             <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f950-d16a-6efc-e730" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f950-d16a-6efc-e730" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1090,20 +1085,20 @@ In narrative play, operatives that are successfully reanimated are not treated a
         <infoLink id="9c37-731d-c592-0262" name="Splash x" hidden="false" targetId="eab8-73f5-feed-5924" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a67c-07e9-e029-2d7a" name="Bayonet" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e294-aee7-0204-90a7" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79ce-2d41-b026-fa4c" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e294-aee7-0204-90a7" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79ce-2d41-b026-fa4c" type="max"/>
       </constraints>
       <profiles>
         <profile id="bd15-262b-f038-2a8d" name="⚔ Bayonet" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
           <modifiers>
             <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f950-d16a-6efc-e730" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f950-d16a-6efc-e730" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1117,12 +1112,12 @@ In narrative play, operatives that are successfully reanimated are not treated a
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cc6e-8caa-5302-eb5a" name="Cryptek 1 - Controlling" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d41-4d27-efd5-a47b" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d41-4d27-efd5-a47b" type="max"/>
       </constraints>
       <profiles>
         <profile id="76d5-e487-a941-e0e5" name="Controlling" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1132,12 +1127,12 @@ In narrative play, operatives that are successfully reanimated are not treated a
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="284c-dd42-3a1b-ef7e" name="Cryptek 2 - Ingenious" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2512-e10e-d0b0-3a7c" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2512-e10e-d0b0-3a7c" type="max"/>
       </constraints>
       <profiles>
         <profile id="52bd-9611-f33a-037d" name="Ingenious" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1147,12 +1142,12 @@ In narrative play, operatives that are successfully reanimated are not treated a
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f248-e5e1-b4a1-898a" name="Cryptek 3 - Collector" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5227-d01c-433a-5303" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5227-d01c-433a-5303" type="max"/>
       </constraints>
       <profiles>
         <profile id="e30a-8ca6-d1d1-ba49" name="Collector" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1162,12 +1157,12 @@ In narrative play, operatives that are successfully reanimated are not treated a
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="db95-5eb2-d14a-63c1" name="Hierotek 1 - Enduring" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9514-71bc-c2c4-324f" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9514-71bc-c2c4-324f" type="max"/>
       </constraints>
       <profiles>
         <profile id="abee-84ba-3395-3975" name="Enduring" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1177,12 +1172,12 @@ In narrative play, operatives that are successfully reanimated are not treated a
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7c79-a325-295b-1058" name="Hierotek 2 - Revenant" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe06-e894-dd6a-7b29" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe06-e894-dd6a-7b29" type="max"/>
       </constraints>
       <profiles>
         <profile id="14ec-4f6a-e034-4735" name="Revenant" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1192,12 +1187,12 @@ In narrative play, operatives that are successfully reanimated are not treated a
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ef0a-ef00-d71e-4d34" name="Hierotek 3 - Unrelenting" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b742-3ef7-05ad-23ed" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b742-3ef7-05ad-23ed" type="max"/>
       </constraints>
       <profiles>
         <profile id="2196-f532-beb0-26af" name="Unrelenting" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1207,7 +1202,7 @@ In narrative play, operatives that are successfully reanimated are not treated a
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -1216,24 +1211,24 @@ In narrative play, operatives that are successfully reanimated are not treated a
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2938-8212-c7a7-4524" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2938-8212-c7a7-4524" type="notInstanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="c61a-51a3-370d-bf55" scope="force" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e44-60f8-0b92-9893" type="max"/>
+        <constraint field="c61a-51a3-370d-bf55" scope="force" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e44-60f8-0b92-9893" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="576f-ddf8-aa22-ce09" name="Phase Oculars" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5164-e254-3d24-4966" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5164-e254-3d24-4966" type="notInstanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5617-bf2a-e974-d217" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5617-bf2a-e974-d217" type="max"/>
           </constraints>
           <profiles>
             <profile id="59bd-8e63-c61c-dca4" name="Phase Oculars (0AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -1243,19 +1238,19 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5658-ed2a-84ab-f5f1" name="Hyperphase Blade" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa0f-6d4d-a4a3-1a50" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa0f-6d4d-a4a3-1a50" type="notInstanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="488e-a651-61fc-a859" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="488e-a651-61fc-a859" type="max"/>
           </constraints>
           <profiles>
             <profile id="42e2-1712-dc40-390c" name="Hyperphase blade" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1265,12 +1260,12 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="14e2-2d85-953f-80dc" name="Tesla Weave" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa35-7495-9eb8-d149" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa35-7495-9eb8-d149" type="max"/>
           </constraints>
           <profiles>
             <profile id="c8c4-79af-26b7-70a9" name="Tesla Weave" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1280,19 +1275,19 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5938-54d3-ad8f-aa19" name="Arcshock Projector" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a5f-e486-22f1-8279" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a5f-e486-22f1-8279" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dd9-a13f-bc68-9e4a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dd9-a13f-bc68-9e4a" type="max"/>
           </constraints>
           <profiles>
             <profile id="6635-fdc6-c5de-f6ba" name="Arcshock Projector" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1302,13 +1297,13 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="acd7-bb5a-c67b-ebfd" name="Quantum Reanimytes*" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5c1-a0e6-2f7d-cec3" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d77d-6e9a-5ad0-5287" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5c1-a0e6-2f7d-cec3" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d77d-6e9a-5ad0-5287" type="max"/>
           </constraints>
           <profiles>
             <profile id="6f60-e73d-7141-0c31" name="Quantum Reanimytes" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1318,20 +1313,20 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7a51-87da-647a-0a6c" name="Plasma Crystal [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ccc-a2b5-6bfd-9c88" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d99-4c2f-1a9b-8fad" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ccc-a2b5-6bfd-9c88" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d99-4c2f-1a9b-8fad" type="max"/>
           </constraints>
           <profiles>
             <profile id="88e4-0952-096a-db1f" name="Plasma Crystal" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1341,13 +1336,13 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9b7e-8b9d-f9bc-06cc" name="Devourer Nanoscarabs" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be72-fa06-638e-8623" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="38b6-8137-bf3e-c049" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be72-fa06-638e-8623" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="38b6-8137-bf3e-c049" type="max"/>
           </constraints>
           <profiles>
             <profile id="a439-c99a-14a3-6439" name="⌖  Devourer nanoscarabs" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1367,20 +1362,20 @@ In narrative play, operatives that are successfully reanimated are not treated a
             <infoLink id="5478-4f30-0b9f-87e8" name="Rng x" hidden="false" targetId="92de-2ad3-3554-0b3e" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cf70-3360-9258-7378" name="Phase Shifter*" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a377-ad3e-4141-00f3" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a377-ad3e-4141-00f3" type="notInstanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bef6-37a7-8621-6e35" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb37-8a0d-173a-b183" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bef6-37a7-8621-6e35" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb37-8a0d-173a-b183" type="max"/>
           </constraints>
           <profiles>
             <profile id="5708-0439-cabc-168c" name="Phase Shifter" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1390,7 +1385,7 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b45b-22b4-1766-386f" name="Resurrection Beam [RARE]" hidden="false" collective="false" import="true" type="upgrade">
@@ -1399,13 +1394,13 @@ In narrative play, operatives that are successfully reanimated are not treated a
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3a89-f4f1-b4ac-caa1" type="notInstanceOf"/>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a377-ad3e-4141-00f3" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3a89-f4f1-b4ac-caa1" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a377-ad3e-4141-00f3" type="notInstanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -1414,8 +1409,8 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe4d-80de-a807-95e9" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e59-631c-226f-05d7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe4d-80de-a807-95e9" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e59-631c-226f-05d7" type="max"/>
           </constraints>
           <profiles>
             <profile id="5888-f58d-71ad-a5e5" name="Resurrection Beam" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1425,7 +1420,7 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cd88-4bac-0c2b-d6bf" name="Tech-tendrils [RARE]" hidden="false" collective="false" import="true" type="upgrade">
@@ -1434,15 +1429,15 @@ In narrative play, operatives that are successfully reanimated are not treated a
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a377-ad3e-4141-00f3" type="notInstanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a377-ad3e-4141-00f3" type="notInstanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b50-bf92-bf9d-7cbd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b50-bf92-bf9d-7cbd" type="max"/>
           </constraints>
           <profiles>
             <profile id="7e83-7700-3019-62f3" name="Tech-tendrils" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1453,20 +1448,20 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1c11-8802-e721-71a4" name="Rapid Reanimatrix [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a8b-358a-06a3-cbda" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e44f-d2f3-f71c-dde7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a8b-358a-06a3-cbda" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e44f-d2f3-f71c-dde7" type="max"/>
           </constraints>
           <profiles>
             <profile id="a158-341d-89e0-cd94" name="Rapid Reanimatrix" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1478,7 +1473,7 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ec22-4f73-b136-9501" name="Temporic Orb [RARE]" hidden="false" collective="false" import="true" type="upgrade">
@@ -1487,15 +1482,15 @@ In narrative play, operatives that are successfully reanimated are not treated a
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a377-ad3e-4141-00f3" type="notInstanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a377-ad3e-4141-00f3" type="notInstanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f30d-64e8-7647-40fd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f30d-64e8-7647-40fd" type="max"/>
           </constraints>
           <profiles>
             <profile id="9819-9a09-dc2b-06c6" name="Temporic Orb" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1505,20 +1500,20 @@ In narrative play, operatives that are successfully reanimated are not treated a
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="af75-2250-5b78-45b9" name="Hunter Scarab [RARE]" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="402f-05c1-ab98-0cfa" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5ed7-b7b8-9da3-02fb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="402f-05c1-ab98-0cfa" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5ed7-b7b8-9da3-02fb" type="max"/>
           </constraints>
           <profiles>
             <profile id="85c1-3ed0-590d-74bd" name="⌖ Hunter scarab" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1538,7 +1533,7 @@ In narrative play, operatives that are successfully reanimated are not treated a
             <infoLink id="afa6-2770-f337-878f" name="No Cover" hidden="false" targetId="c091-97f7-8640-5e56" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1547,12 +1542,12 @@ In narrative play, operatives that are successfully reanimated are not treated a
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+            <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48b6-e134-34f5-5435" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48b6-e134-34f5-5435" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="2936-1951-d609-90ad" name="Scout" hidden="false" collective="false" import="true" targetId="9118-a98b-0ffe-9e3d" type="selectionEntry">
@@ -1561,8 +1556,8 @@ In narrative play, operatives that are successfully reanimated are not treated a
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d78-afa7-1375-f596" type="notInstanceOf"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a377-ad3e-4141-00f3" type="notInstanceOf"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d78-afa7-1375-f596" type="notInstanceOf"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a377-ad3e-4141-00f3" type="notInstanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1573,7 +1568,7 @@ In narrative play, operatives that are successfully reanimated are not treated a
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d78-afa7-1375-f596" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d78-afa7-1375-f596" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1584,8 +1579,8 @@ In narrative play, operatives that are successfully reanimated are not treated a
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d78-afa7-1375-f596" type="instanceOf"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5164-e254-3d24-4966" type="instanceOf"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d78-afa7-1375-f596" type="instanceOf"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5164-e254-3d24-4966" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1607,8 +1602,8 @@ In narrative play, operatives that are successfully reanimated are not treated a
         <characteristic name="APL" typeId="c84a-a042-6fe6-519b">⬤</characteristic>
         <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">⬛</characteristic>
         <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">⬟</characteristic>
-        <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">⌖ </characteristic>
-        <characteristic name="W" typeId="db11-738c-048c-759e">⚔ </characteristic>
+        <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">⌖</characteristic>
+        <characteristic name="W" typeId="db11-738c-048c-759e">⚔</characteristic>
       </characteristics>
     </profile>
     <profile id="5004-f129-a0b3-0c3f" name="Cryptek Actions" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">

--- a/2021 - Kommando.cat
+++ b/2021 - Kommando.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9210-4d15-82ce-4526" name="Kommando" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9210-4d15-82ce-4526" name="Kommando" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="fff5-e805-1699-7f74" name="Ork" hidden="false"/>
     <categoryEntry id="27c3-6016-6b60-a2d3" name="Kommando Grot" hidden="false"/>
@@ -21,70 +21,70 @@
         <categoryLink id="20c9-3a2a-abf3-7d86" name="Configuration" hidden="false" targetId="fb89-efb1-54e4-59c5" primary="false"/>
         <categoryLink id="0375-e929-2425-4bf3" name="Leader" hidden="false" targetId="3198-c1ce-dfd0-fb4f" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b0ac-9b91-6776-4c8f" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b0ac-9b91-6776-4c8f" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3745-f4e3-42da-ebb1" name="Operative" hidden="false" targetId="f98b-0289-0f1f-b233" primary="false"/>
         <categoryLink id="85cc-bd68-c3cf-e7ac" name="Kommando Grot" hidden="false" targetId="27c3-6016-6b60-a2d3" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df2d-407c-790d-917b" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df2d-407c-790d-917b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7fdd-a737-7fc1-2d56" name="Slasha Boy" hidden="false" targetId="002d-52b4-5629-1c01" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10e5-81dd-6c37-092b" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10e5-81dd-6c37-092b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8bc8-1089-75ca-fd13" name="Bomb Squig" hidden="false" targetId="4152-b68f-0cbd-9b3d" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e580-1b78-e150-aa00" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e580-1b78-e150-aa00" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b27b-dac3-1791-5cd0" name="Breacha Boy" hidden="false" targetId="c1a6-ba11-1d1f-7809" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d74c-ad47-ce62-224b" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d74c-ad47-ce62-224b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="c485-243c-179a-6af3" name="Burna Boy" hidden="false" targetId="589f-07cd-c552-ff24" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1571-3dd4-7918-e73b" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1571-3dd4-7918-e73b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3c21-ea76-98b4-c4c2" name="Comms Boy" hidden="false" targetId="346d-8675-ff7f-80ff" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f39-16d7-bee4-9ee8" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f39-16d7-bee4-9ee8" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="c185-36c8-f6de-afde" name="Dakka Boy" hidden="false" targetId="f28e-5ad9-3d14-dd19" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aede-8a5f-e379-b623" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aede-8a5f-e379-b623" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="97ac-3ddc-418c-a4e1" name="Rokkit Boy" hidden="false" targetId="b90d-e593-2aa6-36d5" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a39-d684-4ac2-5690" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a39-d684-4ac2-5690" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="19e8-afd2-cb7f-d061" name="Snipa Boy" hidden="false" targetId="4b8e-20e5-f8eb-0f21" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ca-470e-539d-1d1c" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ca-470e-539d-1d1c" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="f83b-b030-ce9b-afd1" name="Kommando💀" hidden="false" targetId="dde5-2643-f81c-96f5" primary="false">
           <modifiers>
-            <modifier type="increment" field="57c6-c25e-7eb9-6da2" value="1.0">
+            <modifier type="increment" field="57c6-c25e-7eb9-6da2" value="1">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4152-b68f-0cbd-9b3d" type="equalTo"/>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c3-6016-6b60-a2d3" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4152-b68f-0cbd-9b3d" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c3-6016-6b60-a2d3" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57c6-c25e-7eb9-6da2" type="max"/>
+            <constraint field="selections" scope="force" value="10" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57c6-c25e-7eb9-6da2" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -187,8 +187,8 @@
       <selectionEntries>
         <selectionEntry id="3925-021e-387d-85c0" name="Grot choppa" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3d4-0ac6-035e-b439" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0f8-451b-8903-79da" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3d4-0ac6-035e-b439" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0f8-451b-8903-79da" type="max"/>
           </constraints>
           <profiles>
             <profile id="5cd4-48f0-f3dd-2af3" name="⚔ Grot choppa" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -202,7 +202,7 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -222,7 +222,7 @@
         <entryLink id="b223-4219-564e-da5f" name="Specialism" hidden="false" collective="false" import="true" targetId="110b-d090-a59f-6531" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0847-16ff-c2cd-2c64" name="Nob w/ big choppa" hidden="false" collective="false" import="true" type="model">
@@ -239,8 +239,8 @@
       <selectionEntries>
         <selectionEntry id="6bd1-4db2-f39e-d7d8" name="Big choppa" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="319e-8b4b-7b39-4ad6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bad-9a15-fa2d-a8a7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="319e-8b4b-7b39-4ad6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bad-9a15-fa2d-a8a7" type="max"/>
           </constraints>
           <profiles>
             <profile id="dc53-eb8e-b2e8-6319" name="⚔ Big choppa" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -254,15 +254,15 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="faae-5756-bcff-5d7e" name="Slugga" hidden="false" collective="false" import="true" targetId="c9ee-4ebe-26ec-050e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="340f-5642-bc5d-9ea4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1c0-5fef-9ac5-8b9c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="340f-5642-bc5d-9ea4" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1c0-5fef-9ac5-8b9c" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="3212-5d26-c961-8bec" name="Equipment" hidden="false" collective="false" import="true" targetId="9ac8-b82b-4cd6-1e5a" type="selectionEntryGroup"/>
@@ -291,7 +291,7 @@
         <entryLink id="ce79-067a-14c1-4125" name="Battle Scars" hidden="false" collective="false" import="true" targetId="d5ae-a34b-acc2-dfe7" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c9ee-4ebe-26ec-050e" name="Slugga" hidden="false" collective="false" import="true" type="upgrade">
@@ -310,7 +310,7 @@
         <infoLink id="ecfb-48ca-3000-ddf3" name="Rng x" hidden="false" targetId="92de-2ad3-3554-0b3e" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="94ab-c60d-d426-0fdf" name="Dakka Boy" hidden="false" collective="false" import="true" type="model">
@@ -347,8 +347,8 @@
       <selectionEntries>
         <selectionEntry id="3814-f104-ad3e-bf46" name="Dakka shoota" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b32a-6539-938b-8ea0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e10c-e7e3-5089-a2a1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b32a-6539-938b-8ea0" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e10c-e7e3-5089-a2a1" type="max"/>
           </constraints>
           <profiles>
             <profile id="a5df-0b33-d014-30ff" name="⌖ Dakka shoota" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -362,7 +362,7 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -394,7 +394,7 @@
         <entryLink id="33dc-2b4b-6405-2164" name="Specialism" hidden="false" collective="false" import="true" targetId="110b-d090-a59f-6531" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c7da-483a-3f7e-8dd5" name="Snipa Boy" hidden="false" collective="false" import="true" type="model">
@@ -431,8 +431,8 @@
       <selectionEntries>
         <selectionEntry id="b1ca-c3ad-f4ed-123d" name="Scoped big shoota" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f11-e6de-7373-13b2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cc8-c70b-c4c3-761e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f11-e6de-7373-13b2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cc8-c70b-c4c3-761e" type="max"/>
           </constraints>
           <profiles>
             <profile id="c387-a35f-ad72-32c7" name="⌖ Scoped big shoota" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -449,7 +449,7 @@
             <infoLink id="75ae-9104-67c0-d45d" name="MWx" hidden="false" targetId="0d4b-7a76-d266-bcc1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -471,7 +471,7 @@
         <entryLink id="71a7-b3b9-c23b-b062" name="Specialism" hidden="false" collective="false" import="true" targetId="110b-d090-a59f-6531" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1ea0-bc33-96e9-29d3" name="Nob w/ power klaw" hidden="false" collective="false" import="true" type="model">
@@ -488,8 +488,8 @@
       <selectionEntries>
         <selectionEntry id="4c2d-8627-6844-715c" name="Power klaw" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e922-57e5-1e87-a439" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00bd-073c-e49b-5c95" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e922-57e5-1e87-a439" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00bd-073c-e49b-5c95" type="max"/>
           </constraints>
           <profiles>
             <profile id="3ff2-aedc-362e-303e" name="⚔ Power klaw" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -506,15 +506,15 @@
             <infoLink id="da83-3714-ecfa-b308" name="Brutal" hidden="false" targetId="16e9-a975-03a1-91c0" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="aca3-10ff-4d17-a795" name="Slugga" hidden="false" collective="false" import="true" targetId="c9ee-4ebe-26ec-050e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="730c-4913-8289-f2c3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04f9-2c6d-f906-7395" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="730c-4913-8289-f2c3" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04f9-2c6d-f906-7395" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="e1fe-be29-380e-2ee6" name="Equipment" hidden="false" collective="false" import="true" targetId="9ac8-b82b-4cd6-1e5a" type="selectionEntryGroup"/>
@@ -543,7 +543,7 @@
         <entryLink id="ad7b-8b33-b568-6e13" name="Specialism" hidden="false" collective="false" import="true" targetId="110b-d090-a59f-6531" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cb2d-d9d4-fb6f-87d3" name="Boy" hidden="false" collective="false" import="true" type="model">
@@ -570,14 +570,14 @@
       <entryLinks>
         <entryLink id="c955-99e4-0824-036e" name="Slugga" hidden="false" collective="false" import="true" targetId="c9ee-4ebe-26ec-050e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3eed-9ffe-318f-a949" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eab6-929c-624e-3a5f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3eed-9ffe-318f-a949" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eab6-929c-624e-3a5f" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="a06e-d694-8d03-7ee5" name="Choppa" hidden="false" collective="false" import="true" targetId="e84b-1723-e7a8-26eb" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81da-85b9-9b0e-fa0f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7be8-48dd-4a1f-c1d2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81da-85b9-9b0e-fa0f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7be8-48dd-4a1f-c1d2" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="6945-6104-253a-e381" name="Equipment" hidden="false" collective="false" import="true" targetId="9ac8-b82b-4cd6-1e5a" type="selectionEntryGroup"/>
@@ -616,7 +616,7 @@
         <entryLink id="97a8-8968-8fa5-c2c9" name="Specialism" hidden="false" collective="false" import="true" targetId="110b-d090-a59f-6531" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0b3c-3ead-0178-0609" name="Slasha Boy" hidden="false" collective="false" import="true" type="model">
@@ -648,8 +648,8 @@
       <selectionEntries>
         <selectionEntry id="1491-56af-71a8-09da" name="Throwing knives" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="566d-77ac-417d-b039" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="050f-2eac-d233-8f94" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="566d-77ac-417d-b039" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="050f-2eac-d233-8f94" type="max"/>
           </constraints>
           <profiles>
             <profile id="0c72-b8fb-b388-d867" name="Throwing knives" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -667,13 +667,13 @@
             <infoLink id="586e-3259-65c2-47b6" name="Silent" hidden="false" targetId="ce60-8109-69c9-3908" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="01fb-fba5-90ba-7423" name="Twin choppas" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7bc-f584-0a89-15ac" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffd1-b5ff-d3dc-e197" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7bc-f584-0a89-15ac" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffd1-b5ff-d3dc-e197" type="max"/>
           </constraints>
           <profiles>
             <profile id="c536-1718-7897-c509" name="Twin choppas" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -690,7 +690,7 @@
             <infoLink id="c914-5fea-d826-911a" name="Relentless" hidden="false" targetId="1875-9b07-2a07-aacc" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -731,7 +731,7 @@
         <entryLink id="a517-8e98-0267-c1f0" name="Specialism" hidden="false" collective="false" import="true" targetId="110b-d090-a59f-6531" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="277f-a5f5-d3c6-ab2e" name="Breacha Boy" hidden="false" collective="false" import="true" type="model">
@@ -768,8 +768,8 @@
       <selectionEntries>
         <selectionEntry id="f7f4-54c5-66d6-b1d3" name="Breacha ram" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f70f-984d-96f7-4e0e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce4d-e24a-215e-6e37" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f70f-984d-96f7-4e0e" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce4d-e24a-215e-6e37" type="max"/>
           </constraints>
           <profiles>
             <profile id="5a76-02bc-41c8-162f" name="⚔ Breacha ram" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -786,15 +786,15 @@
             <infoLink id="dd3b-f93a-8cb9-6c05" name="Brutal" hidden="false" targetId="16e9-a975-03a1-91c0" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="e736-710c-8e5a-4007" name="Slugga" hidden="false" collective="false" import="true" targetId="c9ee-4ebe-26ec-050e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1677-7b83-ecf8-833f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="127b-7d9d-d1d7-ceb5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1677-7b83-ecf8-833f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="127b-7d9d-d1d7-ceb5" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="8cca-c869-9ee4-998e" name="Equipment" hidden="false" collective="false" import="true" targetId="9ac8-b82b-4cd6-1e5a" type="selectionEntryGroup"/>
@@ -823,13 +823,13 @@
         <entryLink id="80e9-e663-8e74-7e96" name="Specialism" hidden="false" collective="false" import="true" targetId="110b-d090-a59f-6531" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0b03-8967-fc87-3480" name="Fists" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d2f-2844-ee1d-8afd" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="334e-59cd-4a8e-190d" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d2f-2844-ee1d-8afd" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="334e-59cd-4a8e-190d" type="max"/>
       </constraints>
       <profiles>
         <profile id="5f04-e544-f68a-8b09" name="⚔ Fists" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -843,7 +843,7 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ba5-0660-edb1-d020" name="Comms Boy" hidden="false" collective="false" import="true" type="model">
@@ -880,8 +880,8 @@
       <selectionEntries>
         <selectionEntry id="af85-6f33-a425-213a" name="Shokka pistol" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed34-b282-c365-d3f1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7f2-af12-e149-4a5a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed34-b282-c365-d3f1" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7f2-af12-e149-4a5a" type="max"/>
           </constraints>
           <profiles>
             <profile id="3ede-8633-3573-275a" name="⌖ Shokka pistol" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -900,7 +900,7 @@
             <infoLink id="fe94-f970-ee1b-8ce1" name="MWx" hidden="false" targetId="0d4b-7a76-d266-bcc1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -932,7 +932,7 @@
         <entryLink id="51f2-af18-0d74-c6a9" name="Specialism" hidden="false" collective="false" import="true" targetId="110b-d090-a59f-6531" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c18b-b7df-3025-434b" name="Burna Boy" hidden="false" collective="false" import="true" type="model">
@@ -959,8 +959,8 @@
       <selectionEntries>
         <selectionEntry id="1132-90a9-d90c-82f3" name="Burna" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54bc-c5ae-a58c-7f75" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2b7-591e-7ece-17bb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54bc-c5ae-a58c-7f75" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2b7-591e-7ece-17bb" type="max"/>
           </constraints>
           <profiles>
             <profile id="38e6-32f5-756b-34bd" name="⌖ Burna" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -978,7 +978,7 @@
             <infoLink id="7a89-fcfe-be93-0627" name="Torrent x" hidden="false" targetId="ec4b-2d70-51a7-5653" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1010,7 +1010,7 @@
         <entryLink id="8768-b878-ff46-f46a" name="Specialism" hidden="false" collective="false" import="true" targetId="110b-d090-a59f-6531" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f67f-2de3-daef-1fbf" name="Rokkit Boy" hidden="false" collective="false" import="true" type="model">
@@ -1042,8 +1042,8 @@
       <selectionEntries>
         <selectionEntry id="fa8f-2e56-ba1a-dc00" name="Rokkit launcha" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f115-9afb-b183-5ae2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="008b-b792-0079-8f4e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f115-9afb-b183-5ae2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="008b-b792-0079-8f4e" type="max"/>
           </constraints>
           <profiles>
             <profile id="800b-7d03-849f-fc0e" name="⌖ Rokkit launcha" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1061,7 +1061,7 @@
             <infoLink id="f46f-74f1-2547-4974" name="Splash x" hidden="false" targetId="eab8-73f5-feed-5924" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1083,7 +1083,7 @@
         <entryLink id="ce7e-5202-bd94-d4e8" name="Specialism" hidden="false" collective="false" import="true" targetId="110b-d090-a59f-6531" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="254b-70c4-40f8-0556" name="Bomb Squig" hidden="false" collective="false" import="true" type="model">
@@ -1105,7 +1105,7 @@
         </profile>
         <profile id="d53d-7afa-1b90-8783" name="Stoopid" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
           <characteristics>
-            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">This operative cannot perform mission actions, cannot perform the Pick Up action and cannot have a Conceal order. It cannot be equipped with equipment. In narrative play, it cannot gain (or lose) experience and automatically passes Casualty tests.</characteristic>
+            <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">This operative cannot perform mission actions, cannot perform the Pick Up action and cannot have a Conceal order. It cannot be equipped with equipment. In narrative play, it cannot gain (or lose) experience and automatically passes Casualty tests. This operative&apos;s APL characteristic cannot be positively modified.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1117,8 +1117,8 @@
       <selectionEntries>
         <selectionEntry id="f0ad-3ac7-22f2-8973" name="Dynamite" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74f8-7ae5-deb9-138f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fda-0256-d430-bd34" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74f8-7ae5-deb9-138f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fda-0256-d430-bd34" type="max"/>
           </constraints>
           <profiles>
             <profile id="f75f-a951-4257-1828" name="⌖ Dynamite" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1132,7 +1132,7 @@
             </profile>
             <profile id="9494-b28f-3c5f-3a67" name="*Bomb Squig" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
               <characteristics>
-                <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">This operative can perform a Shoot action with this weapon if it is within Engagement Range of an enemy operative. When this operative performs a Shoot action and selects this ranged weapon, make a shooting attack against each other operative Visible to and within of it (even if it has friendly operatives within its Engagement Range) with this weapon - each of them is a valid target and cannot be in Cover. After all of those shooting attacks have been made, this operative is incapacitated and does not roll for its BOOM! ability. This operative cannot make a shooting attack with this weapon by performing an Overwatch action.</characteristic>
+                <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">This operative can perform a Shoot action with this weapon if it is within Engagement Range of an enemy operative. When this operative performs a Shoot action and selects this ranged weapon, make a shooting attack against each other operative within its Engagement Range (even if it has friendly operatives within its Engagement Range) with this weapon - each of them is a valid target and cannot be in Cover. After all of those shooting attacks have been made, this operative is incapacitated and does not roll for its BOOM! ability. This operative cannot make a shooting attack with this weapon by performing an Overwatch action.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -1141,13 +1141,13 @@
             <infoLink id="93e5-2979-7583-c98f" name="Px" hidden="false" targetId="1f11-c169-2746-13cf" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a37f-d047-9693-69f3" name="Vicious Bite" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6baa-7c2e-d16d-19f8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9d2-8db6-fc61-4465" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6baa-7c2e-d16d-19f8" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9d2-8db6-fc61-4465" type="max"/>
           </constraints>
           <profiles>
             <profile id="d6b2-0648-8524-bbb5" name="⚔ Vicious Bite" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1161,12 +1161,12 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e84b-1723-e7a8-26eb" name="Choppa" hidden="false" collective="false" import="true" type="upgrade">
@@ -1179,15 +1179,22 @@
             <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">-</characteristic>
             <characteristic name="!" typeId="c495-8d08-b6b8-b434">-</characteristic>
           </characteristics>
+          <modifiers>
+            <modifier type="set" value="3" field="5f37-25bb-661b-5c9c">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="parent" childId="8996-77be-ec77-1199" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="de96-3828-9883-b545" name="Kommando 1 - Skinna" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6221-2096-24f7-9789" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6221-2096-24f7-9789" type="max"/>
       </constraints>
       <profiles>
         <profile id="0b34-b6d9-ff0a-fca8" name="Skinna" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1197,12 +1204,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e0eb-aa61-24ef-1e8a" name="Kommando 2 - Irritable" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f626-54d6-fa7e-a924" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f626-54d6-fa7e-a924" type="max"/>
       </constraints>
       <profiles>
         <profile id="c14d-c787-908a-d8f4" name="Irritable" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1212,12 +1219,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6c99-0749-78d8-2dc7" name="Kommando 3 - Destructive" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cb9-6f79-0b08-0191" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cb9-6f79-0b08-0191" type="max"/>
       </constraints>
       <profiles>
         <profile id="1e1a-c7a9-e915-fe51" name="Destructive" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1230,12 +1237,12 @@
         <infoLink id="b394-ca08-cb5c-bad4" name="Relentless" hidden="false" targetId="1875-9b07-2a07-aacc" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4237-cb68-cc4a-d786" name="Kommando 4 - Shifty" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af80-de8e-7f43-e1f8" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af80-de8e-7f43-e1f8" type="max"/>
       </constraints>
       <profiles>
         <profile id="1fb7-3471-8573-5a5a" name="Shifty" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1245,12 +1252,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c3d0-feff-41d0-3129" name="Kommando 5 - Thievin&apos; Git" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f27-ae03-fc8f-682d" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f27-ae03-fc8f-682d" type="max"/>
       </constraints>
       <profiles>
         <profile id="600f-c225-b12e-9785" name="Thievin&apos; Git" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1260,12 +1267,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c8bc-82c8-e9e3-8974" name="Kommando 6 - Ambusher" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02ac-cd7a-3385-fcff" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02ac-cd7a-3385-fcff" type="max"/>
       </constraints>
       <profiles>
         <profile id="cbcd-ba40-a666-ab85" name="Ambusher" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -1275,7 +1282,7 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -1284,18 +1291,18 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7138-2b60-74ce-a90b" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7138-2b60-74ce-a90b" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="c61a-51a3-370d-bf55" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f68-7415-9c4e-f14a" type="max"/>
+        <constraint field="c61a-51a3-370d-bf55" scope="roster" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f68-7415-9c4e-f14a" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="1eb6-0b9f-49d4-8d5f" name="Harpoon*" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d641-c6fc-fe88-002a" type="max"/>
-            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf12-1573-92de-b128" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d641-c6fc-fe88-002a" type="max"/>
+            <constraint field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf12-1573-92de-b128" type="max"/>
           </constraints>
           <profiles>
             <profile id="cbef-d427-7972-f430" name="⌖ Harpoon" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1313,13 +1320,13 @@
             <infoLink id="8cb5-92a5-aac1-9f7b" name="Stun" hidden="false" targetId="a1e3-4e0b-f7c2-eb59" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d8c1-5c20-442c-3791" name="Sledgehammer*" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ed0-cdbb-1bc6-3750" type="max"/>
-            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b608-a73e-a41a-f0b9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ed0-cdbb-1bc6-3750" type="max"/>
+            <constraint field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b608-a73e-a41a-f0b9" type="max"/>
           </constraints>
           <profiles>
             <profile id="2868-b20a-c9ab-d279" name="⚔ Sledgehammer" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1336,12 +1343,12 @@
             <infoLink id="21bf-199c-0c18-b7d4" name="Stun" hidden="false" targetId="a1e3-4e0b-f7c2-eb59" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="46c4-0c4f-db8c-ea2f" name="Stun Grenade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7887-3e76-8fcd-4f95" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7887-3e76-8fcd-4f95" type="max"/>
           </constraints>
           <profiles>
             <profile id="f342-fd5f-8360-4b5a" name="Stun Grenade (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -1351,12 +1358,12 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0d60-d5b5-ef5f-65f4" name="Smoke Grenade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18bb-72b7-c73c-03af" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18bb-72b7-c73c-03af" type="max"/>
           </constraints>
           <profiles>
             <profile id="bac2-dfa2-e31f-b1d8" name="Smoke Grenade (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
@@ -1366,13 +1373,13 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0139-613e-fe57-b163" name="Stikkbomb" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf2c-6cec-bcc8-9543" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="841c-717d-d8b0-dae6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf2c-6cec-bcc8-9543" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="841c-717d-d8b0-dae6" type="max"/>
           </constraints>
           <profiles>
             <profile id="446e-a24e-0e7e-304a" name="Stikkbomb" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1392,13 +1399,13 @@
             <infoLink id="31fd-7acf-a0d1-c7f3" name="Limited" hidden="false" targetId="1eb0-6ad3-3e5a-d8ec" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7594-f92e-a294-719c" name="Dynamite*" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a66f-653a-4401-12ef" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8aed-4de8-c3c4-b0d4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a66f-653a-4401-12ef" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8aed-4de8-c3c4-b0d4" type="max"/>
           </constraints>
           <profiles>
             <profile id="4722-591f-6895-4f89" name="Dynamite" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1420,12 +1427,12 @@
             <infoLink id="01f6-6e62-ad52-6043" name="Unwieldy" hidden="false" targetId="b30a-9fa8-7a06-ce70" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="4.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="4"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f580-1b46-b68c-c45d" name="Climbing Rope" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fab2-bd75-8994-913e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fab2-bd75-8994-913e" type="max"/>
           </constraints>
           <profiles>
             <profile id="9e5c-6756-60b2-6500" name="Climbing Rope" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1438,36 +1445,36 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8fc7-8995-ed4a-9f43" name="Shiny Slugz (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3814-f104-ad3e-bf46" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1ca-c3ad-f4ed-123d" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9ee-4ebe-26ec-050e" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3814-f104-ad3e-bf46" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1ca-c3ad-f4ed-123d" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9ee-4ebe-26ec-050e" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="set" field="c61a-51a3-370d-bf55" value="2.0">
+            <modifier type="set" field="c61a-51a3-370d-bf55" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9ee-4ebe-26ec-050e" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9ee-4ebe-26ec-050e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4e8-46d8-b3d3-73c4" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2fa9-e2a6-a034-3ed6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4e8-46d8-b3d3-73c4" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2fa9-e2a6-a034-3ed6" type="max"/>
           </constraints>
           <profiles>
             <profile id="5a7c-952b-0fc4-3ace" name="Shiny Slugz" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1477,42 +1484,42 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bca7-db74-5d0e-c51d" name="Mork&apos;s Eyeball (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3814-f104-ad3e-bf46" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1ca-c3ad-f4ed-123d" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9ee-4ebe-26ec-050e" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fa8f-2e56-ba1a-dc00" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3814-f104-ad3e-bf46" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1ca-c3ad-f4ed-123d" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9ee-4ebe-26ec-050e" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fa8f-2e56-ba1a-dc00" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="set" field="c61a-51a3-370d-bf55" value="1.0">
+            <modifier type="set" field="c61a-51a3-370d-bf55" value="1">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fa8f-2e56-ba1a-dc00" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9ee-4ebe-26ec-050e" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fa8f-2e56-ba1a-dc00" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9ee-4ebe-26ec-050e" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e6-a9d2-55a4-1c26" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="059f-435e-6d83-4bff" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e6-a9d2-55a4-1c26" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="059f-435e-6d83-4bff" type="max"/>
           </constraints>
           <profiles>
             <profile id="2c82-5b67-089d-bc28" name="Mork&apos;s Eyeball" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1522,25 +1529,25 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="aa8e-f1a6-96f3-573e" name="Devil&apos;s Whispa (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9ee-4ebe-26ec-050e" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9ee-4ebe-26ec-050e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d784-9084-a602-1065" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b5a1-4f1a-c41a-6bd6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d784-9084-a602-1065" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b5a1-4f1a-c41a-6bd6" type="max"/>
           </constraints>
           <profiles>
             <profile id="49e8-9f51-7a20-7956" name="Devil&apos;s Whispa" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1552,31 +1559,31 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4d78-3389-ae8b-a18a" name="Skraga&apos;s Choppa (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6bd1-4db2-f39e-d7d8" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01fb-fba5-90ba-7423" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e84b-1723-e7a8-26eb" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6bd1-4db2-f39e-d7d8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01fb-fba5-90ba-7423" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e84b-1723-e7a8-26eb" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aa9-11ad-a250-e9c9" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c284-3304-865e-a86f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aa9-11ad-a250-e9c9" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c284-3304-865e-a86f" type="max"/>
           </constraints>
           <profiles>
             <profile id="fa6d-7ee7-85d3-cd98" name="Skraga&apos;s Choppa" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1586,20 +1593,20 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6242-4fbd-a481-b30a" name="Fungal Brew (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="538c-88cb-7d34-0bd7" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f92-0f31-fd9c-f60d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="538c-88cb-7d34-0bd7" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f92-0f31-fd9c-f60d" type="max"/>
           </constraints>
           <profiles>
             <profile id="5350-aa05-3f12-c04a" name="Fungal Brew" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1613,20 +1620,20 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="257a-ef95-6d65-fbe2" name="Klever Kap (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ef6-d924-b62c-2c11" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="797c-95a9-6bed-0fbf" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ef6-d924-b62c-2c11" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="797c-95a9-6bed-0fbf" type="max"/>
           </constraints>
           <profiles>
             <profile id="c08e-d7f5-2491-3d6b" name="Klever Kap" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1636,25 +1643,25 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="f193-c718-ef06-4201" name="Choppa" hidden="false" collective="false" import="true" targetId="e84b-1723-e7a8-26eb" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3279-2aa0-878f-714e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3279-2aa0-878f-714e" type="max"/>
           </constraints>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </entryLink>
         <entryLink id="94a5-808f-ad14-96aa" name="Slugga" hidden="false" collective="false" import="true" targetId="c9ee-4ebe-26ec-050e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a381-4c1b-211d-7a93" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a381-4c1b-211d-7a93" type="max"/>
           </constraints>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </entryLink>
         <entryLink id="f050-74df-99de-bf34" name="Melee Weapons Rare Equipment" hidden="false" collective="false" import="true" targetId="d419-7a47-04c4-e1d9" type="selectionEntryGroup"/>
@@ -1665,12 +1672,12 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+            <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="555b-7035-8191-6a45" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="555b-7035-8191-6a45" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="ae4b-81fa-3d47-ed6e" name="Combat" hidden="false" collective="false" import="true" targetId="97d8-19ec-143d-8aad" type="selectionEntry">
@@ -1679,12 +1686,12 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c3-6016-6b60-a2d3" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f28e-5ad9-3d14-dd19" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b90d-e593-2aa6-36d5" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="589f-07cd-c552-ff24" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="346d-8675-ff7f-80ff" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8e-20e5-f8eb-0f21" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c3-6016-6b60-a2d3" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f28e-5ad9-3d14-dd19" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b90d-e593-2aa6-36d5" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="589f-07cd-c552-ff24" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="346d-8675-ff7f-80ff" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8e-20e5-f8eb-0f21" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1697,10 +1704,10 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c3-6016-6b60-a2d3" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b90d-e593-2aa6-36d5" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8e-20e5-f8eb-0f21" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f28e-5ad9-3d14-dd19" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c3-6016-6b60-a2d3" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b90d-e593-2aa6-36d5" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8e-20e5-f8eb-0f21" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f28e-5ad9-3d14-dd19" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1713,11 +1720,11 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b90d-e593-2aa6-36d5" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="589f-07cd-c552-ff24" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8e-20e5-f8eb-0f21" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1a6-ba11-1d1f-7809" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c33-5897-9860-0d86" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b90d-e593-2aa6-36d5" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="589f-07cd-c552-ff24" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8e-20e5-f8eb-0f21" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1a6-ba11-1d1f-7809" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c33-5897-9860-0d86" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1730,12 +1737,12 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c33-5897-9860-0d86" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c3-6016-6b60-a2d3" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="346d-8675-ff7f-80ff" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1a6-ba11-1d1f-7809" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="002d-52b4-5629-1c01" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8996-77be-ec77-1199" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c33-5897-9860-0d86" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c3-6016-6b60-a2d3" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="346d-8675-ff7f-80ff" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1a6-ba11-1d1f-7809" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="002d-52b4-5629-1c01" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8996-77be-ec77-1199" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1753,7 +1760,7 @@
         <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">⬛</characteristic>
         <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">⬟</characteristic>
         <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">⌖ 
-⚔ </characteristic>
+⚔</characteristic>
         <characteristic name="W" typeId="db11-738c-048c-759e">💀</characteristic>
       </characteristics>
     </profile>

--- a/2021 - Strike Force Justian.cat
+++ b/2021 - Strike Force Justian.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="cf38-3ba4-6a60-835a" name="Strike Force Justian" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="cf38-3ba4-6a60-835a" name="Strike Force Justian" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="7" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedProfiles>
     <profile name="Shape Reference" hidden="false" id="6ef3-2679-f642-90d6" typeId="350c-2ddd-8a24-377b" typeName="Operative">
       <characteristics>
@@ -282,7 +282,7 @@
             <characteristic name="APL" typeId="c84a-a042-6fe6-519b">3</characteristic>
             <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
             <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
-            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">5+</characteristic>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">3+</characteristic>
             <characteristic name="W" typeId="db11-738c-048c-759e">12</characteristic>
           </characteristics>
         </profile>
@@ -428,12 +428,12 @@
       <profiles>
         <profile name="Brother Vignus" typeId="350c-2ddd-8a24-377b" typeName="Operative" hidden="false" id="b172-3662-94c4-c966">
           <characteristics>
-            <characteristic name="M" typeId="c36f-3952-a91d-5a06"/>
-            <characteristic name="APL" typeId="c84a-a042-6fe6-519b"/>
-            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b"/>
-            <characteristic name="DF" typeId="4a18-41c1-51f2-c88c"/>
-            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2"/>
-            <characteristic name="W" typeId="db11-738c-048c-759e"/>
+            <characteristic name="M" typeId="c36f-3952-a91d-5a06">3⬤</characteristic>
+            <characteristic name="APL" typeId="c84a-a042-6fe6-519b">3</characteristic>
+            <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
+            <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
+            <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">3+</characteristic>
+            <characteristic name="W" typeId="db11-738c-048c-759e">14</characteristic>
           </characteristics>
         </profile>
       </profiles>

--- a/2021 - Veteran Guardsmen.cat
+++ b/2021 - Veteran Guardsmen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8e62-da18-67f9-c594" name="Veteran Guardsmen" revision="18" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="8e62-da18-67f9-c594" name="Veteran Guardsmen" revision="19" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="6790-22ed-c8fa-6309" name="Comms Veteran" hidden="false"/>
     <categoryEntry id="e2e3-78d3-0b08-9d27" name="VETERAN GUARDSMAN" hidden="false"/>
@@ -1356,7 +1356,7 @@
         </profile>
         <profile id="386d-88fd-a17e-acc5" name="Plant Mine (1AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
           <characteristics>
-            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Place a Mine token within ▲ of and Visible to this operative, then perform a free Dash action. This operative cannot perform this action if it is within Engagement Range of an enemy operative, or if this operative&apos;s Mine token is in the killzone. If this operative is incapacitated and removed from the killzone, remove its Mine token.</characteristic>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Place a Mine token within ▲ of and Visible to this operative, then perform a free Dash action. This operative cannot perform this action if it is within Engagement Range of an enemy operative, or if this operative&apos;s Mine token is in the killzone. If this operative is incapacitated and removed from the killzone, remove its Mine token. This operative can only perform this action once.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1384,7 +1384,7 @@
             </profile>
             <profile id="a14a-705c-7ba5-6fd0" name="Detonate" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
               <characteristics>
-                <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time this operative makes a Shoot action using its remote mine, make a shooting attack against each operative within ⬛ of the centre of its Mine token with that weapon. When making those shooting attacks, each operative (friendly and enemy) within ⬛ is a valid target, but when determining if it is in Cover, treat this operative&apos;s Mine token as the active operative. Then remove this operative&apos;s Mine token. An operative cannot make a shooting attack with this weapon by performing an Overwatch action, or if its Mine token is not in the killzone.</characteristic>
+                <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time this operative makes a Shoot action using its remote mine, make a shooting attack against each operative within ⬤ of the centre of its Mine token with that weapon. When making those shooting attacks, each operative (friendly and enemy) within ⬤ is a valid target, but when determining if it is in Cover, treat this operative&apos;s Mine token as the active operative. Then remove this operative&apos;s Mine token. An operative cannot make a shooting attack with this weapon by performing an Overwatch action, or if its Mine token is not in the killzone. An operative cannot be a valid target if Heavy terrain is wholly intervening (must be able to draw a Cover line from the centre of the Mine token to any part of the intended target&apos;s base without crossing Heavy terrain).</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -1616,7 +1616,7 @@
         </profile>
         <profile id="4a48-85c2-8a18-53cf" name="Spotter (2AP)" hidden="false" typeId="17cd-eb4c-f9cd-36f2" typeName="Unique Actions">
           <characteristics>
-            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative Visible to this operative, then select one other ready friendly VETERAN GUARDSMAN operative with a Group Activation characteristic of 1 within ⬤ of and Visible to this operative. After this activation ends, you can activate that other friendly operative, and during its next activation, it treats that enemy operative as if it has an Engage order. This operative cannot perform this action if it is within Engagement Range of an enemy operative.</characteristic>
+            <characteristic name="Unique Action" typeId="8d9f-0a91-4133-bc4a">Select one enemy operative Visible to this operative, then select one other ready friendly VETERAN GUARDSMAN operative with a Group Activation characteristic of 1 within ⬤ of and Visible to this operative. After this activation ends, you can activate that other friendly operative, and during its next activation, it treats that enemy operative as if it has an Engage order unless that enemy operative is in Cover provided by Heavy terrain. This operative cannot perform this action if it is within Engagement Range of an enemy operative.</characteristic>
           </characteristics>
         </profile>
       </profiles>

--- a/2021 - Void-Dancer Troupe.cat
+++ b/2021 - Void-Dancer Troupe.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7232-14ad-4b1e-3aeb" name="Void-Dancer Troupe" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7232-14ad-4b1e-3aeb" name="Void-Dancer Troupe" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <profileTypes>
     <profileType id="e0f0-c569-de36-d361" name="Allegory">
       <characteristicTypes>
@@ -23,29 +23,29 @@
         <categoryLink id="79dc-2f83-2c17-9816" name="Reference" hidden="false" targetId="322e-38ea-bf3e-c785" primary="false"/>
         <categoryLink id="4651-fe04-6ff5-d451" name="Leader" hidden="false" targetId="3198-c1ce-dfd0-fb4f" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3068-c2ca-9de0-f107" type="min"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e2ae-6dff-2f82-87a3" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3068-c2ca-9de0-f107" type="min"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e2ae-6dff-2f82-87a3" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="daf6-dfa0-1650-fc7f" name="Operative" hidden="false" targetId="f98b-0289-0f1f-b233" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1040-e473-5441-678a" type="max"/>
-            <constraint field="selections" scope="force" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1945-5e33-e4d5-0ac2" type="min"/>
+            <constraint field="selections" scope="force" value="8" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1040-e473-5441-678a" type="max"/>
+            <constraint field="selections" scope="force" value="8" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1945-5e33-e4d5-0ac2" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="63b3-4fb8-7cc3-2283" name="Player" hidden="false" targetId="3a2a-5234-3fbe-9da9" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c9b-7c28-2d81-c2c8" type="max"/>
+            <constraint field="selections" scope="force" value="7" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c9b-7c28-2d81-c2c8" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="e8fe-4404-b132-4dcc" name="Shadowseer" hidden="false" targetId="c537-4d50-751d-bb65" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6af-3878-10ac-e7f8" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6af-3878-10ac-e7f8" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="9d64-3737-4602-07b4" name="Death Jester" hidden="false" targetId="b408-f968-9f7e-abcb" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dcb1-e547-d323-c4f5" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dcb1-e547-d323-c4f5" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -61,21 +61,21 @@
   <sharedSelectionEntries>
     <selectionEntry id="07dc-ea59-cf33-5b7d" name="Neuro disruptor" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
-        <modifier type="set" field="6063-7f1f-18b7-78a3" value="1.0">
+        <modifier type="set" field="6063-7f1f-18b7-78a3" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4030-c1aa-dc38-fe97" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4030-c1aa-dc38-fe97" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6063-7f1f-18b7-78a3" type="max"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6063-7f1f-18b7-78a3" type="max"/>
       </constraints>
       <profiles>
         <profile id="b1ae-b8cf-4cee-1fad" name="⌖ Neuro disruptor" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
           <modifiers>
             <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -94,7 +94,7 @@
         <infoLink id="2704-cbbe-8514-28ea" name="APx" hidden="false" targetId="db98-339e-d0a2-e042" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8206-0591-49ff-5da7" name="Shuriken pistol" hidden="false" collective="false" import="true" type="upgrade">
@@ -103,7 +103,7 @@
           <modifiers>
             <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -121,26 +121,26 @@
         <infoLink id="004d-4112-e9d7-e034" name="Rng x" hidden="false" targetId="92de-2ad3-3554-0b3e" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a72c-2a2e-f38a-b67c" name="Fusion pistol" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
-        <modifier type="set" field="a703-888f-62a6-5555" value="1.0">
+        <modifier type="set" field="a703-888f-62a6-5555" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4030-c1aa-dc38-fe97" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4030-c1aa-dc38-fe97" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a703-888f-62a6-5555" type="max"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a703-888f-62a6-5555" type="max"/>
       </constraints>
       <profiles>
         <profile id="c2f8-93f5-d37c-17e8" name="⌖ Fusion pistol" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
           <modifiers>
             <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -159,7 +159,7 @@
         <infoLink id="24d4-ae00-e519-a464" name="Rng x" hidden="false" targetId="92de-2ad3-3554-0b3e" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1986-b812-ce2f-e755" name="Death Jester" hidden="false" collective="false" import="true" type="model">
@@ -187,19 +187,19 @@
       </profiles>
       <infoLinks>
         <infoLink id="8ee1-e234-5c29-9024" name="Holo suit" hidden="false" targetId="a9f4-43d7-9856-c1a3" type="profile"/>
+        <infoLink name="Flip Belts" hidden="false" id="8256-f4b9-936f-639e" type="profile" targetId="4a91-b419-2823-e3d6"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f788-fd88-ba0a-be04" name="New CategoryLink" hidden="false" targetId="f98b-0289-0f1f-b233" primary="true"/>
         <categoryLink id="b5a5-c93c-a90d-ef4f" name="Aeldari" hidden="false" targetId="c62e-f54d-e0bb-6940" primary="false"/>
         <categoryLink id="f2dd-0302-9c55-a4ed" name="Harlequins" hidden="false" targetId="3a79-b339-6bdf-bb39" primary="false"/>
-        <categoryLink id="a53e-ca9c-5fb5-529c" name="Fly" hidden="false" targetId="383e-c92a-c607-c7e1" primary="false"/>
         <categoryLink id="a49d-179b-91dd-8e46" name="Death Jester" hidden="false" targetId="b408-f968-9f7e-abcb" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2951-3490-637c-d67a" name="Shrieker cannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95af-3444-26e3-9734" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c073-3f01-46a6-4a87" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95af-3444-26e3-9734" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c073-3f01-46a6-4a87" type="max"/>
           </constraints>
           <profiles>
             <profile id="fd0c-7c4a-ca2d-6a84" name="⌖ Shrieker cannon" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -217,13 +217,13 @@
             <infoLink id="b42d-fba3-5795-b164" name="Heavy" hidden="false" targetId="1e77-6974-cf90-6008" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f817-eef7-ea81-a8a0" name="Shrieker blade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d2b-1b95-976c-5bf7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9993-67a8-7bd1-d745" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d2b-1b95-976c-5bf7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9993-67a8-7bd1-d745" type="max"/>
           </constraints>
           <profiles>
             <profile id="d394-32e1-1bc8-ddd3" name="⚔ Shrieker blade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -240,7 +240,7 @@
             <infoLink id="1f30-c04d-a557-0438" name="Reap x" hidden="false" targetId="bed1-0d23-de84-30a1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -249,12 +249,12 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="434b-9895-cae3-bde6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="434b-9895-cae3-bde6" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="e7d6-f26b-b0a9-b81d" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry"/>
@@ -277,7 +277,7 @@
         <entryLink id="2ff9-b82b-20b5-2f7d" name="Equipment" hidden="false" collective="false" import="true" targetId="b758-20df-5be4-7940" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fa47-e530-67b7-4c97" name="Lead Player" hidden="false" collective="false" import="true" type="model">
@@ -300,13 +300,13 @@
       </profiles>
       <infoLinks>
         <infoLink id="cad1-907c-103e-4d2b" name="Holo suit" hidden="false" targetId="a9f4-43d7-9856-c1a3" type="profile"/>
+        <infoLink name="Flip Belts" hidden="false" id="f908-90-c83b-8a02" type="profile" targetId="4a91-b419-2823-e3d6"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="01e9-7e16-d622-cbf7" name="New CategoryLink" hidden="false" targetId="ff86-0e1d-49ed-6270" primary="false"/>
         <categoryLink id="175c-bcd7-64d3-f3e3" name="Aeldari" hidden="false" targetId="c62e-f54d-e0bb-6940" primary="false"/>
         <categoryLink id="6f85-615d-2955-fdd4" name="Harlequins" hidden="false" targetId="3a79-b339-6bdf-bb39" primary="false"/>
         <categoryLink id="ef7d-1132-a4d7-9e4d" name="New CategoryLink" hidden="false" targetId="3198-c1ce-dfd0-fb4f" primary="true"/>
-        <categoryLink id="c285-c01e-cbf2-cc50" name="Fly" hidden="false" targetId="383e-c92a-c607-c7e1" primary="false"/>
         <categoryLink id="3dff-b941-0584-6349" name="Lead Player" hidden="false" targetId="8bf7-2ffc-fc0c-40cf" primary="false"/>
         <categoryLink id="c79b-9da2-72e4-1b2e" name="Operative" hidden="false" targetId="f98b-0289-0f1f-b233" primary="false"/>
       </categoryLinks>
@@ -315,12 +315,12 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c760-8a22-b00a-f045" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c760-8a22-b00a-f045" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="aacd-3ee5-3b15-d7dd" name="Combat" hidden="false" collective="false" import="true" targetId="97d8-19ec-143d-8aad" type="selectionEntry"/>
@@ -367,7 +367,7 @@
         <entryLink id="6b8a-f093-6bfa-a280" name="Equipment" hidden="false" collective="false" import="true" targetId="b758-20df-5be4-7940" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="13ea-471e-55f5-b59c" name="Player" hidden="false" collective="false" import="true" type="model">
@@ -385,12 +385,12 @@
       </profiles>
       <infoLinks>
         <infoLink id="5b48-d436-9a3d-1b21" name="Holo suit" hidden="false" targetId="a9f4-43d7-9856-c1a3" type="profile"/>
+        <infoLink name="Flip Belts" hidden="false" id="ef67-c93a-b8c2-4378" type="profile" targetId="4a91-b419-2823-e3d6"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="24ae-bfcd-7a6c-cfd6" name="New CategoryLink" hidden="false" targetId="ff86-0e1d-49ed-6270" primary="false"/>
         <categoryLink id="434d-e971-1063-8ffc" name="Aeldari" hidden="false" targetId="c62e-f54d-e0bb-6940" primary="false"/>
         <categoryLink id="b6a0-763f-46b8-6bbc" name="Harlequins" hidden="false" targetId="3a79-b339-6bdf-bb39" primary="false"/>
-        <categoryLink id="65f0-1081-53f9-7dec" name="Fly" hidden="false" targetId="383e-c92a-c607-c7e1" primary="false"/>
         <categoryLink id="db0f-5a21-607a-97c7" name="Player" hidden="false" targetId="3a2a-5234-3fbe-9da9" primary="false"/>
         <categoryLink id="80de-d944-532c-1e27" name="New CategoryLink" hidden="false" targetId="f98b-0289-0f1f-b233" primary="true"/>
       </categoryLinks>
@@ -399,12 +399,12 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4669-7b79-73d0-3996" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4669-7b79-73d0-3996" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="38e4-eff8-09a9-5d97" name="Combat" hidden="false" collective="false" import="true" targetId="97d8-19ec-143d-8aad" type="selectionEntry"/>
@@ -451,7 +451,7 @@
         <entryLink id="9888-96a2-fe24-e157" name="Equipment" hidden="false" collective="false" import="true" targetId="b758-20df-5be4-7940" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ba73-4761-0b9a-4269" name="Shadowseer" hidden="false" collective="false" import="true" type="model">
@@ -496,21 +496,21 @@
       </profiles>
       <infoLinks>
         <infoLink id="cbd4-b2f3-8572-9ef2" name="Holo suit" hidden="false" targetId="a9f4-43d7-9856-c1a3" type="profile"/>
+        <infoLink name="Flip Belts" hidden="false" id="c448-e3e5-46f-6a89" type="profile" targetId="4a91-b419-2823-e3d6"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0a5b-8531-bf06-a840" name="New CategoryLink" hidden="false" targetId="f98b-0289-0f1f-b233" primary="true"/>
         <categoryLink id="ac0b-515a-41c9-f1de" name="VOID-DANCER TROUPE" hidden="false" targetId="ff86-0e1d-49ed-6270" primary="false"/>
         <categoryLink id="8856-283d-f0be-adc6" name="Aeldari" hidden="false" targetId="c62e-f54d-e0bb-6940" primary="false"/>
         <categoryLink id="005d-3767-cf39-ee32" name="Harlequins" hidden="false" targetId="3a79-b339-6bdf-bb39" primary="false"/>
-        <categoryLink id="22f4-6ffa-99a6-d1ad" name="Fly" hidden="false" targetId="383e-c92a-c607-c7e1" primary="false"/>
         <categoryLink id="7771-c2f1-5dab-2e4e" name="Shadowseer" hidden="false" targetId="c537-4d50-751d-bb65" primary="false"/>
         <categoryLink id="cc70-fd06-4e01-3bde" name="Psyker" hidden="false" targetId="55b9-413d-e975-492a" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7f2d-5a01-37cc-6d9d" name="Miststave" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="750f-9ce8-7c05-3878" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60ac-02eb-6b82-3006" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="750f-9ce8-7c05-3878" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60ac-02eb-6b82-3006" type="max"/>
           </constraints>
           <profiles>
             <profile id="aa30-39f2-f92f-baf1" name="⚔ Miststave" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -527,7 +527,7 @@
             <infoLink id="650a-8632-da98-e488" name="Stun" hidden="false" targetId="a1e3-4e0b-f7c2-eb59" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -536,12 +536,12 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
+                <condition field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82af-b9b8-518f-aaf1" type="lessThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba2-896d-59b2-f957" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba2-896d-59b2-f957" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="ff57-af5d-eb07-a6dc" name="Marksman" hidden="false" collective="false" import="true" targetId="715c-810e-df05-01ad" type="selectionEntry"/>
@@ -576,12 +576,12 @@
         <entryLink id="4175-e0f6-bd9a-6115" name="Equipment" hidden="false" collective="false" import="true" targetId="b758-20df-5be4-7940" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b179-a3f9-6cc8-ac3e" name="Troupe 2 - Well Versed" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6bd-4abf-9440-f926" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6bd-4abf-9440-f926" type="max"/>
       </constraints>
       <profiles>
         <profile id="19cb-624f-c02e-5832" name="Well Versed" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -591,12 +591,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a034-2c0e-5493-1090" name="Troupe 3 - Martial Artistry" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7119-a14b-6a9f-3179" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7119-a14b-6a9f-3179" type="max"/>
       </constraints>
       <profiles>
         <profile id="475e-8ed8-2d97-17e3" name="Martial Artistry" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -606,12 +606,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fca2-6e48-0bcd-93e5" name="Troupe 5 - Virtuoso" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6851-4e3d-f1c4-bf0f" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6851-4e3d-f1c4-bf0f" type="max"/>
       </constraints>
       <profiles>
         <profile id="e8e3-dd06-29e1-df25" name="Virtuoso" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -621,12 +621,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dc7a-72ff-cfe1-1145" name="Troupe 4 - Dazzling Spectacle" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3442-8d16-0e41-2b16" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3442-8d16-0e41-2b16" type="max"/>
       </constraints>
       <profiles>
         <profile id="238c-c953-8bf7-6b0b" name="Dazzling Spectacle" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -636,12 +636,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="42cb-0a61-dbf6-401b" name="Troupe 1 - Whimsical" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ef5-e22f-bf1a-258a" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ef5-e22f-bf1a-258a" type="max"/>
       </constraints>
       <profiles>
         <profile id="7217-e0ce-4998-8c29" name="Whimsical" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -651,12 +651,12 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8ef6-16a4-5c1c-2639" name="Troupe 6 - Pre-eminent" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e84-c771-40f5-6200" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e84-c771-40f5-6200" type="max"/>
       </constraints>
       <profiles>
         <profile id="58c0-fc37-49ac-14aa" name="Pre-eminent" hidden="false" typeId="5237-8077-f013-a2cc" typeName="Battle Honours">
@@ -666,7 +666,7 @@
         </profile>
       </profiles>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5592-910d-900f-da92" name="Saedath" hidden="false" collective="false" import="true" type="upgrade">
@@ -714,23 +714,22 @@ Note that this means, for the purposes of your kill team&apos;s Performance tall
 
 When you add the fourth mark to your Performance tally:
 - All friendly VOID-DANCER TROUPE operatives have the Accolade ability of the active Allegory until the end of the battle.
-- You gain 1 Command Point.
-</description>
+- You gain 1 Command Point.</description>
         </rule>
       </rules>
       <categoryLinks>
         <categoryLink id="3135-2959-91ce-a9c4" name="New CategoryLink" hidden="false" targetId="322e-38ea-bf3e-c785" primary="true"/>
       </categoryLinks>
       <costs>
-        <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+        <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="0330-e335-3d8d-4d9f" name="Melee weapon" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="306a-47c6-7f14-21a6" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f25-61f7-ad35-055b" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="306a-47c6-7f14-21a6" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f25-61f7-ad35-055b" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="425d-cff0-5b4e-8656" name="Blade" hidden="false" collective="false" import="true" type="upgrade">
@@ -739,7 +738,7 @@ When you add the fourth mark to your Performance tally:
               <modifiers>
                 <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -756,7 +755,7 @@ When you add the fourth mark to your Performance tally:
             <infoLink id="ff39-165d-7bd2-905f" name="Balanced" hidden="false" targetId="547c-e6e5-64d4-a519" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f628-e46e-8dbf-16d7" name="Caress" hidden="false" collective="false" import="true" type="upgrade">
@@ -765,7 +764,7 @@ When you add the fourth mark to your Performance tally:
               <modifiers>
                 <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -782,7 +781,7 @@ When you add the fourth mark to your Performance tally:
             <infoLink id="ebe4-1030-9c0c-0d66" name="Rending" hidden="false" targetId="0550-3332-7a93-ab5b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a183-8f10-7f8b-4fc8" name="Kiss" hidden="false" collective="false" import="true" type="upgrade">
@@ -791,7 +790,7 @@ When you add the fourth mark to your Performance tally:
               <modifiers>
                 <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -805,7 +804,7 @@ When you add the fourth mark to your Performance tally:
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0dab-30b1-82fc-64e4" name="Embrace" hidden="false" collective="false" import="true" type="upgrade">
@@ -814,7 +813,7 @@ When you add the fourth mark to your Performance tally:
               <modifiers>
                 <modifier type="set" field="32b4-9a0e-e740-6031" value="2+">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -831,14 +830,14 @@ When you add the fourth mark to your Performance tally:
             <infoLink id="f699-504d-e168-e653" name="Brutal" hidden="false" targetId="16e9-a975-03a1-91c0" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ef47-f115-8c1a-69ff" name="Power weapon" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8bf7-2ffc-fc0c-40cf" type="notInstanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -857,22 +856,22 @@ When you add the fourth mark to your Performance tally:
             <infoLink id="5bdf-576f-534d-ae4e" name="Lethal x" hidden="false" targetId="be29-25db-e215-b3b0" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="f699-4f43-be8b-25ff" name="Pistol" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22f2-0d43-c72e-d632" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84fa-8974-3faf-5925" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22f2-0d43-c72e-d632" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84fa-8974-3faf-5925" type="min"/>
       </constraints>
       <entryLinks>
         <entryLink id="5e35-13da-4a7b-c859" name="Fusion pistol" hidden="false" collective="false" import="true" targetId="a72c-2a2e-f38a-b67c" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c537-4d50-751d-bb65" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c537-4d50-751d-bb65" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -885,12 +884,12 @@ When you add the fourth mark to your Performance tally:
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4030-c1aa-dc38-fe97" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4030-c1aa-dc38-fe97" type="notInstanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="c61a-51a3-370d-bf55" scope="force" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="396a-d693-8cc1-0d2a" type="max"/>
+        <constraint field="c61a-51a3-370d-bf55" scope="force" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="396a-d693-8cc1-0d2a" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="f52b-c9d1-7289-86df" name="Shrieker Toxin Rounds" hidden="false" collective="false" import="true" type="upgrade">
@@ -899,20 +898,20 @@ When you add the fourth mark to your Performance tally:
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8206-0591-49ff-5da7" type="equalTo"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2951-3490-637c-d67a" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8206-0591-49ff-5da7" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2951-3490-637c-d67a" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="set" field="c61a-51a3-370d-bf55" value="4.0">
+            <modifier type="set" field="c61a-51a3-370d-bf55" value="4">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2951-3490-637c-d67a" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2951-3490-637c-d67a" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="311a-3329-f050-ebc1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="311a-3329-f050-ebc1" type="max"/>
           </constraints>
           <profiles>
             <profile id="40f0-2190-fbf2-ae7f" name="Shrieker Toxin Rounds" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -922,13 +921,13 @@ When you add the fourth mark to your Performance tally:
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="55a8-8663-20ca-f1d1" name="Death Mask*" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9899-c501-2145-744b" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="30b9-9a55-dece-9d55" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9899-c501-2145-744b" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="30b9-9a55-dece-9d55" type="max"/>
           </constraints>
           <profiles>
             <profile id="6067-ec72-c2cb-2bea" name="Death Mask" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -938,19 +937,19 @@ When you add the fourth mark to your Performance tally:
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2ed9-9cbf-17d1-942d" name="Accelerated Monofilament Wire" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0dab-30b1-82fc-64e4" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0dab-30b1-82fc-64e4" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bf8-5edf-0885-3d17" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bf8-5edf-0885-3d17" type="max"/>
           </constraints>
           <profiles>
             <profile id="4cee-3898-d4c2-c3c5" name="Accelerated Monofilament Wire" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -964,19 +963,19 @@ When you add the fourth mark to your Performance tally:
             <infoLink id="fe77-e250-ec56-31f1" name="Lethal x" hidden="false" targetId="be29-25db-e215-b3b0" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6860-cde4-5746-c977" name="Supertensile Monofilament Wire" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a183-8f10-7f8b-4fc8" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a183-8f10-7f8b-4fc8" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="358c-0ed9-f4db-8e32" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="358c-0ed9-f4db-8e32" type="max"/>
           </constraints>
           <profiles>
             <profile id="ad93-fab4-9fe5-dc2b" name="Supertensile Monofilament Wire" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -986,12 +985,12 @@ When you add the fourth mark to your Performance tally:
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c069-cc87-b84e-0949" name="Wraithbone Talisman" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ce0-4264-0f4d-9ff3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ce0-4264-0f4d-9ff3" type="max"/>
           </constraints>
           <profiles>
             <profile id="c977-da76-6099-1000" name="Wraithbone Talisman" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1001,13 +1000,13 @@ When you add the fourth mark to your Performance tally:
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e44b-dd26-9237-bc7f" name="Prismatic Grenade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eee4-c2ec-8961-2da5" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4230-67be-1a4c-ef44" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eee4-c2ec-8961-2da5" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4230-67be-1a4c-ef44" type="max"/>
           </constraints>
           <profiles>
             <profile id="5dbc-5662-1693-43b8" name="Prismatic grenade" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
@@ -1028,20 +1027,20 @@ When you add the fourth mark to your Performance tally:
             <infoLink id="94c8-96c9-4271-6819" name="Blast x" hidden="false" targetId="d848-be09-6d6d-4708" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6cd1-717a-fc5e-b0c7" name="Pure Psychocrystals*" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="07dc-ea59-cf33-5b7d" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="07dc-ea59-cf33-5b7d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a00-04d2-2eb3-1fcf" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9cca-b06a-f72f-0185" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a00-04d2-2eb3-1fcf" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9cca-b06a-f72f-0185" type="max"/>
           </constraints>
           <profiles>
             <profile id="bdec-51ce-cb2a-1007" name="Pure Psychocrystals" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1054,20 +1053,20 @@ When you add the fourth mark to your Performance tally:
             <infoLink id="feb4-d54d-c8c4-acca" name="Lethal x" hidden="false" targetId="be29-25db-e215-b3b0" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3276-5dbf-0b62-bec2" name="Support Grip*" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b408-f968-9f7e-abcb" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b408-f968-9f7e-abcb" type="notInstanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc6-fb32-b851-1b4a" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a74-ad53-f8cb-cdb2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc6-fb32-b851-1b4a" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a74-ad53-f8cb-cdb2" type="max"/>
           </constraints>
           <profiles>
             <profile id="b56b-faf4-ef6a-492c" name="Support Grip" hidden="false" typeId="ef4d-f12f-036e-9f14" typeName="Equipment">
@@ -1079,20 +1078,20 @@ Cumbersome: An operative cannot move more than 3⬤ in the same activation in wh
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="24bc-1266-2229-734c" name="Crystal Shard (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d4b-a8ef-5c6a-2687" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bc70-889d-d77e-f44e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d4b-a8ef-5c6a-2687" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bc70-889d-d77e-f44e" type="max"/>
           </constraints>
           <profiles>
             <profile id="d993-bba4-eb0e-806b" name="Crystal Shard" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1102,20 +1101,20 @@ Cumbersome: An operative cannot move more than 3⬤ in the same activation in wh
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ff49-6d36-78c9-79e0" name="Shimmerclone (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3eca-e188-34af-f9f9" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7565-c7f9-815f-542d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3eca-e188-34af-f9f9" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7565-c7f9-815f-542d" type="max"/>
           </constraints>
           <profiles>
             <profile id="f98b-e320-d3a6-2b5b" name="Shimmerclone" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1125,20 +1124,20 @@ Cumbersome: An operative cannot move more than 3⬤ in the same activation in wh
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="25f7-0a21-2e94-19a6" name="Falcon&apos;s Feather (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28a1-25fa-b3cf-e200" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cfc6-699c-ef3e-226e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28a1-25fa-b3cf-e200" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cfc6-699c-ef3e-226e" type="max"/>
           </constraints>
           <profiles>
             <profile id="a18b-0435-212b-04b9" name="Falcon&apos;s Feather" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1148,20 +1147,20 @@ Cumbersome: An operative cannot move more than 3⬤ in the same activation in wh
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="3.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="3"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c160-432e-9194-69e1" name="Mocking Panoply (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d641-17d3-cf91-ce10" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f4e0-3bf0-fe62-93ef" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d641-17d3-cf91-ce10" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f4e0-3bf0-fe62-93ef" type="max"/>
           </constraints>
           <profiles>
             <profile id="eb59-6d10-b3d2-dd9d" name="Mocking Panoply" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1171,20 +1170,20 @@ Cumbersome: An operative cannot move more than 3⬤ in the same activation in wh
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="2.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="2"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e762-6fcf-2591-4255" name="Hidden Guise (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87bb-576b-4ce0-ab4c" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a889-d126-effa-6894" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87bb-576b-4ce0-ab4c" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a889-d126-effa-6894" type="max"/>
           </constraints>
           <profiles>
             <profile id="ca9c-c72b-fcc2-b53a" name="Hidden Guise" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1194,20 +1193,20 @@ Cumbersome: An operative cannot move more than 3⬤ in the same activation in wh
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="1.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="1"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f09b-8818-f1f3-6604" name="Raiment of Mirrors (RARE)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b888-71c3-b9f6-b49d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="796d-393b-20f5-8113" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a18b-996e-a408-e45c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="796d-393b-20f5-8113" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a18b-996e-a408-e45c" type="max"/>
           </constraints>
           <profiles>
             <profile id="c8ed-9336-083e-ecae" name="Raiment of Mirrors" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
@@ -1217,7 +1216,7 @@ Cumbersome: An operative cannot move more than 3⬤ in the same activation in wh
             </profile>
           </profiles>
           <costs>
-            <cost name=" EP" typeId="c61a-51a3-370d-bf55" value="0.0"/>
+            <cost name="EP" typeId="c61a-51a3-370d-bf55" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1235,13 +1234,18 @@ Cumbersome: An operative cannot move more than 3⬤ in the same activation in wh
         <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">⬛</characteristic>
         <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">⬟</characteristic>
         <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">⌖ 
-⚔ </characteristic>
+⚔</characteristic>
         <characteristic name="W" typeId="db11-738c-048c-759e">💀</characteristic>
       </characteristics>
     </profile>
     <profile id="a9f4-43d7-9856-c1a3" name="Holo suit" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
       <characteristics>
         <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">This operative has a 4+ invulnerable save.</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Flip Belts" hidden="false" id="4a91-b419-2823-e3d6" typeId="f52d-76ec-b279-093b" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">This operative has the FLY keyword for the purposes of moving around, across and over other operatives. However, each time this operative is climbing or dropping, treat the total vertical distance as ⬤.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/2021 - Warp Coven.cat
+++ b/2021 - Warp Coven.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5d8e-22a5-1698-fb08" name="Warp Coven" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="5d8e-22a5-1698-fb08" name="Warp Coven" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <profileTypes>
     <profileType id="0221-fadb-8acc-cec7" name="Boon of Tzeentch">
       <characteristicTypes>
@@ -797,7 +797,7 @@
                   <profiles>
                     <profile id="e338-981c-aca6-df35" name="Weave Fate" hidden="false" typeId="031c-1555-fc2c-3d40" typeName="Psychic Power">
                       <characteristics>
-                        <characteristic name="Effect" typeId="3895-3533-1c76-676a">Select one friendly WARPCOVEN operative visible to this operative. Until the end of the Turning Point, each time a shooting attack is made against that operative, in the Roll Defence Dice step of that shooting attack, you can re-roll any or all of your defence dice.</characteristic>
+                        <characteristic name="Effect" typeId="3895-3533-1c76-676a">Select one friendly WARPCOVEN operative visible to this operative. Until the start of this operative&apos;s next activation, until it&apos;s incapacitated, or until this psychic power is selected again (whichever comes first), each time a shooting attack is made against that operative, in the Roll Defence Dice step of that shooting attack, you can re-roll any or all of your defence dice.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
@@ -813,7 +813,7 @@
                   <profiles>
                     <profile id="0c96-41a7-a90f-6a63" name="Twist Destiny" hidden="false" typeId="031c-1555-fc2c-3d40" typeName="Psychic Power">
                       <characteristics>
-                        <characteristic name="Effect" typeId="3895-3533-1c76-676a">Select one enemy operative Visible to this operative. Until the end of the Turning Point:
+                        <characteristic name="Effect" typeId="3895-3533-1c76-676a">Select one enemy operative Visible to this operative. Until the start of this operative&apos;s next activation, until it&apos;s incapacitated, or until this psychic power is selected again (whichever comes first):
 - Each time that enemy operative fights in combat or makes a shooting attack, in the Roll Attack Dice step of that [combat or] shooting attack, your opponent cannot re-roll their attack dice.
 - That enemy operative ignores all positive modifiers to its APL.</characteristic>
                       </characteristics>
@@ -913,7 +913,7 @@
                   <profiles>
                     <profile id="2e3c-30e8-288c-ce87" name="Infernal Fire" hidden="false" typeId="031c-1555-fc2c-3d40" typeName="Psychic Power">
                       <characteristics>
-                        <characteristic name="Effect" typeId="3895-3533-1c76-676a">Select one enemy operative Visible to this operative. Until the end of the Turning Point, each time a friendly WARPCOVEN operative fights in combat or makes a shooting attack against that enemy operative, in the Roll Attack Dice step of that combat or shooting attack, you can re-roll any or all of your attack dice.</characteristic>
+                        <characteristic name="Effect" typeId="3895-3533-1c76-676a">Select one enemy operative Visible to this operative. Until the start of this operative&apos;s next activation, until it&apos;s incapacitated, or until this psychic power is selected again (whichever comes first), each time a friendly WARPCOVEN operative fights in combat or makes a shooting attack against that enemy operative, in the Roll Attack Dice step of that combat or shooting attack, you can re-roll any or all of your attack dice.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
@@ -981,7 +981,7 @@
                   <profiles>
                     <profile id="c277-61f3-5e54-1776" name="Ephemeral Instability" hidden="false" typeId="031c-1555-fc2c-3d40" typeName="Psychic Power">
                       <characteristics>
-                        <characteristic name="Effect" typeId="3895-3533-1c76-676a">Until the end of the Turning Point, subtract ⬤ from the distance that enemy operatives can move when performing Charge and Dash actions.</characteristic>
+                        <characteristic name="Effect" typeId="3895-3533-1c76-676a">Until the start of this operative&apos;s next activation, until it&apos;s incapacitated, or until this psychic power is selected again (whichever comes first), subtract ▲ from the distance that enemy operatives can move when performing Charge and Dash actions.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
@@ -1894,7 +1894,7 @@
           <profiles>
             <profile id="4789-14b9-0058-e290" name="Arcane Robes" hidden="false" typeId="f52d-76ec-b279-093b" typeName="Abilities">
               <characteristics>
-                <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Once per battle, when Critical Damage would be inflicted upon this operative, you can use this ability. If you do so, that attack dice inflicts Normal Damage instead.</characteristic>
+                <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Once per Turning Point, when Critical Damage would be inflicted upon this operative, you can use this ability. If you do so, that attack dice inflicts Normal Damage instead.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -2014,7 +2014,7 @@
         <characteristic name="GA" typeId="7a85-5063-6d1a-2a0b">1</characteristic>
         <characteristic name="DF" typeId="4a18-41c1-51f2-c88c">3</characteristic>
         <characteristic name="SV" typeId="dd03-76d2-dda8-eca2">6+</characteristic>
-        <characteristic name="W" typeId="db11-738c-048c-759e">8</characteristic>
+        <characteristic name="W" typeId="db11-738c-048c-759e">9</characteristic>
       </characteristics>
     </profile>
     <profile id="e051-6c4d-c203-2db9" name="Warp Swell" hidden="false" typeId="0221-fadb-8acc-cec7" typeName="Boon of Tzeentch">
@@ -2043,7 +2043,7 @@
     </profile>
     <profile name="Sorcerer&apos;s Command" hidden="false" id="8fa0-2a9e-7f96-5ccb" typeId="f52d-76ec-b279-093b" typeName="Abilities">
       <characteristics>
-        <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time this operative is activated, if it isn’t within ⬟ of a friendly SORCERER operative, subtract 1 from its APL.</characteristic>
+        <characteristic name="Ability" typeId="dff3-a2cc-d103-683d">Each time this operative is activated, if it isn&apos;t within ⬟+⬛ of a friendly SORCERER operative, subtract 1 from its APL characteristic.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/2021 - Wyrmblade.cat
+++ b/2021 - Wyrmblade.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="381a-c69a-a399-fbbc" name="Wyrmblade" revision="5" battleScribeVersion="2.03" authorName="Mad-Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="381a-c69a-a399-fbbc" name="Wyrmblade" revision="6" battleScribeVersion="2.03" authorName="Mad-Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="3b7e-7dab-f79f-2e74" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="a223-4c7f-7c64-cdd1" name="Cult Agent" hidden="false"/>
     <categoryEntry id="06d8-a7f8-589c-a573" name="WYRMBLADE" hidden="false"/>
@@ -1812,7 +1812,7 @@ Until the end of the Turning Point, each time this operative fights in combat wi
     <rule id="af15-09c9-71d0-68db" name="Cult Ambush" hidden="false">
       <description>During the first Turning Point, when this operative activated, you can change its order.
 
-The first time this operative performs either a Fight or Shoot action in each of its activations, if its order was changed from Conceal to Engage during that activation, or it wasn&apos;t visible to every enemy operative at the start of that activation, in the Roll Attack Dice step of that combat or shooting attack, you can re-roll any or all of your attack dice results of one result (e.g. results of 2).</description>
+The first time this operative performs either a Fight or Shoot action in each of its activations, if its order was changed from Conceal to Engage during that activation, or it wasn&apos;t Visible to enemy operatives at the start of that activation, in the Roll Attack Dice step of that combat or shooting attack, you can re-roll any or all of your attack dice results of one result (e.g. results of 2).</description>
     </rule>
     <rule id="2477-012d-2873-a3c3" name="Preternatural Assassin" hidden="false">
       <description>This operative cannot be equipped with equipment.


### PR DESCRIPTION
KOMMANDO
- BOMB SQUIG operative: This operative's APL characteristic cannot be positively modified. For its Bomb Squig special rule, make a shooting attack against each other operative within its Engagement Range (instead of Visible to and within CIRCLE of it).
- Choppa equipment: Subtract 1 from the weapon's Attacks characteristic (note KOMMANDO BOY operatives are unaffected).

VETERAN GUARDSMAN
- SPOTTER VETERAN operative's Spotter action: It treats that enemy operative as if it has an Engage order unless that enemy operative is in Cover provided by Heavy terrain.
- DEMOLITION VETERAN operative's Detonate special rule: Change the distance requirement to CIRCLE (instead of SQUARE). An operative cannot be a valid target if Heavy terrain is wholly intervening (must be able to draw a Cover line from the centre of the Mine token to any part of the intended target's base without crossing Heavy terrain).
- DEMOLITION VETERAN operative's Plant Mine action: This operative can only perform this action once.

VOID-DANCER TROUPE
- All operatives: Remove FLY keyword and they gain the following ability: 'Flip Belts: This operative has the FLY keyword for the purposes of moving around, across and over other operatives. However, each time this operative is climbing or dropping, treat the total vertical distance as CIRCLE.'

WYRMBLADE
- Change second paragraph of Cult Ambush ability to: 'The first time this operative performs either a Fight or Shoot action in each of its activations, if its order was changed from Conceal to Engage during that activation, or it wasn't Visible to enemy operatives at the start of that activation, in the Roll Attack Dice step of that combat or shooting attack, you can re-roll any or all of your attack dice results of one result (e.g. results of 2).'

WARPCOVEN
- RUBRIC MARINE operatives gain the following ability: 'Sorcerer's Command: Each time this operative is activated, if it isn't within PENTAGON+SQUARE of a friendly SORCERER operative, subtract 1 from its APL characteristic.'
- TZAANGOR operatives: Add 1 to Wounds characteristic.
- Psychic Powers: Change all instances of 'the end of the Turning Point' to 'the start of this operative's next activation, until it's incapacitated, or until this psychic power is selected again (whichever comes first)'.
- Ephemeral Instability psychic power: Subtract TRIANGLE (instead of CIRCLE).
- Arcane Robes equipment: Once per Turning Point.

FARSTALKER KINBAND
- KILL-BROKER operative's ritual blade (equipment) and blade: Add 1 to Attacks characteristic.
- STALKER operative's stalker's blade: Add 1 to Attacks characteristic.
- HOUND operative: Change GA characteristic to 1.
- TRACKER operative's Marked for the Hunt and From the Eye Above actions: This operative cannot perform those actions while within Engagement Range of an enemy operative (instead of ).

HIEROTEK CIRCLE
- Reanimation Protocols ability: Resolve before Living Metal ability, operatives are successfully reanimated on a 2+, they regain D3+3 lost wounds and can instead be placed within SQUARE of that reanimation token (but not within Engagement Range of enemy operatives) with an order of your choice.
- CHRONOMANCER operative's Countertemporal Nanomine action: If the enemy operative would move within SQUARE of your Countertemporal Nanomine token (instead of PENTAGON), and subtract CIRCLE from the distance it can move (to a minimum of 2CIRCLE). Note Dash actions would therefore be unaffected.
- TECHNOMANCER operative's Rites of Reanimation action: Delete first paragraph. Second paragraph becomes an ability (in other words, it no longer requires the operative to perform an action), but
subtract 1 from the TECHNOMANCER operative's APL if you use that ability.
- PSYCHOMANCER operative's Conjure Trauma action: In addition, roll one D6. If the result is higher than that enemy operative's APL, subtract 1 from that enemy operative's APL.
- APPRENTEK operative: Change APL characteristic to 3.

HEARTHKYN SALVAGER
- DÔZR operative's Knux Smash action: Add the following sentence: 'This operative can then perform a free Charge action up to SQUARE (even if it's performed an action during this activation that prevents it from doing so).'
- LOKÂTR operative's Early Detection ability: In addition, enemy operatives cannot move until the Firefight phase of the first Turning Point.
- LOKÂTR operative's Pan Spectral Scan action: In addition, that enemy operative is not Obscured for that shooting attack.

FELLGOR RAVAGER
- IRONHORN operative's Call the Attack ability: The selected operative must be Visible to and within PENTAGON of this operative.
- GNARLSCAR operative's Uncompromising Attack action: You can only select an autopistol for this action's shooting attack.
- War Paint equipment: 2EP.
- DEATHKNELL operative's War Gong ability: No effect when the DEATHKNELL operative has a Frenzy token.

CHAOS CULT
- Winged Accursed Gift: Delete first bullet point.
- Operative selection: 1 less DEVOTEE operative.