### PR TITLE
Update Novitiate Dialogus with correct number of melee attacks

### DIFF
--- a/2021 - Novitiate.cat
+++ b/2021 - Novitiate.cat
@@ -1449,7 +1449,7 @@ You cannot use Acts of Faith to change dice you’ve re-rolled.</characteristic>
           <profiles>
             <profile id="1ee2-9d3e-4f5c-be32" name="⚔ Dialogus stave" hidden="false" typeId="a917-3c2e-f7b8-1bdc" typeName="Weapons">
               <characteristics>
-                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">2</characteristic>
+                <characteristic name="A" typeId="5f37-25bb-661b-5c9c">3</characteristic>
                 <characteristic name="WS/BS" typeId="32b4-9a0e-e740-6031">4+</characteristic>
                 <characteristic name="D" typeId="337a-2e5b-e4e3-f489">3/3</characteristic>
                 <characteristic name="SR" typeId="c9c0-f6c9-c787-e650">-</characteristic>


### PR DESCRIPTION
The Novitiate Dialogus should have 3 attacks with their Dialogus Stave