### PR TITLE
Add Nemesis Operatives & Some Nemesis NPOs

### DIFF
--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -2120,6 +2120,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
           <description>Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</description>
         </rule>
       </rules>
+      <categoryLinks>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="64da-795b-204b-af2f" primary="true" name="Operative"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="model" import="true" name="Nemesis (L)" hidden="false" id="b375-1cc0-1990-a18d">
       <selectionEntryGroups>
@@ -3705,6 +3708,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
           <description>Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</description>
         </rule>
       </rules>
+      <categoryLinks>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="b43f-ecce-be89-9a76" primary="true" name="Operative"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="model" import="true" name="Nemesis (M)" hidden="false" id="be0b-e701-602a-7b29">
       <selectionEntryGroups>
@@ -4430,6 +4436,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
           <description>Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</description>
         </rule>
       </rules>
+      <categoryLinks>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="ab9f-e5c8-b988-0b6a" primary="true" name="Operative"/>
+      </categoryLinks>
     </selectionEntry>
   </selectionEntries>
   <sharedProfiles>

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -157,45 +157,39 @@
         <infoLink name="Brawler" id="2433-e39c-aa0d-671b" hidden="false" type="profile" targetId="8119-7495-8063-6302"/>
       </infoLinks>
     </selectionEntry>
-    <selectionEntry type="model" import="true" name="Warrior (Marksman)" hidden="false" id="16a0-e2ba-d7f4-cbd9">
+    <selectionEntry type="model" import="true" name="Necron warrior (Pts 2)" hidden="false" id="16a0-e2ba-d7f4-cbd9">
       <profiles>
-        <profile name="Warrior (Marksman)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="ee13-2b46-158e-738c">
+        <profile name="Necron warrior (Pts 2)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="ee13-2b46-158e-738c">
           <characteristics>
             <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">2</characteristic>
-            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">5&quot;</characteristic>
             <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
-            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">8</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">9</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Unrelenting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="90cc-0221-ead2-6403">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this NPO is shooting against the closest valid target, its weapons have the Accurate 1 weapon rule.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Weapon Options" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0767-a7df-b796-dbc5">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This NPO has a combat attachment and either a gauss flayer or a gauss reaper.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Firearm" hidden="false" id="3f21-6f91-baf1-a59f" sortIndex="1">
-          <profiles>
-            <profile name="⌖ Firearm" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="dfec-b5d9-f9f7-61d8">
-              <characteristics>
-                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
-                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
-                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f558-cdf9-3e13-ed2a" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bfaa-9936-a6df-eeef" includeChildSelections="false"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Knife" hidden="false" id="f55d-8cfb-e594-f973" sortIndex="2">
+        <selectionEntry type="upgrade" import="true" name="Combat attachment" hidden="false" id="f55d-8cfb-e594-f973" sortIndex="2">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="095d-4c81-076b-9b49" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f98-746b-1da9-c9c5" includeChildSelections="false"/>
           </constraints>
           <profiles>
-            <profile name="⚔ Knife" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="98c4-8a5a-2e18-9caf">
+            <profile name="⚔ Combat attachment" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="98c4-8a5a-2e18-9caf">
               <characteristics>
                 <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
                 <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
-                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">2/3</characteristic>
+                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
                 <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
               </characteristics>
             </profile>
@@ -209,6 +203,47 @@
       <infoLinks>
         <infoLink name="Marksman" id="08ab-832b-0284-de9f" hidden="false" type="profile" targetId="a6db-a06f-71ee-1feb"/>
       </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Ranged weapon" id="9cf3-987c-384f-ff62" hidden="false">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1160-31c6-6ad8-14a3" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="072c-238b-9a7a-3a9b" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Gauss reaper" hidden="false" id="3f21-6f91-baf1-a59f">
+              <profiles>
+                <profile name="⌖ Gauss reaper" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="dfec-b5d9-f9f7-61d8">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Piercing 1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink name="Range x" id="11d3-9a45-a73b-3b5a" hidden="false" type="rule" targetId="a528-829e-8268-c005"/>
+                <infoLink name="Piercing x" id="29a1-4c2c-1f4d-b002" hidden="false" type="rule" targetId="4c07-2cb3-1417-cbb7"/>
+              </infoLinks>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Gauss flayer" hidden="false" id="1c0c-b54c-3377-e6dd">
+              <profiles>
+                <profile name="⌖ Gauss flayer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0a0b-5e38-1644-415f">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink name="Piercing x" id="2cbc-dcae-6287-ed7e" hidden="false" type="rule" targetId="4c07-2cb3-1417-cbb7"/>
+              </infoLinks>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry type="model" import="true" name="Heavy (Brawler)" hidden="false" id="4673-fc17-efd9-fb10">
       <selectionEntries>
@@ -802,81 +837,78 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="model" import="true" name="Lychguard" hidden="false" id="9cab-7121-b3e3-21aa">
+    <selectionEntry type="model" import="true" name="Lychguard (Pts 3)" hidden="false" id="9cab-7121-b3e3-21aa">
       <categoryLinks>
         <categoryLink name="Operative" hidden="false" id="34db-d4a5-6800-6128" targetId="cf83-4496-b58e-ac82" primary="true"/>
       </categoryLinks>
       <profiles>
-        <profile name="Lychguard" typeId="a8aa-8fdf-b828-ee91" typeName="Behaviour" hidden="false" id="97f5-19ce-d3c9-8c69">
+        <profile name="Lychguard (Pts 3)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="119b-5ee2-16e6-d9d6">
           <characteristics>
-            <characteristic name="Behaviour" typeId="9afc-d237-3382-7dba">This NPO will stay close to the Royal Warden unless the enemy is close enough to charge or fight. If it can perform either of its first two actions during that activation, or if it can end the activation with a Royal Warden that has an Engage order within its control range, give it an Engage order. If it cannot, give it a Conceal order. It will perform the **Operate Hatch** action where necessary to fulfil its behaviour.
-
-
-1. **Fight**.
-2. **Charge** the closest player operative via the shortest possible route.
-3. **Reposition** towards the Royal Warden NPO, to cover if possible (a subsequent Dash action can fulfil this, if able). If the Royal Warden NPO isn&apos;t in the killzone, **Reposition** towards the closest player operative (following the same conditions).
-4. **Dash** towards the Royal Warden NPO, to cover if possible. If the Royal Warden NPO isn&apos;t in the killzone, Dash towards the closest player operative (following the same conditions).</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Lychguard" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="119b-5ee2-16e6-d9d6">
-          <characteristics>
-            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">2</characteristic>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">3</characteristic>
             <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">5&quot;</characteristic>
             <characteristic name="Save" typeId="3241-5548-12d6-f103">3+</characteristic>
             <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">13</characteristic>
           </characteristics>
         </profile>
-        <profile name="Guardian Protocols" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c9ea-bfae-d2f4-ddd9">
+        <profile name="Weapon Options" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="47df-e36c-8a30-0a90">
           <characteristics>
-            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a player operative is performing a **Shoot** action, if this NPO has an Engage order, the player(s) cannot select a Royal Warden NPO within this NPO&apos;s control range as a valid target.</characteristic>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This NPO has a hyperphase sword &amp; dispersion shield or a warsythe.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Lychguard" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="63ba-36c3-6270-e9db">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This NPO can perform two Fight actions during each of its activations</characteristic>
           </characteristics>
         </profile>
       </profiles>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Hyperphase sword" hidden="false" id="c572-f606-0255-190b">
+      <infoLinks>
+        <infoLink name="Brawler" id="3baa-c20a-ab3d-c1df" hidden="false" type="profile" targetId="8119-7495-8063-6302"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Weapon" id="6765-3600-f24d-b671" hidden="false">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Warscythe" hidden="false" id="4430-c9a4-a301-0030">
+              <profiles>
+                <profile name="⚔ Warscythe" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bb7f-5218-0bf8-57b0">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink name="Lethal x+" id="ebe3-24bd-1140-80a0" hidden="false" type="rule" targetId="8b97-e3e3-2857-817a"/>
+              </infoLinks>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Hyperphase sword &amp; dispersion shield" hidden="false" id="c572-f606-0255-190b">
+              <profiles>
+                <profile name="⚔ Hyperphase sword &amp; dispersion shield" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ac56-a5a0-61ed-2132">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Shield*</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink name="Lethal x+" id="d656-f379-690f-7043" hidden="false" type="rule" targetId="8b97-e3e3-2857-817a"/>
+              </infoLinks>
+              <rules>
+                <rule name="*Shield" id="dc63-dee0-2c84-b3ca" hidden="false">
+                  <description>Whenever this NPO is fighting or retaliating with this weapon, each of its blocks can be allocated to block two unresolved successes (instead of one). Whenever an operative is shooting this NPO, weapons that have the Piercing 1 weapon rule have the Piercing Crits 1 weapon rule instead.</description>
+                </rule>
+              </rules>
+            </selectionEntry>
+          </selectionEntries>
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0800-c442-d346-b9e9-min"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0800-c442-d346-b9e9-max"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dd81-ebe9-0697-41c8" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f578-3fb4-bc76-6118" includeChildSelections="false"/>
           </constraints>
-          <profiles>
-            <profile name="⚔ Hyperphase sword" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ac56-a5a0-61ed-2132">
-              <characteristics>
-                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Shield*</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink name="Lethal x+" id="d656-f379-690f-7043" hidden="false" type="rule" targetId="8b97-e3e3-2857-817a"/>
-          </infoLinks>
-          <rules>
-            <rule name="*Shield" id="dc63-dee0-2c84-b3ca" hidden="false">
-              <description>Whenever this operative is fighting or retaliating with this weapon, each of your blocks can be allocated to block two unresolved successes (instead of one).</description>
-            </rule>
-          </rules>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Warscythe" hidden="false" id="4430-c9a4-a301-0030">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fdde-935d-ba15-3de7-min"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fdde-935d-ba15-3de7-max"/>
-          </constraints>
-          <profiles>
-            <profile name="⚔ Warscythe" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bb7f-5218-0bf8-57b0">
-              <characteristics>
-                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink name="Lethal x+" id="ebe3-24bd-1140-80a0" hidden="false" type="rule" targetId="8b97-e3e3-2857-817a"/>
-          </infoLinks>
-        </selectionEntry>
-      </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry type="model" import="true" name="Canoptek Scarab Swarm" hidden="false" id="8e39-f188-b121-1f36">
       <categoryLinks>
@@ -4461,6 +4493,474 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
           </constraints>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Chaos cultist (Pts 1)" hidden="false" id="1732-2a55-539d-f5e3">
+      <categoryLinks>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="8763-a58d-9a92-81b1" primary="true" name="Operative"/>
+      </categoryLinks>
+      <profiles>
+        <profile name="Chaos cultist" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="e6b2-b4e3-f8dd-d240">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">2</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">5+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">7</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Battler" typeId="a8aa-8fdf-b828-ee91" typeName="Behaviour" hidden="false" id="339d-c8f3-3ec4-71cc">
+          <characteristics>
+            <characteristic name="Behaviour" typeId="9afc-d237-3382-7dba"/>
+          </characteristics>
+        </profile>
+        <profile name="Mob" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8e45-bdb0-8fd5-3f7a">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this NPO is within 3&quot; of any other friendly CULTIST NPOs, add 1 to both Dmg stats of this NPO&apos;s weapons and they have Accurate 1 weapon rule.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Pistol" hidden="false" id="5cf3-5598-77ad-3296">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="041c-d5e2-2b4b-a035" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2ca2-a470-d6d5-c1f8" includeChildSelections="false"/>
+          </constraints>
+          <profiles>
+            <profile name="⌖ Pistol" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9e1b-66ca-9e9b-7329">
+              <characteristics>
+                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">2/3</characteristic>
+                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Range x" id="9c2c-72e1-99fa-67c5" hidden="false" type="rule" targetId="a528-829e-8268-c005"/>
+          </infoLinks>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="9689-3718-e4ae-e520">
+          <profiles>
+            <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="eef6-b7d4-39e9-03e0">
+              <characteristics>
+                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">2/3</characteristic>
+                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="efb1-a0a8-f3cc-5205" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b8e0-6918-6ec7-25a6" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Lesser daemon (Pts 2)" hidden="false" id="896f-0fde-dcd7-3b93">
+      <categoryLinks>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="98e5-341d-3a5f-2132" primary="true" name="Operative"/>
+      </categoryLinks>
+      <profiles>
+        <profile name="Lesser daemon (Pts 2)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="2c9e-714d-dcda-227c">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">2</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">10</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink name="Brawler" id="ecf1-5349-ea51-a560" hidden="false" type="profile" targetId="8119-7495-8063-6302"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Daemonic weapon" hidden="false" id="929b-3343-4b46-6b24">
+          <profiles>
+            <profile name="⚔ Daemonic weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5446-5afd-c161-8248">
+              <characteristics>
+                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fb94-98ca-915c-441e" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9ceb-b5d5-53af-8d02" includeChildSelections="false"/>
+          </constraints>
+          <infoLinks>
+            <infoLink name="Lethal x+" id="c4a1-c4bb-a78b-2084" hidden="false" type="rule" targetId="8b97-e3e3-2857-817a"/>
+          </infoLinks>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Legionary (Pts 3)" hidden="false" id="36e3-58bd-982d-5323">
+      <categoryLinks>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="2f44-46ce-65fb-6db0" primary="true" name="Operative"/>
+      </categoryLinks>
+      <profiles>
+        <profile name="Legionary (Pts 3)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="3e30-575a-89b7-6cc9">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">3</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">3+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">14</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Behaviour" typeId="a8aa-8fdf-b828-ee91" typeName="Behaviour" hidden="false" id="bc18-4180-2793-2329">
+          <characteristics>
+            <characteristic name="Behaviour" typeId="9afc-d237-3382-7dba">Battler, or Guardian if this NPO has a weapon marked with an asterisk (*).</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Astartes" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ba7f-ca97-1a1c-f18a">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This NPO can perform two Fight or two Shoot actions during each of its activations. If it&apos;s two Shoot actions, a bolt pistol or boltgun must be selected for both of them.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Weapon options" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1cd4-5352-2317-e42c">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This NPO has either a boltgun and fists or bolt pistol and chainsword. 1 in 5 can have a ranged weapon marked with and asterisk (*) instead of a boltgun. Note that if a weapon with an asterisk has multiple profiles, it&apos;s still the same ranged weapon.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Weapons" id="b582-ffe4-9f69-c973" hidden="false">
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Special weapon &amp; Fists" id="b77b-6786-105c-2855" hidden="false">
+              <profiles>
+                <profile name="⚔ Fists" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7e66-674e-9847-4b0b">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Reaper chaincannon*" hidden="false" id="255c-56d9-29fa-fa21">
+                  <profiles>
+                    <profile name="⌖ Reaper chaincannon (sweeping)*" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bdd5-5163-49ed-8747">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless, Heavy (Reposition only), Punishing, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Reaper chaincannon (focused)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="290d-3c71-301a-095e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless, Heavy (Reposition only), Punishing</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink name="Torrent x" id="a8ec-26a2-b472-4303" hidden="false" type="rule" targetId="ad45-b4bb-1345-e4f9"/>
+                    <infoLink name="Ceaseless" id="6b71-9d6c-3af2-2890" hidden="false" type="rule" targetId="752d-ce38-c325-4b8a"/>
+                    <infoLink name="Heavy" id="0202-c8ce-4a0c-289e" hidden="false" type="rule" targetId="816e-44a2-6be4-6a9a"/>
+                    <infoLink name="Punishing" id="19fd-6e7a-d0e5-7b37" hidden="false" type="rule" targetId="4805-d37d-3ff2-5c9e"/>
+                  </infoLinks>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Missile launcher*" hidden="false" id="b368-ea9f-90a5-d298">
+                  <profiles>
+                    <profile name="⌖ Missile launcher (krak)*" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="20bf-a043-315d-23f0">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition), Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Missile launcher (frag)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b0ba-01e5-c4ec-b760">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition)</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink name="Blast x" id="fdc5-dc32-4c3b-c400" hidden="false" type="rule" targetId="0d74-0977-b481-bd13"/>
+                    <infoLink name="Heavy" id="585e-cafe-04a5-96e8" hidden="false" type="rule" targetId="816e-44a2-6be4-6a9a"/>
+                    <infoLink name="Piercing x" id="7a5d-8c4b-b239-da7a" hidden="false" type="rule" targetId="4c07-2cb3-1417-cbb7"/>
+                  </infoLinks>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma gun*" hidden="false" id="6d85-2e18-f9aa-062e">
+                  <profiles>
+                    <profile name="⌖ Plasma gun (standard)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a36b-748b-cd11-6298">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma gun (supercharge)*" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="16e7-885d-85bb-dd3f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink name="Lethal x+" id="084b-95c4-a584-93a9" hidden="false" type="rule" targetId="8b97-e3e3-2857-817a"/>
+                    <infoLink name="Piercing x" id="3263-c377-01e7-7801" hidden="false" type="rule" targetId="4c07-2cb3-1417-cbb7"/>
+                    <infoLink name="Hot" id="c7ef-6374-5e37-542b" hidden="false" type="rule" targetId="ec63-40e6-6282-8420"/>
+                  </infoLinks>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Flamer*" hidden="false" id="845e-4bbc-19a8-cea4">
+                  <profiles>
+                    <profile name="⌖ Flamer*" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="087c-7196-f4e8-77d6">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink name="Torrent x" id="08f3-5f42-f5e9-3343" hidden="false" type="rule" targetId="ad45-b4bb-1345-e4f9"/>
+                    <infoLink name="Range x" id="028b-dfb8-ab74-1c06" hidden="false" type="rule" targetId="a528-829e-8268-c005"/>
+                    <infoLink name="Saturate" id="b169-b969-8eae-d576" hidden="false" type="rule" targetId="3c10-2d52-d1ac-b0f6"/>
+                  </infoLinks>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy bolter*" hidden="false" id="498e-f3c4-b1c2-55b8">
+                  <profiles>
+                    <profile name="⌖ Heavy bolter (focused)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7ab1-3d43-85d0-e6e4">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing Crists 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Heavy bolter (sweeping)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a3ca-7ab1-040d-bd7f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing Crists 1, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink name="Torrent x" id="c027-2adb-0712-366d" hidden="false" type="rule" targetId="ad45-b4bb-1345-e4f9"/>
+                    <infoLink name="Heavy" id="0206-362d-8ef9-d81b" hidden="false" type="rule" targetId="816e-44a2-6be4-6a9a"/>
+                    <infoLink name="Piercing x" id="6468-af6d-f0f2-26c6" hidden="false" type="rule" targetId="4c07-2cb3-1417-cbb7"/>
+                  </infoLinks>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Meltagun*" hidden="false" id="e6e8-0248-8196-7865">
+                  <profiles>
+                    <profile name="⌖ Meltagun*" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a72f-0c18-aa80-cee0">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink name="Piercing x" id="af41-f70b-62bb-35cc" hidden="false" type="rule" targetId="4c07-2cb3-1417-cbb7"/>
+                    <infoLink name="Range x" id="6643-9edd-f856-4b7f" hidden="false" type="rule" targetId="a528-829e-8268-c005"/>
+                    <infoLink name="Devastating x" id="16c2-5939-3a51-a5b2" hidden="false" type="rule" targetId="a8ba-6e3a-76b3-f05c"/>
+                  </infoLinks>
+                </selectionEntry>
+              </selectionEntries>
+              <constraints>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="8f13-cc78-6496-d400" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5971-6bf0-9048-2738" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="d582-b7ca-a35b-9b9c" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6636-33cb-4ece-5113" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Boltgun &amp; Fists" hidden="false" id="3962-9a3a-bcf4-274d">
+              <profiles>
+                <profile name="⌖ Boltgun" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0a87-0bda-9398-98e5">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="⚔ Fists" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2410-8a42-1ae2-c22b">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Bolt pistol &amp; Chainsword" hidden="false" id="e57c-c253-9e38-9d71">
+              <infoLinks>
+                <infoLink name="Range x" id="b62c-c723-5587-aff5" hidden="false" type="rule" targetId="a528-829e-8268-c005"/>
+              </infoLinks>
+              <profiles>
+                <profile name="⚔ Chainsword" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e8dd-61e8-0dc6-6ab9">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="⌖ Bolt pistol" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7966-4a41-aa34-6432">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Warrior (Marksman)" hidden="false" id="9363-90e0-d781-8228">
+      <profiles>
+        <profile name="Warrior (Marksman)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="2b38-8985-b1ef-b16a">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">2</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">8</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Firearm" hidden="false" id="090a-a7cb-22c6-5d62" sortIndex="1">
+          <profiles>
+            <profile name="⌖ Firearm" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6f6e-62e0-063c-ca4d">
+              <characteristics>
+                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f5bd-adea-9dec-c6e7" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2044-43a0-4cd0-8512" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Knife" hidden="false" id="a284-a829-ebf7-9891" sortIndex="2">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="37d9-034d-50e8-26bd" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b784-57da-bd5a-7794" includeChildSelections="false"/>
+          </constraints>
+          <profiles>
+            <profile name="⚔ Knife" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="90a4-81fd-d487-2d77">
+              <characteristics>
+                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
+                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">2/3</characteristic>
+                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+      </selectionEntries>
+      <categoryLinks>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="9ba1-0c53-21e2-c61a" primary="true" name="Operative"/>
+        <categoryLink targetId="42ac-1bda-6ac1-8220" id="b251-d94d-e4ba-080a" primary="false" name="Marksman"/>
+      </categoryLinks>
+      <infoLinks>
+        <infoLink name="Marksman" id="cf20-0ad5-c45f-6847" hidden="false" type="profile" targetId="a6db-a06f-71ee-1feb"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Lychguard" hidden="false" id="d15a-a553-1ff9-321c">
+      <categoryLinks>
+        <categoryLink name="Operative" hidden="false" id="1a5d-5e0f-0383-3208" targetId="cf83-4496-b58e-ac82" primary="true"/>
+      </categoryLinks>
+      <profiles>
+        <profile name="Lychguard" typeId="a8aa-8fdf-b828-ee91" typeName="Behaviour" hidden="false" id="5986-bf00-285a-0620">
+          <characteristics>
+            <characteristic name="Behaviour" typeId="9afc-d237-3382-7dba">This NPO will stay close to the Royal Warden unless the enemy is close enough to charge or fight. If it can perform either of its first two actions during that activation, or if it can end the activation with a Royal Warden that has an Engage order within its control range, give it an Engage order. If it cannot, give it a Conceal order. It will perform the **Operate Hatch** action where necessary to fulfil its behaviour.
+
+
+1. **Fight**.
+2. **Charge** the closest player operative via the shortest possible route.
+3. **Reposition** towards the Royal Warden NPO, to cover if possible (a subsequent Dash action can fulfil this, if able). If the Royal Warden NPO isn&apos;t in the killzone, **Reposition** towards the closest player operative (following the same conditions).
+4. **Dash** towards the Royal Warden NPO, to cover if possible. If the Royal Warden NPO isn&apos;t in the killzone, Dash towards the closest player operative (following the same conditions).</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Lychguard" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="7c7c-24e9-38e7-c629">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">2</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">5&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">3+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">13</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Guardian Protocols" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f0f1-e122-5f72-69cd">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a player operative is performing a **Shoot** action, if this NPO has an Engage order, the player(s) cannot select a Royal Warden NPO within this NPO&apos;s control range as a valid target.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Hyperphase sword" hidden="false" id="5140-66ba-b1e1-5f46">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b644-b9f0-a6a5-9f04"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="26a0-3a7f-bda1-9256"/>
+          </constraints>
+          <profiles>
+            <profile name="⚔ Hyperphase sword" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d2eb-0fda-19f9-9bfb">
+              <characteristics>
+                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Shield*</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Lethal x+" id="6502-2b36-b556-39ab" hidden="false" type="rule" targetId="8b97-e3e3-2857-817a"/>
+          </infoLinks>
+          <rules>
+            <rule name="*Shield" id="b1db-8973-6917-6704" hidden="false">
+              <description>Whenever this operative is fighting or retaliating with this weapon, each of your blocks can be allocated to block two unresolved successes (instead of one).</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Warscythe" hidden="false" id="a51e-c731-b0a9-684f">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="25a1-c61a-d4bc-180e"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d683-9a64-45be-d0a6"/>
+          </constraints>
+          <profiles>
+            <profile name="⚔ Warscythe" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f553-0f64-26df-50d7">
+              <characteristics>
+                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Lethal x+" id="6e4e-8d9a-471a-cce9" hidden="false" type="rule" targetId="8b97-e3e3-2857-817a"/>
+          </infoLinks>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntry>
   </selectionEntries>
   <sharedProfiles>

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -1396,6 +1396,3041 @@
         </profile>
       </profiles>
     </selectionEntry>
+    <selectionEntry type="model" import="true" name="Nemesis (S)" hidden="false" id="d19e-756d-b1ce-e474">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Allegiance Trait" id="8987-3f7b-1772-4233" hidden="false">
+          <profiles>
+            <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="648d-5a6a-a1a1-1c14">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6ee7-d969-ea32-490d">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c635-7dc5-7b3f-743f">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ec34-7b1e-c621-2af4">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8928-c83e-b378-7384">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2664-7a1f-c901-4d0e">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5be5-efd8-e934-4723">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="586a-a460-3121-2f3d">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bdb9-e93f-b644-ccba" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f6c-4613-7603-fd45" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Nemesis Trait" id="ca26-013f-2758-775c" hidden="false">
+          <profiles>
+            <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c439-9e65-8f61-88f8">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b981-b25b-b4a1-7481">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="92aa-6d81-73ce-93b1">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f41c-1291-a5ff-2426">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="dfe3-87b5-8edf-f629">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b343-4b47-73c0-f171">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1dfe-eb50-8534-2ab5">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a0ea-33e6-c114-5da5">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c284-90f2-fa12-7796">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b047-76ff-d45c-cc0d">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c62b-45af-79d2-3234">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2da1-97d1-2372-544d">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6c6f-118b-b1f6-17d7">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a3d2-3f00-0807-c949" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2f25-ae57-e508-3a09" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Weapons" id="3f35-4ad4-8112-2bf6" hidden="false">
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Weapons / Trait x2" id="3782-f40c-3b8c-7912" hidden="false">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a8b4-6323-14d4-5dbb" includeChildSelections="false"/>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="c6a0-1826-bfd0-4978" includeChildSelections="false"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="51cd-7dde-9593-458d">
+                  <profiles>
+                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3a15-e8d8-ecbf-3f88">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="a6b5-15bd-6e18-a16c">
+                  <profiles>
+                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fe89-81b2-c524-72ae">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="8179-fb7f-da28-bd3d">
+                  <profiles>
+                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0859-fe1b-9f30-16ce">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="e94d-eacd-b5a4-3de5">
+                  <profiles>
+                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d8ee-4242-8a44-b2db">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="4b3f-34b5-2141-0506">
+                  <profiles>
+                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="15e7-9ab9-3185-b1d5">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="bd79-5a4d-25f6-dc32">
+                  <profiles>
+                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9f66-6563-c823-8dc3">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="2116-851b-acae-3dea">
+                  <profiles>
+                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c3bb-46e6-d592-68d0">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="ec9d-47ac-3d9d-f58c">
+                  <profiles>
+                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8b32-0d3b-521d-8c09">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="49aa-6bdd-53c0-d8ec">
+                  <profiles>
+                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="637b-6bdb-a219-1a9c">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="7cf8-9abe-1d98-806a">
+                  <profiles>
+                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="457f-c62b-e6f0-ce67">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="35df-3499-073f-aadb">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="b4d2-9ef9-e5d5-db29">
+                  <profiles>
+                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fffb-f08e-99cc-9a7f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="df59-8790-d33a-3895">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="a582-60fe-9009-b17f">
+                  <profiles>
+                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="371f-2d38-bbc4-3cdf">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="acb7-1d59-86d7-e8ec">
+                  <profiles>
+                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1e11-7167-1783-79e3">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="63fd-3a3d-6575-eef1">
+                  <profiles>
+                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c622-0a87-aa20-5ef7">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="eddf-1d22-6faa-64a7">
+                  <profiles>
+                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3855-798e-49da-2ebc">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="4fcb-52e8-07a3-9904">
+                  <profiles>
+                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="83bf-109d-3f9e-a875">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="2213-e28e-0a03-78a5">
+                  <profiles>
+                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5841-60fe-6fbd-6f79">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="9ecc-ca30-80e1-50e1">
+                  <profiles>
+                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e506-01f0-5186-9d4b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="8de4-f7e7-2349-72f0">
+                  <profiles>
+                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cc1b-4a16-c47d-1379">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="b082-e17b-ae4b-a4c2">
+                  <profiles>
+                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5bb9-84ae-e06d-a613">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="bac4-b9d0-5420-ae0a">
+                  <profiles>
+                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0c9a-7c3e-ccd6-6b99">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="1e80-be8e-8252-7bff">
+                  <profiles>
+                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="977c-f63f-48ba-d4e5">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="f47c-77ca-b5e2-afb5">
+                  <profiles>
+                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e895-cd17-a0fd-e911">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="3d0e-b4c1-ccae-1416">
+                  <profiles>
+                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1695-16f5-2e1d-98ce">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="da09-5083-d75a-ade0">
+                  <profiles>
+                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="adee-9217-e850-56d5">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="8276-b301-d183-1a9f">
+                  <profiles>
+                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f0d0-755a-8167-bf90">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="2f61-9931-dd3e-bcb0">
+                  <profiles>
+                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bac2-c943-d1f4-11db">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="f940-6694-02d7-f1f9">
+                  <profiles>
+                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0879-476e-fc0b-c6fa">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <profiles>
+                <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3ce4-0b97-8020-4579">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="525a-508f-d4b5-f82e">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1617-ec77-4b48-efb9">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="12a0-e13d-11ec-25bc">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4d14-7636-4c2f-3c0d">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2323-a02b-0577-6d10">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1c8e-7ff2-cc64-8b85">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3326-12f4-42bb-6205">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2496-2a00-5f4b-e7ed">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2ac9-fc6d-8f3e-4032">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2f07-ee0e-ca17-7d39">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="cdef-556f-b625-7ae7">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e1ce-a3e8-02cf-b7bf">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Weapon x1" id="ddcc-612d-8e31-bbc1" hidden="false">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="928d-4aa8-8dc3-0b9f">
+                  <profiles>
+                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2155-8760-f817-7be8">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="6ca3-be48-3535-e3f5">
+                  <profiles>
+                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b0da-aa8d-27d7-3b1f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="d23d-4c77-20ae-ea20">
+                  <profiles>
+                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e000-d507-db21-f91a">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="58a0-020c-138c-90d4">
+                  <profiles>
+                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0fa0-6ae5-65d7-6b7d">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="1026-e8a1-4179-7194">
+                  <profiles>
+                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5c8a-d8fe-51f4-4812">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8796-e3c8-f29c-ee96">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="fd87-3c6c-b9de-c147">
+                  <profiles>
+                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="eea5-ca71-7602-b84e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2e93-af17-75a4-9d39">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="2a0d-c6c9-ec36-59cb">
+                  <profiles>
+                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7540-1044-2337-fd3f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c113-52d7-d3e9-377e" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4dab-3286-cdc9-472a" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9bdd-2b44-cc95-4852" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4786-184c-e327-6b26" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Close combat weapon" id="00ec-596a-ae74-5468" hidden="false">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="52ae-f95e-17ad-e8ef" includeChildSelections="false"/>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="dda7-76d9-6276-ac2e" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="5a11-1573-1ba3-afa2">
+              <profiles>
+                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8c87-0ed2-6cf3-c5bf">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Selection 0</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <profiles>
+        <profile name="Nemesis Small (S) (Pts 4)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="9635-547c-17c0-61d2">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">-</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">35</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Extra Defense" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a52e-8d44-15d2-b1a6">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Bulky" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d76c-8b00-b5d1-332e">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative cannot be placed on Vantage terrain higher than 2&quot; from the killzone floor.
+Whenever this operative would perform the fight action, the distance requirements for its control range can be changed to 1&quot; horizontally and 4&quot; vertically until the end of that action.
+This operative can move through other operatives (excluding Nemesis operatives)
+Ignore all changes to this operative&apos;s APL and if it&apos;s a player operative, APL changes don&apos;t affect the 5AP you can spend per turning point.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Towering size" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c4d7-659a-93ab-65ab">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the Firefight phase, whenever you determine this operative&apos;s order, you cannot select Conceal.
+This operative cannot be in cover or obscured by Light terrain, terrain parts less than 3&quot; tall or terrain that&apos;s not wholly intervening.
+Whenever another operative is performing the Shoot action, being within control range of other operatives doesn&apos;t prevent this operative from being selected as a valid target.
+This operative can move through terrain parts less than 2&quot; tall. It cannot move through Accessible terrain (excluding hatchways) unless that terrain is also less than 2&quot; tall.
+Whenever this operative would finish a move in a terrain feature less than 2&quot; tall, temporarily remove that terrain feature from the killzone, then return it when this operative leaves that location. If it&apos;s an equipment terrain feature, remove it from the battle instead.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule name="Extra Defense" id="671e-f995-24cf-3b74" hidden="false">
+          <description>Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</description>
+        </rule>
+      </rules>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Nemesis (L)" hidden="false" id="b375-1cc0-1990-a18d">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Allegiance Trait" id="51c4-75a2-f245-d01f" hidden="false">
+          <profiles>
+            <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="32ce-f9d3-fa56-6129">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="93e4-bfbf-c0de-0561">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f86a-7f1c-4fec-efb6">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3c5e-9105-e8ce-699a">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d1ec-827b-c4c3-e34b">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="debe-8953-8433-5bd6">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="98a3-5042-cfc1-75c9">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="76ff-83e2-76e4-ed3a">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0f0-8133-722e-f117" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="409d-9591-53a9-20a6" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Nemesis Trait" id="9c5c-c1cd-cab8-3292" hidden="false">
+          <profiles>
+            <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="eb86-ffdb-699f-cee6">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3369-f828-27a8-95d0">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c99f-390a-fed6-079a">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="88d1-79f9-59a0-8bea">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d64d-a840-7026-07a3">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3c58-2493-a76c-69ab">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="9cbf-fab5-a216-33de">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4112-68e1-bc2e-e5e9">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e481-acc9-2b4c-7fbd">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3fe1-cf72-28fa-6dc0">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0162-3de1-bdfe-670a">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bea8-353d-0407-9daf">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7e7f-2ac9-acec-ca55">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="040b-599e-6e41-6512" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="831e-e730-4649-8e1c" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Weapons" id="5702-3b0e-f0e8-bacd" hidden="false">
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Weapons Selection 2" id="7bb7-dd1c-73f1-e735" hidden="false">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="Weapon x1" id="5603-bf51-4666-8496" hidden="false">
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="44f4-0d39-160b-fbff">
+                      <profiles>
+                        <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d328-d531-9e03-86bc">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="d7d2-7e5d-1189-ba2e">
+                      <profiles>
+                        <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d29e-7154-68fa-fba8">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="87e9-50a8-fa62-114e">
+                      <profiles>
+                        <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bfbb-ebfa-0e94-c9e4">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="f93f-55aa-015b-bbc5">
+                      <profiles>
+                        <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="943b-1f7a-2086-2963">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="4e17-713d-ea31-1cb4">
+                      <profiles>
+                        <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4e80-6b9d-72c5-55ee">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a714-0ba9-94ca-a849">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="4671-b16e-c684-74b8">
+                      <profiles>
+                        <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b519-58fe-e7fa-9c69">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="15b0-cad5-0bae-d34c">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="ea54-1d11-b2df-6769">
+                      <profiles>
+                        <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2a17-749c-e7eb-9b12">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3d0f-1960-235c-5aca" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2595-1e6c-cc2a-f5c3" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="Weapons / Trait x2" id="b95a-ef96-01ea-2289" hidden="false">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="be75-312c-2c5c-5948" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4262-7f18-d084-0621" includeChildSelections="false"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="3401-97bd-0332-a58d">
+                      <profiles>
+                        <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="14f7-fe0c-c55b-d3fc">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="9b88-18a7-d260-20cc">
+                      <profiles>
+                        <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7b93-0d4e-ee7b-d3e9">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="c2ab-505c-b567-30c5">
+                      <profiles>
+                        <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="511d-05fa-b997-8467">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="ce59-3759-1346-751e">
+                      <profiles>
+                        <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e6dc-beaf-e338-a7d8">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="49b6-8977-ff99-9b7f">
+                      <profiles>
+                        <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="75a1-3099-a332-2b19">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="fccd-fe1d-5702-c366">
+                      <profiles>
+                        <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3d87-3045-370d-14a2">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="cd60-2ef2-0db8-a0a1">
+                      <profiles>
+                        <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4d55-57ea-113e-7771">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="b052-699f-b1e7-ea47">
+                      <profiles>
+                        <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="45c4-bfb7-6553-ee20">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="9b4d-25fc-d432-b496">
+                      <profiles>
+                        <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f036-0ada-674b-1ed1">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="ba98-04a6-d16a-e6fa">
+                      <profiles>
+                        <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0050-32e4-6a2b-91f8">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6a64-b8c6-bc05-d85b">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="5d52-3642-529b-8f7b">
+                      <profiles>
+                        <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a791-d476-b810-8fec">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6066-f261-25b7-5358">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="f080-0113-43bf-60f8">
+                      <profiles>
+                        <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5112-d868-2483-8f4a">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="730f-7ec2-559b-a1dd">
+                      <profiles>
+                        <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="13f6-3f18-bd2e-5496">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="cc8c-511e-c504-2d4b">
+                      <profiles>
+                        <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="85ec-ca76-f548-9114">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="f36e-07d9-2c2e-6098">
+                      <profiles>
+                        <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b80a-1676-b2ba-a9a6">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="3e51-fa92-0dc2-627d">
+                      <profiles>
+                        <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="780d-fe88-4449-2e15">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="8750-4526-e6a8-52b9">
+                      <profiles>
+                        <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0a26-3b39-a0b4-52cd">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="981b-7c2e-b973-958f">
+                      <profiles>
+                        <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="66ec-db19-bdfb-01ae">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="e66b-7319-9353-097e">
+                      <profiles>
+                        <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1366-51a7-6981-bedb">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="30f5-e5ac-1fb2-eab0">
+                      <profiles>
+                        <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8142-5415-9bab-1969">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="da12-2834-06f6-1007">
+                      <profiles>
+                        <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2959-cb45-4fc1-7f81">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="1873-23b0-6449-0dfd">
+                      <profiles>
+                        <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3168-63e5-c330-1097">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="e359-450a-71c1-b39c">
+                      <profiles>
+                        <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6441-bb10-951e-78ca">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="3f6e-8f26-64b7-bd16">
+                      <profiles>
+                        <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="71ff-ad6f-3332-2584">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="eb1b-d3ce-f09e-747c">
+                      <profiles>
+                        <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ed24-ff93-a25b-6090">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="4270-5104-b1ff-2c7d">
+                      <profiles>
+                        <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8c87-9e61-15d1-87c7">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="cf3b-6205-6a98-e1a4">
+                      <profiles>
+                        <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a0b7-5cb5-2cfd-dfd1">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="96f9-e084-aad8-2a66">
+                      <profiles>
+                        <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="db31-e54a-7494-7246">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <profiles>
+                    <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2ca9-27ce-fc6d-1293">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bd34-8845-62e0-d917">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a7d4-454a-cdf0-359b">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="27b6-7c4f-fbd4-cc82">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0eb8-8661-e98f-e7c0">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d3d2-a50d-89ab-bb99">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="da2a-3249-9a4b-bb2a">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c48e-8d8c-d062-059f">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0aa0-682c-495a-6603">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6d02-51db-0426-31be">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c1a1-4a06-2334-490c">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d25c-ae3f-43b5-a2ba">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="fa6b-b64a-0743-80ce">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup name="Weapons / Trait x2" id="2b04-84a0-0641-6156" hidden="false">
+                      <constraints>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="910c-acdb-ffef-7f58" includeChildSelections="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5572-904a-ce68-6672" includeChildSelections="false"/>
+                      </constraints>
+                      <selectionEntries>
+                        <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="663a-141f-9acc-a1ea">
+                          <profiles>
+                            <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6119-ddac-7f8e-7957">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="40b6-0bba-0ca6-a859">
+                          <profiles>
+                            <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f5cf-40ce-a769-cf08">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="aa65-31d5-a7d9-b650">
+                          <profiles>
+                            <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4491-5e6a-0807-3efc">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="203b-9658-7b31-b9e1">
+                          <profiles>
+                            <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="03ad-c5f5-2b04-d437">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="d621-de52-195a-3b96">
+                          <profiles>
+                            <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="04e3-b7a4-55de-07ba">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="b56e-1084-1499-5750">
+                          <profiles>
+                            <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="705e-2d1f-36c1-bd3d">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="61f6-ecd2-1fd5-2cfe">
+                          <profiles>
+                            <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="766c-16e7-8ed9-7c1d">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="fbe2-7e28-09aa-500b">
+                          <profiles>
+                            <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ee6e-3651-118e-28d0">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="91fe-e9d4-3584-1aaa">
+                          <profiles>
+                            <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7c48-a273-4985-6997">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="1c01-662e-c6c1-4308">
+                          <profiles>
+                            <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="be3c-400f-fe5d-b894">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                              </characteristics>
+                            </profile>
+                            <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2cb3-8dc2-468f-088e">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="dfb9-a9e2-b2e2-4387">
+                          <profiles>
+                            <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0538-06b3-cb17-78dd">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                              </characteristics>
+                            </profile>
+                            <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a91d-2b19-247a-fa76">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="02a7-0fd8-76b6-cfc0">
+                          <profiles>
+                            <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="088e-d8ad-074c-b908">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="4887-09d7-f5ad-3b26">
+                          <profiles>
+                            <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8e26-54c9-05a5-19a1">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="e79f-01cc-f06e-1446">
+                          <profiles>
+                            <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0f32-8a8b-82a9-40ef">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="c177-b0e7-7f07-9495">
+                          <profiles>
+                            <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2021-3115-377c-15a3">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="454d-7a4f-14a4-fa40">
+                          <profiles>
+                            <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d3d3-b17a-c049-f0e6">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="eb78-58f2-4cbb-9c5d">
+                          <profiles>
+                            <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bccb-507f-b647-05cf">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="352a-6fec-4368-8797">
+                          <profiles>
+                            <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cdaa-e3f8-03ac-3deb">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="f0aa-cec5-c9a0-4eb5">
+                          <profiles>
+                            <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="573e-dec5-66e9-f6e0">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="9698-3e9f-f7af-6eee">
+                          <profiles>
+                            <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="dc37-046b-3647-9b01">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="2bf1-aba4-959b-8d68">
+                          <profiles>
+                            <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bf78-7ff1-7cbf-902d">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="98c6-2b9b-c0c6-1f82">
+                          <profiles>
+                            <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="162b-64d9-2f00-dcba">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="3208-97ad-0d93-889f">
+                          <profiles>
+                            <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="77f7-cc12-d47a-43c1">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="2b24-e163-e30d-c779">
+                          <profiles>
+                            <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="dad8-af15-8004-edf8">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="bdb8-acf0-4a43-e8d5">
+                          <profiles>
+                            <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9bd7-2b2f-ef0d-1b9f">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="d52d-c89b-511b-5b4f">
+                          <profiles>
+                            <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="28f9-19a3-e420-d657">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="171a-493d-d50a-782d">
+                          <profiles>
+                            <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="dc48-1253-247a-a6f3">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="7744-c0bb-ad3d-d18e">
+                          <profiles>
+                            <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8006-763f-2cd0-16e5">
+                              <characteristics>
+                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <profiles>
+                        <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="28ba-5e22-6084-3d9d">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d659-46b7-57da-3d15">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1093-3d69-3806-492c">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c027-ca59-e574-bd7b">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7e6a-ae75-6fb2-c56d">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d0f3-5d53-baa4-10f0">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f964-0930-e3cc-7242">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="fdbe-826c-2ca2-321a">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="581f-b17b-29ea-ac42">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ed95-eb9b-6a55-d2e3">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2245-8bc9-1e56-62ce">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bbac-f1c8-87a3-156f">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5955-9e39-16e2-a3dd">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Weapons / Trait x3" id="f331-8078-0e57-7cd4" hidden="false">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cd19-054f-7d32-f4b2" includeChildSelections="false"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="631e-ad35-d772-04d0" includeChildSelections="false"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="760c-d6f7-9533-5a1a">
+                  <profiles>
+                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ae4e-29ff-1f8c-ed04">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="6350-78a5-12e6-65e8">
+                  <profiles>
+                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3447-2591-7cb4-89ba">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="50a7-022b-0ad0-4da2">
+                  <profiles>
+                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7dd0-7adc-f3ca-d3b1">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="971d-cd51-e7ad-005e">
+                  <profiles>
+                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8df9-aa3c-dfeb-1bf8">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="6cdb-b511-4d0b-b5ff">
+                  <profiles>
+                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a6cf-3c9f-60e4-75b8">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="8119-3e83-fc0e-b491">
+                  <profiles>
+                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f33f-b686-76c0-fae8">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="c164-8cc7-8eae-b0a2">
+                  <profiles>
+                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3d1d-8887-4f05-c36f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="757b-1135-2bae-9886">
+                  <profiles>
+                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9c2b-760e-1a48-6512">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="28f5-06d9-3812-a7ce">
+                  <profiles>
+                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7bdc-eac0-870e-a7d1">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="1398-e5e6-e148-ddcf">
+                  <profiles>
+                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c19e-3698-04fb-2409">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="00cf-9ef3-30f0-511c">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="0cb6-9e92-9b6a-2e6c">
+                  <profiles>
+                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="eb82-f1d9-23ff-5a67">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="340a-4a8d-43c9-1764">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="63b9-ba1e-4b5a-cd72">
+                  <profiles>
+                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b869-d790-666f-49af">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="7964-6883-8ca3-070b">
+                  <profiles>
+                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6257-2de4-789d-d0bd">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="b63d-1941-42dd-da8c">
+                  <profiles>
+                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="87ed-32d2-497d-de79">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="4f10-d8e9-c336-b578">
+                  <profiles>
+                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0958-2367-f1ae-4edf">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="3489-ab8c-dfa0-64b9">
+                  <profiles>
+                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ade7-c059-7171-937e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="e50c-6d65-056e-7c7c">
+                  <profiles>
+                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7d02-7594-79db-771f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="3a3e-1323-0a84-f704">
+                  <profiles>
+                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="810d-e78b-f1d1-9d5b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="7cf9-ab4c-a9f5-5441">
+                  <profiles>
+                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5a5d-6bad-ad3c-5b9f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="dafd-ca0c-021d-837f">
+                  <profiles>
+                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0cd5-1653-7552-8463">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="9d8d-5e07-06a7-6078">
+                  <profiles>
+                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="16de-e6f0-e402-8b9f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="89c1-f570-ea5e-a82c">
+                  <profiles>
+                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="41d7-b9b3-f7e3-0ee1">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="1996-a9bf-3765-7ac7">
+                  <profiles>
+                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cad0-b3bc-e80e-4150">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="e601-e455-5ea0-6504">
+                  <profiles>
+                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fbff-fae5-1550-7e6f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="2f7b-84e6-bc8f-6f27">
+                  <profiles>
+                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cdb2-abbb-7c8b-540c">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="bf77-92f9-1edd-4a31">
+                  <profiles>
+                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7f84-5d31-7ee6-53c0">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="a121-9038-69b3-41bf">
+                  <profiles>
+                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="544c-5414-c0e2-a5bf">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="8aec-6ca9-abee-8327">
+                  <profiles>
+                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f626-1a14-c1f5-fdbb">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <profiles>
+                <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e3ae-2af0-81f7-a27d">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="708a-fc23-7c1c-2871">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2a5b-5503-f032-5d4a">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="05a1-6257-bd59-eba3">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1b4b-9cf1-f4e5-0b9c">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bdf7-29a2-317e-3bcb">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="fb66-be3e-7550-f69c">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4b8b-436b-8a54-8108">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1206-85b7-1dad-42dc">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3904-1f49-95d8-9336">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="83b5-e732-3b77-67c3">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d811-801c-18ad-33cd">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="9349-e889-3915-e8ef">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c1e7-ed6b-54e5-c7b2" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4b35-9761-24ff-1888" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Close combat weapon" id="5ab8-6299-8a5f-d642" hidden="false">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7c39-c891-e682-94cb" includeChildSelections="false"/>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="2337-bc63-dcc9-1a1f" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="381c-9ca4-993a-ed8d">
+              <profiles>
+                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="49fc-d78d-b3fe-8707">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Selection 0</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <profiles>
+        <profile name="Nemesis Large (L) (Pts 6)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="5c3e-3694-729e-16d0">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">-</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">75</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Extra Defense" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a7a2-a9b8-388e-952a">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Bulky" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="dd75-355e-0804-863c">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative cannot be placed on Vantage terrain higher than 2&quot; from the killzone floor.
+Whenever this operative would perform the fight action, the distance requirements for its control range can be changed to 1&quot; horizontally and 4&quot; vertically until the end of that action.
+This operative can move through other operatives (excluding Nemesis operatives)
+Ignore all changes to this operative&apos;s APL and if it&apos;s a player operative, APL changes don&apos;t affect the 5AP you can spend per turning point.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Towering size" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6ba9-2004-32bf-9330">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the Firefight phase, whenever you determine this operative&apos;s order, you cannot select Conceal.
+This operative cannot be in cover or obscured by Light terrain, terrain parts less than 3&quot; tall or terrain that&apos;s not wholly intervening.
+Whenever another operative is performing the Shoot action, being within control range of other operatives doesn&apos;t prevent this operative from being selected as a valid target.
+This operative can move through terrain parts less than 2&quot; tall. It cannot move through Accessible terrain (excluding hatchways) unless that terrain is also less than 2&quot; tall.
+Whenever this operative would finish a move in a terrain feature less than 2&quot; tall, temporarily remove that terrain feature from the killzone, then return it when this operative leaves that location. If it&apos;s an equipment terrain feature, remove it from the battle instead.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule name="Extra Defense" id="292e-4144-2abd-1e39" hidden="false">
+          <description>Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</description>
+        </rule>
+      </rules>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Nemesis (M)" hidden="false" id="be0b-e701-602a-7b29">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Allegiance Trait" id="3c53-26bc-df22-42bf" hidden="false">
+          <profiles>
+            <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7a13-93e2-63f1-880c">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="efc8-01ad-a23a-d9b9">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d4cc-26eb-2f76-510a">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="615a-0860-676c-5a3f">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2b74-efe0-83c1-1362">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c732-3a1d-baa0-4798">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6061-0a33-1115-1553">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1692-d393-ecc2-c707">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dddb-b987-7082-d3da" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ae38-1cd5-a2a8-8649" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Nemesis Trait" id="18ef-9b71-3b32-dbe7" hidden="false">
+          <profiles>
+            <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="836a-a3e6-7a66-32c0">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7e4c-629d-e817-1d8c">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b80d-170a-ee95-6267">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6649-b89c-e6bc-fbcb">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0e9b-ac30-298b-d86a">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="edfd-6151-ae42-5cf2">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b50a-bded-c918-7193">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7839-3d21-f197-8d31">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3ede-5b4a-e07a-f7c2">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a1cd-8289-1041-246d">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b040-897c-81cb-0656">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8587-d505-2cdf-b5ad">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6e62-d928-3c15-28e7">
+              <characteristics>
+                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="23ab-722b-7c36-8d6d" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0440-f22a-adc7-2ed7" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Weapons" id="631b-a555-d7d6-7ba1" hidden="false">
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Weapons / Trait x2" id="bae1-5857-ae09-072e" hidden="false">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="351f-0f8a-2a1d-fc5e" includeChildSelections="false"/>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="2fe8-b04c-0386-d157" includeChildSelections="false"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="0ae9-763a-a6f8-71c0">
+                  <profiles>
+                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b89b-d164-92f7-8f82">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="e0c0-0da0-1130-6ef9">
+                  <profiles>
+                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8bd0-bf62-5b61-acf6">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="19cd-b1c7-fa62-6381">
+                  <profiles>
+                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6cd1-d063-770f-af51">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="c52e-d62b-b71c-79a3">
+                  <profiles>
+                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="18ba-a42e-d7da-240e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="b547-1bcd-5b73-e826">
+                  <profiles>
+                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2998-a154-552e-202e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="cb4a-e32a-f6e6-27e3">
+                  <profiles>
+                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d802-d70a-c250-6621">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="052b-9114-d040-8113">
+                  <profiles>
+                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a734-6455-8168-a056">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="244d-3061-4bf7-c5e9">
+                  <profiles>
+                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7863-0d73-1742-aed3">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="2c56-e210-6c8c-bb55">
+                  <profiles>
+                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1b95-aa69-93d3-e950">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="986c-7607-7e06-d2b3">
+                  <profiles>
+                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9e8e-a42e-8dc8-d8ed">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1c16-241c-02a2-6f8c">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="7f54-38f7-19ae-7a3a">
+                  <profiles>
+                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="700d-4dd2-b32f-165d">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="078c-fada-dbb9-cd93">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="0297-c66d-3e63-5465">
+                  <profiles>
+                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5ebc-6602-0f32-79ae">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="29ba-70ef-3044-a6b1">
+                  <profiles>
+                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c7bf-5c05-bf1e-7175">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="0705-6024-2e05-6832">
+                  <profiles>
+                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3a9c-19c1-58c5-2ed9">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="44c6-4327-a73a-69b5">
+                  <profiles>
+                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f13d-1733-5af8-5e95">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="761d-1cc9-2e5b-d5f7">
+                  <profiles>
+                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9a59-662b-ceac-9e11">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="11f6-e5ad-1c17-2280">
+                  <profiles>
+                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c751-a59a-7f2c-8cea">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="e4b5-a253-539d-b500">
+                  <profiles>
+                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="04a7-7836-e9d8-ffad">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="1222-3ee1-3a77-c800">
+                  <profiles>
+                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8cc4-01c7-18e5-d54f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="82c0-eb7a-1e3d-8f45">
+                  <profiles>
+                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2f65-d62e-b7f2-5e3a">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="d5ed-a63b-f000-0f34">
+                  <profiles>
+                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8b02-6646-c7e8-1c17">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="15ac-a58d-5c1a-62c1">
+                  <profiles>
+                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7678-2c9a-fea3-485b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="b04a-da3d-ac40-7111">
+                  <profiles>
+                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e0ae-1526-dc83-549a">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="0cad-a594-c988-c649">
+                  <profiles>
+                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="198c-0300-510f-c382">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="947b-2ed6-5ece-d683">
+                  <profiles>
+                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0e23-79b9-88da-7a6f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="8a87-d76e-fb88-faef">
+                  <profiles>
+                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="29d2-b47f-a067-384b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="6c90-baa8-4d53-f774">
+                  <profiles>
+                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6e84-c585-29b9-d583">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="e698-86a4-24f8-d224">
+                  <profiles>
+                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e22b-8c95-4690-6508">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <profiles>
+                <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0184-66c2-6452-819c">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bd65-f27f-d4b8-b558">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="82ba-0c5b-4dc0-4992">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4dec-3bfe-15eb-fcda">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="99fd-8f75-60ab-a96e">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a0c6-3055-5fe3-afc7">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5961-b6a2-2852-5ac7">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1e68-00ae-5e68-a129">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6def-1ce7-2a3c-fbb6">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7f2b-6575-e3bc-b9bf">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7e18-4a9b-67a8-99a7">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6bdc-c2ee-b816-15db">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c9b8-af2a-ac02-a5f9">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Weapon x1" id="b881-816e-a44d-233b" hidden="false">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="7f09-445f-4da7-9c87">
+                  <profiles>
+                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6381-d0d9-10dc-59ab">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="dd86-002b-d44a-a84d">
+                  <profiles>
+                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3d8f-e3ac-0b16-a2e1">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="34a8-1c7c-01a0-078c">
+                  <profiles>
+                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5655-8a79-379c-ac2d">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="05ec-78dd-ef1f-4ec0">
+                  <profiles>
+                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2387-8b5a-d8bb-fdd8">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="3791-736d-5ab3-9627">
+                  <profiles>
+                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3984-8626-18aa-9d2b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4301-ec70-4045-d668">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="03a8-f339-c30d-0761">
+                  <profiles>
+                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="16f0-ea74-719f-9d53">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ac95-97ab-95e4-e0a0">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="7ef0-3e44-ede3-479f">
+                  <profiles>
+                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e71d-ee99-113e-1be0">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="982d-9839-03b2-c36f" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b8e4-8919-6914-f753" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8bb5-f795-3d91-68c2" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0889-4888-a9a7-6888" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Close combat weapon" id="95b4-633e-df54-3eed" hidden="false">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="294f-58f0-112b-beae" includeChildSelections="false"/>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="dd50-0b3a-2890-d416" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="814d-a01b-bd5e-5d28">
+              <profiles>
+                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4ab2-cfcb-fea0-2ea1">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Selection 0</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <profiles>
+        <profile name="Nemesis Medium (M) (Pts 5)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="0f9b-9e24-8f3c-2729">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">-</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">50</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Extra Defense" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0342-1fee-177f-2598">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Bulky" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6b13-9669-0448-826b">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative cannot be placed on Vantage terrain higher than 2&quot; from the killzone floor.
+Whenever this operative would perform the fight action, the distance requirements for its control range can be changed to 1&quot; horizontally and 4&quot; vertically until the end of that action.
+This operative can move through other operatives (excluding Nemesis operatives)
+Ignore all changes to this operative&apos;s APL and if it&apos;s a player operative, APL changes don&apos;t affect the 5AP you can spend per turning point.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Towering size" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="507d-dc9d-81b3-2da9">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the Firefight phase, whenever you determine this operative&apos;s order, you cannot select Conceal.
+This operative cannot be in cover or obscured by Light terrain, terrain parts less than 3&quot; tall or terrain that&apos;s not wholly intervening.
+Whenever another operative is performing the Shoot action, being within control range of other operatives doesn&apos;t prevent this operative from being selected as a valid target.
+This operative can move through terrain parts less than 2&quot; tall. It cannot move through Accessible terrain (excluding hatchways) unless that terrain is also less than 2&quot; tall.
+Whenever this operative would finish a move in a terrain feature less than 2&quot; tall, temporarily remove that terrain feature from the killzone, then return it when this operative leaves that location. If it&apos;s an equipment terrain feature, remove it from the battle instead.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule name="Extra Defense" id="8ba2-7a3d-60ea-2086" hidden="false">
+          <description>Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</description>
+        </rule>
+      </rules>
+    </selectionEntry>
   </selectionEntries>
   <sharedProfiles>
     <profile name="Shape Reference" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="33ab-2508-5035-24df">

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ffd6-f3ca-defa-f836" name="Non-player Operatives" gameSystemId="c521-ad27-44df-f959" gameSystemRevision="5" revision="6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ffd6-f3ca-defa-f836" name="Non-player Operatives" gameSystemId="c521-ad27-44df-f959" gameSystemRevision="5" revision="7" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry type="model" import="true" name="Trooper (Brawler)" hidden="false" id="f599-6934-5d14-a8fa">
       <categoryLinks>
@@ -1304,6 +1304,97 @@
           </infoLinks>
         </selectionEntry>
       </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Fire Warrior (Pts 1)" hidden="false" id="3ae3-a720-355d-86f7">
+      <categoryLinks>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="8a7c-60b3-f271-2e4f" primary="true" name="Operative"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Gun butt" hidden="false" id="aa36-0639-436d-60d6">
+          <profiles>
+            <profile name="⚔ Gun butt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3630-14e0-6624-dc51">
+              <characteristics>
+                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
+                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">5+</characteristic>
+                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">2/3</characteristic>
+                <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c27e-4b6c-5912-a85e" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a625-c6a5-30a3-10fc" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Ranged weapon" id="fe28-0eed-0042-2f1b" hidden="false">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Pulse Blaster" hidden="false" id="3beb-34e3-54f9-751c">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9259-1b44-7c65-b102" includeChildSelections="false"/>
+              </constraints>
+              <profiles>
+                <profile name="⌖ Pulse Blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e74f-c5ac-919a-d447">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/4</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink name="Range x" id="2957-cbae-0280-d70d" hidden="false" type="rule" targetId="a528-829e-8268-c005"/>
+              </infoLinks>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Pulse Rifle" hidden="false" id="05ec-3847-72a2-397c">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ff41-aec0-2ea0-be94" includeChildSelections="false"/>
+              </constraints>
+              <profiles>
+                <profile name="⌖ Pulse Rifle (stationary)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1c1b-beeb-3c29-798a">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Balanced, Heavy</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="⌖ Pulse Rifle (mobile)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="dd48-bdc9-87a1-84dc">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink name="Balanced" id="b241-d06c-4ebe-6461" hidden="false" type="rule" targetId="28f7-0d96-d1fc-f75b"/>
+                <infoLink name="Heavy" id="479f-3efe-87b5-0dd9" hidden="false" type="rule" targetId="816e-44a2-6be4-6a9a"/>
+              </infoLinks>
+            </selectionEntry>
+          </selectionEntries>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c23e-3f8d-71a5-00a8" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="177d-d48f-dfbd-581d" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <infoLinks>
+        <infoLink name="Marksman" id="8716-5b16-bfd9-ff5c" hidden="false" type="profile" targetId="a6db-a06f-71ee-1feb"/>
+      </infoLinks>
+      <profiles>
+        <profile name="Fire Warrior (Pts 1)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="b863-fc04-8710-a648">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">2</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
     </selectionEntry>
   </selectionEntries>
   <sharedProfiles>

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -109,7 +109,7 @@
             <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">2</characteristic>
             <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
             <characteristic name="Save" typeId="3241-5548-12d6-f103">5+</characteristic>
-            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">67</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">7</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -313,7 +313,7 @@
         <infoLink name="Marksman" id="1b55-65e3-a68b-2643" hidden="false" type="profile" targetId="a6db-a06f-71ee-1feb"/>
       </infoLinks>
     </selectionEntry>
-    <selectionEntry type="model" import="true" name="Hormagaunt" hidden="false" id="c58a-49df-9f3c-a358">
+    <selectionEntry type="model" import="true" name="Hormagaunt (Pts 1)" hidden="false" id="c58a-49df-9f3c-a358">
       <profiles>
         <profile name="Hormagaunt" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="201c-59ce-d288-7c96">
           <characteristics>
@@ -492,7 +492,7 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="model" import="true" name="Termagant" hidden="false" id="d01b-4991-49ca-de90">
+    <selectionEntry type="model" import="true" name="Termagant (Pts 1)" hidden="false" id="d01b-4991-49ca-de90">
       <infoLinks>
         <infoLink name="Marksman (Typhon)" id="50df-104b-02f7-7626" hidden="false" type="profile" targetId="fdfb-9a72-f4de-726a"/>
       </infoLinks>
@@ -1398,1289 +1398,14 @@
     </selectionEntry>
     <selectionEntry type="model" import="true" name="Nemesis (L)" hidden="false" id="d19e-756d-b1ce-e474">
       <selectionEntryGroups>
-        <selectionEntryGroup name="Allegiance Trait" id="8987-3f7b-1772-4233" hidden="false">
+        <selectionEntryGroup name="Close combat weapon" id="2802-86c9-a59d-2ea3" hidden="false" sortIndex="4">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bdb9-e93f-b644-ccba" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f6c-4613-7603-fd45" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b65c-1567-702b-e5f2" includeChildSelections="false"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Leagues of Vontann: Acquisition at all costs" hidden="false" id="94ef-2a37-c14d-6f5c">
+            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="bfa5-b5a8-22a1-4555">
               <profiles>
-                <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ec34-7b1e-c621-2af4">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Chaos: Let the galaxy burn" hidden="false" id="ff89-dc6b-e2c7-ecb8">
-              <profiles>
-                <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8928-c83e-b378-7384">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Aeldari: Arrogant Superiority" hidden="false" id="08df-d27b-4b31-6167">
-              <profiles>
-                <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="648d-5a6a-a1a1-1c14">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Imperium: Defenders of the Imperium" hidden="false" id="08b8-2096-3125-ffde">
-              <profiles>
-                <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="586a-a460-3121-2f3d">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Ork: WAAAGH!" hidden="false" id="e037-2d4b-cc16-5297">
-              <profiles>
-                <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c635-7dc5-7b3f-743f">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Necron: Living Metal" hidden="false" id="6fe8-8c54-081c-0e90">
-              <profiles>
-                <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5be5-efd8-e934-4723">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="T&apos;au: Supporting Fire" hidden="false" id="9a95-d628-68fc-5826">
-              <profiles>
-                <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2664-7a1f-c901-4d0e">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Tyranid: Will of the hive mind" hidden="false" id="936b-b437-00e1-7168">
-              <profiles>
-                <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6ee7-d969-ea32-490d">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Nemesis Trait" id="ca26-013f-2758-775c" hidden="false">
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a3d2-3f00-0807-c949" includeChildSelections="false"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2f25-ae57-e508-3a09" includeChildSelections="false"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="add1-07a1-5b5c-14a8"/>
-            <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="d109-2341-fdf6-d6a7">
-              <profiles>
-                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a0ea-33e6-c114-5da5">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="78a1-e1c9-eec2-ce6f">
-              <profiles>
-                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b981-b25b-b4a1-7481">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="2773-eb8c-6360-4ffd">
-              <profiles>
-                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b047-76ff-d45c-cc0d">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="cd5f-7560-3551-4ab5">
-              <profiles>
-                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="dfe3-87b5-8edf-f629">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="0a6a-5e34-f53c-adc9">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="21a4-6cd0-1cc9-cef6">
-                  <profiles>
-                    <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c284-90f2-fa12-7796">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-              </selectionEntries>
-              <profiles>
-                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="92aa-6d81-73ce-93b1">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="ff8e-8dfa-63e7-433b">
-              <profiles>
-                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f41c-1291-a5ff-2426">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="565e-9e58-52fe-d394">
-              <profiles>
-                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c62b-45af-79d2-3234">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="d0fc-f47e-a184-f97b">
-              <profiles>
-                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2da1-97d1-2372-544d">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="3f45-d276-16c9-26ba">
-              <profiles>
-                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b343-4b47-73c0-f171">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="a965-1826-618a-bccd">
-              <profiles>
-                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6c6f-118b-b1f6-17d7">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="9132-c6c0-a947-77d7">
-              <profiles>
-                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1dfe-eb50-8534-2ab5">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Weapons" id="3f35-4ad4-8112-2bf6" hidden="false">
-          <selectionEntryGroups>
-            <selectionEntryGroup name="3 Choices" id="3782-f40c-3b8c-7912" hidden="false">
-              <constraints>
-                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="c6a0-1826-bfd0-4978" includeChildSelections="false"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="51cd-7dde-9593-458d" sortIndex="2">
-                  <profiles>
-                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3a15-e8d8-ecbf-3f88">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="a6b5-15bd-6e18-a16c" sortIndex="4">
-                  <profiles>
-                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fe89-81b2-c524-72ae">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="8179-fb7f-da28-bd3d" sortIndex="12">
-                  <profiles>
-                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0859-fe1b-9f30-16ce">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="e94d-eacd-b5a4-3de5" sortIndex="14">
-                  <profiles>
-                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d8ee-4242-8a44-b2db">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="4b3f-34b5-2141-0506" sortIndex="13">
-                  <profiles>
-                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="15e7-9ab9-3185-b1d5">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="bd79-5a4d-25f6-dc32" sortIndex="15">
-                  <profiles>
-                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9f66-6563-c823-8dc3">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="2116-851b-acae-3dea" sortIndex="16">
-                  <profiles>
-                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c3bb-46e6-d592-68d0">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="ec9d-47ac-3d9d-f58c" sortIndex="18">
-                  <profiles>
-                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8b32-0d3b-521d-8c09">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="49aa-6bdd-53c0-d8ec" sortIndex="37">
-                  <profiles>
-                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="637b-6bdb-a219-1a9c">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="7cf8-9abe-1d98-806a" sortIndex="20">
-                  <profiles>
-                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="457f-c62b-e6f0-ce67">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="35df-3499-073f-aadb">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="b4d2-9ef9-e5d5-db29" sortIndex="23">
-                  <profiles>
-                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fffb-f08e-99cc-9a7f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="df59-8790-d33a-3895">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="a582-60fe-9009-b17f" sortIndex="21">
-                  <profiles>
-                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="371f-2d38-bbc4-3cdf">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="acb7-1d59-86d7-e8ec" sortIndex="19">
-                  <profiles>
-                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1e11-7167-1783-79e3">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="63fd-3a3d-6575-eef1" sortIndex="28">
-                  <profiles>
-                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c622-0a87-aa20-5ef7">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="eddf-1d22-6faa-64a7" sortIndex="32">
-                  <profiles>
-                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3855-798e-49da-2ebc">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="4fcb-52e8-07a3-9904" sortIndex="33">
-                  <profiles>
-                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="83bf-109d-3f9e-a875">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="2213-e28e-0a03-78a5" sortIndex="34">
-                  <profiles>
-                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5841-60fe-6fbd-6f79">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="9ecc-ca30-80e1-50e1" sortIndex="35">
-                  <profiles>
-                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e506-01f0-5186-9d4b">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="8de4-f7e7-2349-72f0" sortIndex="39">
-                  <profiles>
-                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cc1b-4a16-c47d-1379">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="b082-e17b-ae4b-a4c2" sortIndex="5">
-                  <profiles>
-                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5bb9-84ae-e06d-a613">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="bac4-b9d0-5420-ae0a" sortIndex="8">
-                  <profiles>
-                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0c9a-7c3e-ccd6-6b99">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="1e80-be8e-8252-7bff" sortIndex="9">
-                  <profiles>
-                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="977c-f63f-48ba-d4e5">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="f47c-77ca-b5e2-afb5" sortIndex="22">
-                  <profiles>
-                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e895-cd17-a0fd-e911">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="3d0e-b4c1-ccae-1416" sortIndex="24">
-                  <profiles>
-                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1695-16f5-2e1d-98ce">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="da09-5083-d75a-ade0" sortIndex="25">
-                  <profiles>
-                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="adee-9217-e850-56d5">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="8276-b301-d183-1a9f" sortIndex="26">
-                  <profiles>
-                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f0d0-755a-8167-bf90">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="2f61-9931-dd3e-bcb0" sortIndex="27">
-                  <profiles>
-                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bac2-c943-d1f4-11db">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="f940-6694-02d7-f1f9" sortIndex="29">
-                  <profiles>
-                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0879-476e-fc0b-c6fa">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="db35-9889-d6b1-4a6e">
-                  <profiles>
-                    <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c439-9e65-8f61-88f8">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="31bb-c597-de90-3e0b">
-                  <profiles>
-                    <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3b2a-5ac7-1842-3500">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="11a2-0739-5a89-3468">
-                  <profiles>
-                    <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="650c-b8ce-dfc0-011d">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="35ff-b9af-b8f1-4d2c">
-                  <profiles>
-                    <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5636-b0d5-8410-58f5">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="d30e-787b-10fa-72e0">
-                  <profiles>
-                    <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b257-2fdf-3b8f-f686">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="6c23-a97d-31f0-5aa7">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="6f8d-21c4-24ab-ee33">
-                      <profiles>
-                        <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ad38-f47d-1be6-566a">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <profiles>
-                    <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0b91-3da2-6679-c48d">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="530c-e607-4827-462f">
-                  <profiles>
-                    <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="56a6-e28d-3214-f90e">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="06c3-bcba-9af5-4423">
-                  <profiles>
-                    <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b1c0-cb02-2836-67a4">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="4edc-cd33-6459-3f70">
-                  <profiles>
-                    <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b6ed-0a17-6553-1d1b">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="afca-bfa9-33c2-aaa9">
-                  <profiles>
-                    <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a0bc-b5fa-fcb1-c0fb">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="4847-c056-3fa2-7781">
-                  <profiles>
-                    <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2a1a-4420-2ce1-c002">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="63bc-9dc7-fb4a-9cb2">
-                  <profiles>
-                    <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="edcc-149d-fa78-217a">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="2 Choices" id="ddcc-612d-8e31-bbc1" hidden="false">
-              <selectionEntryGroups>
-                <selectionEntryGroup name="Weapon" id="e15c-7ed3-157f-e825" hidden="false">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="2a0d-c6c9-ec36-59cb">
-                      <profiles>
-                        <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7540-1044-2337-fd3f">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="928d-4aa8-8dc3-0b9f">
-                      <profiles>
-                        <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2155-8760-f817-7be8">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="6ca3-be48-3535-e3f5">
-                      <profiles>
-                        <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b0da-aa8d-27d7-3b1f">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="d23d-4c77-20ae-ea20">
-                      <profiles>
-                        <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e000-d507-db21-f91a">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="58a0-020c-138c-90d4">
-                      <profiles>
-                        <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0fa0-6ae5-65d7-6b7d">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="1026-e8a1-4179-7194">
-                      <profiles>
-                        <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5c8a-d8fe-51f4-4812">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8796-e3c8-f29c-ee96">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="fd87-3c6c-b9de-c147">
-                      <profiles>
-                        <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="eea5-ca71-7602-b84e">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2e93-af17-75a4-9d39">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <constraints>
-                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="c113-52d7-d3e9-377e" includeChildSelections="false"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4dab-3286-cdc9-472a" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntryGroup>
-                <selectionEntryGroup name="Weapon / Trait" id="5bb1-02d4-004a-4116" hidden="false">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2269-a22e-8be2-6b51" includeChildSelections="false"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="c4de-3b31-e3a2-4206" sortIndex="2">
-                      <profiles>
-                        <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e915-2671-6505-f044">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="dcfb-988d-55cc-ee16" sortIndex="4">
-                      <profiles>
-                        <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="717a-ad9d-f85e-65a9">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="fca9-48ef-c91f-3090" sortIndex="12">
-                      <profiles>
-                        <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d2aa-ac3c-1a3c-510c">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="8cb4-f51f-3aaa-137f" sortIndex="14">
-                      <profiles>
-                        <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c203-0e9e-23bb-e374">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="3d19-2b77-ef00-4dc8" sortIndex="13">
-                      <profiles>
-                        <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7c8c-c2d9-ea11-8c21">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="ee60-f97d-1439-e216" sortIndex="15">
-                      <profiles>
-                        <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d27b-8bc2-2cf5-26b9">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="a652-50b6-ac4c-7d47" sortIndex="16">
-                      <profiles>
-                        <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9490-24f8-7549-31dd">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="f348-e09a-2a90-ce82" sortIndex="18">
-                      <profiles>
-                        <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="68c4-f592-4f32-fadb">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="31b6-2883-a525-57c3" sortIndex="37">
-                      <profiles>
-                        <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="972f-b820-a8b1-0585">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="fe70-c4aa-b6b2-a499" sortIndex="20">
-                      <profiles>
-                        <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6dc9-5b29-e1d9-7e14">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bc07-ba74-fdb6-f910">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="b165-1095-71f3-ffea" sortIndex="23">
-                      <profiles>
-                        <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b1b4-4b4d-b286-7dac">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="20da-7bc5-ed89-1df8">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="2266-4dcd-a467-1790" sortIndex="21">
-                      <profiles>
-                        <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6e39-b387-3d13-db55">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="a18c-4eb9-aed6-d747" sortIndex="19">
-                      <profiles>
-                        <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4899-3732-8200-b1e0">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="abe5-486a-d438-07af" sortIndex="28">
-                      <profiles>
-                        <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cb8c-ffdd-4b2a-44c8">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="e936-6206-c9ee-c645" sortIndex="32">
-                      <profiles>
-                        <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d2e6-2421-1cd6-a5f1">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="55b9-a48d-7655-4930" sortIndex="33">
-                      <profiles>
-                        <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0f9c-1d51-b591-6dcc">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="fbae-558f-78d6-2270" sortIndex="34">
-                      <profiles>
-                        <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7391-084c-3eac-4146">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="c0e6-5d4a-2c4b-3f76" sortIndex="35">
-                      <profiles>
-                        <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="95fb-b995-921e-6188">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="9ba8-16f5-7001-2454" sortIndex="39">
-                      <profiles>
-                        <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="289b-ca7d-8801-2a19">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="72e7-6af0-d02a-daec" sortIndex="5">
-                      <profiles>
-                        <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c81b-58d0-e805-59f0">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="95c8-9474-d491-7cbc" sortIndex="8">
-                      <profiles>
-                        <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5cb4-8a5c-c74d-348f">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="9081-5f06-54aa-a26e" sortIndex="9">
-                      <profiles>
-                        <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b2f6-9fb7-1b3b-6c86">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="bf7f-4de3-ab1c-a92c" sortIndex="22">
-                      <profiles>
-                        <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="77fb-1d11-ce4a-e17d">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="231d-5b13-dacb-72fb" sortIndex="24">
-                      <profiles>
-                        <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0042-bf75-e41f-aaa6">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="7ce2-39b1-7e57-5c00" sortIndex="25">
-                      <profiles>
-                        <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cec2-f8e2-3587-7a39">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="e379-268a-d776-1932" sortIndex="26">
-                      <profiles>
-                        <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="38a6-c394-028c-68e6">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="8507-4583-0e73-cb8b" sortIndex="27">
-                      <profiles>
-                        <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3bff-a700-5747-beda">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="a295-d80a-6779-6649" sortIndex="29">
-                      <profiles>
-                        <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="23ac-92d3-ea6a-1402">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="6f22-8909-e901-2539">
-                      <profiles>
-                        <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7eab-b8b0-d25c-14a9">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="7918-aae0-0334-381f">
-                      <profiles>
-                        <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8f3f-2a98-5ddd-9b25">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="882f-7396-6d06-6499">
-                      <profiles>
-                        <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b84e-6d0d-cc56-8783">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="1b24-a845-1fff-ecd6">
-                      <profiles>
-                        <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1f7c-6cd8-7264-479f">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="2c0c-97a5-6364-0d31">
-                      <profiles>
-                        <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d780-5d0f-5ceb-78fe">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="07ee-1a4c-2c54-b48b">
-                      <selectionEntries>
-                        <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="43ca-7a62-f176-f9c2">
-                          <profiles>
-                            <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0179-8fc3-ecc1-6e73">
-                              <characteristics>
-                                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <profiles>
-                        <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a5d6-f6bb-35c3-737c">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="80d0-c5a7-2cba-ff26">
-                      <profiles>
-                        <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ef38-840b-26e6-e79d">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="ce86-4372-c948-a442">
-                      <profiles>
-                        <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="dc6a-d3d1-3ab0-850b">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="2840-039b-eca6-d594">
-                      <profiles>
-                        <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3537-dfd2-b486-bb39">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="a9be-e559-4248-f850">
-                      <profiles>
-                        <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0a02-6645-ac82-8a02">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="b379-6d8f-33ac-f5e0">
-                      <profiles>
-                        <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="38c0-66df-589a-525b">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="7be6-16bb-628e-ec59">
-                      <profiles>
-                        <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="fa08-1167-7673-f0ce">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9bdd-2b44-cc95-4852" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4786-184c-e327-6b26" includeChildSelections="false"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Close combat weapon" id="00ec-596a-ae74-5468" hidden="false">
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="52ae-f95e-17ad-e8ef" includeChildSelections="false"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="5a11-1573-1ba3-afa2">
-              <profiles>
-                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8c87-0ed2-6cf3-c5bf">
+                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cc44-1acc-bd3a-92d7">
                   <characteristics>
                     <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
                     <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
@@ -2691,6 +1416,933 @@
               </profiles>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Allegiance Trait" id="6d91-603b-0b80-0404" hidden="false" sortIndex="1">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5535-1622-e85a-e122" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="34e0-6db7-ad0d-eacc" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Leagues of Vontann: Acquisition at all costs" hidden="false" id="b764-2ad3-b0fb-f84c">
+              <profiles>
+                <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2f7f-cb1c-3939-737d">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Chaos: Let the galaxy burn" hidden="false" id="c3b7-51da-69a9-0eea">
+              <profiles>
+                <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="364e-5e32-f8eb-0e48">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Aeldari: Arrogant Superiority" hidden="false" id="54b9-741e-8520-7889">
+              <profiles>
+                <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="cda1-ac8a-31c7-c6ba">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Imperium: Defenders of the Imperium" hidden="false" id="6753-5c62-f2db-b186">
+              <profiles>
+                <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8ff2-b3da-ee36-9db2">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Ork: WAAAGH!" hidden="false" id="867c-413c-467b-e206">
+              <profiles>
+                <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="85a4-3100-ff72-2ebf">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Necron: Living Metal" hidden="false" id="30a1-878b-3107-cfe5">
+              <profiles>
+                <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="05e0-714c-6bd2-ebc2">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="T&apos;au: Supporting Fire" hidden="false" id="b047-075b-9602-cacd">
+              <profiles>
+                <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b750-5364-b601-b7bd">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tyranid: Will of the hive mind" hidden="false" id="7045-600a-97b0-50c0">
+              <profiles>
+                <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="49a5-7edb-b0f0-73d5">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Nemesis Trait" id="9639-fd45-37e0-681b" hidden="false" sortIndex="2">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="17b4-3fdd-b936-3b6d" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5f60-1d1a-c6e4-b47f" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="a2a5-ac7e-f593-0466"/>
+            <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="3d51-5e93-5470-2973">
+              <profiles>
+                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3508-38e0-c452-1d6e">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="d7cc-ea3e-1c49-ecdf">
+              <profiles>
+                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="12c4-e58f-f17d-0d35">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="a8c6-2844-19a1-588a">
+              <profiles>
+                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3c03-331a-1971-7e4b">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="b7ec-e8f3-0593-1f5c">
+              <profiles>
+                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="af42-d999-b05e-3e68">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="73a6-661e-4901-c9e3">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="4263-cdb5-9e09-bc63">
+                  <profiles>
+                    <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="14f6-8aef-ec52-47f4">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <profiles>
+                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="051b-bae5-a72a-3537">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="9592-2647-2f46-f707">
+              <profiles>
+                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="96cb-7eef-b148-30ce">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="ccfa-e716-fb8f-744e">
+              <profiles>
+                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="02bd-942b-a24f-56aa">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="9b74-dbba-2aac-9fff">
+              <profiles>
+                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0dc3-e2df-11de-f473">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="b386-46f5-6b28-28cd">
+              <profiles>
+                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="729b-5aed-1797-2fd3">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="941d-8e14-b000-e900">
+              <profiles>
+                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c323-8d86-705b-d6b5">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="26cb-aa3e-b7e9-c23e">
+              <profiles>
+                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c312-ff75-92a1-fafd">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Weapons" id="88e6-ab78-5a6f-687b" hidden="false" sortIndex="3">
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Heavy Weapon (count as 2)" id="900d-ed9f-ed0f-04bc" hidden="false">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="c137-9ecb-914c-4300">
+                  <profiles>
+                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="828f-d6f0-2204-e020">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="0e20-51e4-efb9-dcfa">
+                  <profiles>
+                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f84c-9d69-19c4-3488">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="262a-5a4e-367d-2ef6">
+                  <profiles>
+                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e4b1-4a37-e38e-4b4d">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="e3e8-a16b-2272-dd32">
+                  <profiles>
+                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9175-f3d2-2331-63eb">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="d668-a1da-f676-f3c9">
+                  <profiles>
+                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="755d-46c1-fad6-5bd0">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3c63-7414-8644-30c2">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="22c9-3f2d-e9ed-6431">
+                  <profiles>
+                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d2ae-80d6-3448-47e8">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9857-f402-5059-a318">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="613b-e491-538d-544a">
+                  <profiles>
+                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3616-6de6-69d1-55de">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <constraints>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="d38a-5833-429c-4337" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0b27-be81-511c-3c97" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Weapon / Trait" id="555d-ba02-79d1-883e" hidden="false">
+              <constraints>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="4fcf-9f88-4532-9d5f" includeChildSelections="false"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="5d33-e3ef-7c85-6971">
+                  <profiles>
+                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9546-f016-8035-f3da">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="83e9-68e9-2474-7b82" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="218a-757e-fd5c-230d">
+                  <profiles>
+                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="181d-fb13-473e-569b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cd1b-002e-6c33-c413" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="b344-3187-c35a-ea96">
+                  <profiles>
+                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7de9-3f4f-725a-4a2f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1820-89b6-13f5-8463" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="3ed8-2c51-7484-5bb5">
+                  <profiles>
+                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3380-998d-ef86-1fe4">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9c4a-f95a-800c-0cf0" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="124a-8753-4b15-397f">
+                  <profiles>
+                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bd54-8827-cac8-7423">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="45d6-dfde-1f7b-eb22" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="b43d-1924-4c8f-5c20">
+                  <profiles>
+                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fb45-3259-e97b-f2a5">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a003-e66c-222b-b7b0" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="86fe-4a84-87e4-83c0">
+                  <profiles>
+                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ecb3-62ae-9650-beca">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="32f8-50f8-04a9-96dd" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="5afd-5979-c535-1c21">
+                  <profiles>
+                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0ab9-41a6-a8ca-e885">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5366-791a-68f6-103b" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="18ca-575a-d74b-c1bf">
+                  <profiles>
+                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="87e5-0e2f-4b6f-2a2b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="616b-4f5b-0d52-5e90" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="aa45-a55e-ca2d-2387">
+                  <profiles>
+                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="393d-f96d-de63-d16b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7f99-4445-89de-7689" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="c96b-25fb-4a7a-6569">
+                  <profiles>
+                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9a15-d366-64d8-4e80">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6a39-7207-7e9a-0744" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="f39f-68ca-37a9-bf7d">
+                  <profiles>
+                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d628-80c5-eb0c-957b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="be92-5653-ac6f-4186" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="83c0-fb7e-40fc-fd4a">
+                  <profiles>
+                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="909b-d942-5349-c021">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9150-cac5-ed47-b82a">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="973b-49b2-e920-4406" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="20c6-0353-6f8f-82ad">
+                  <profiles>
+                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1c40-6cd4-b4b8-1124">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3031-48f1-52c4-2801" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="329a-f17a-816a-bed8">
+                  <profiles>
+                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bcef-9617-bbb2-6c26">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a3f3-8366-01e9-c8b2" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="9320-782f-9552-5367">
+                  <profiles>
+                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="40cb-ca59-a55a-328d">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="293d-2074-26d1-1748">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3887-7666-2587-8749" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="7ce9-586a-0df1-4c7f">
+                  <profiles>
+                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f4b4-ec2e-e927-375f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7841-8026-3948-89b8" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="189d-b28c-a8c9-1570">
+                  <profiles>
+                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5d5e-cc31-cc86-142f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="126e-744d-1854-7c0a" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="8ea8-688c-2cb0-4a52">
+                  <profiles>
+                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b5c4-8938-f37b-68c9">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="58b1-a383-a89d-3486" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="c2b1-2e69-9796-e70e">
+                  <profiles>
+                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2316-1409-b08f-e929">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f1a3-864e-a27a-2341" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="4eb0-7df7-4a1d-ec10">
+                  <profiles>
+                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d974-5e7b-eeaa-c760">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fe64-4ba8-9364-238a" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="4d64-2257-c563-c08d">
+                  <profiles>
+                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8598-556d-09f9-158c">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1dee-befb-21fd-7903" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="3605-2330-447d-6907">
+                  <profiles>
+                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a27f-c09b-8d26-f3d2">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5c54-aa81-4391-e84e" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="e6c0-2028-4fda-e518">
+                  <profiles>
+                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="39d0-30a5-3c7f-3683">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d29f-7b83-ae38-6eef" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="eda5-f792-b6fb-9a25">
+                  <profiles>
+                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ac8b-ae1a-0c30-cbf3">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="48e4-0ce6-6edc-6031" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="7c08-133d-a782-41ae">
+                  <profiles>
+                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fb54-5190-1992-b516">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ecaa-a782-bb0c-0eac" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="5ef9-3815-b533-f736">
+                  <profiles>
+                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5ceb-e23a-abab-2475">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3fe4-775c-ec04-b36a" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="e7d9-a6b5-dae3-e42d">
+                  <profiles>
+                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0f1a-7621-0124-6c81">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="72a0-2803-5586-095e" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup name="Bonus Trait" id="5bca-7868-3caf-870b" hidden="false">
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="2afa-d389-e2f9-7174">
+                      <profiles>
+                        <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b911-b4f9-b1e5-0850">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="18d4-0eaf-4feb-76ad" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="e70f-087e-0b11-f949">
+                      <profiles>
+                        <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1246-14f7-ac28-eed3">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="606d-dc3c-ee6d-3f79" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="9664-9211-fdd6-3f71">
+                      <profiles>
+                        <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="95bb-ae89-4dac-e6d5">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2668-e68c-bb68-8506" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="1eb3-2a68-5a73-0afa">
+                      <profiles>
+                        <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a660-5d43-c949-0d89">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1bfd-8b7d-1357-419d" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="5d42-513e-3c86-30c0">
+                      <profiles>
+                        <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d0fc-e33d-4e4f-606b">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9869-2e18-9e1b-e856" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="940f-a826-8695-01b4">
+                      <profiles>
+                        <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="18e0-0383-f1d5-5329">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f21b-a6cb-5146-f29e" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="5dcb-e746-8615-78ca">
+                      <profiles>
+                        <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="eef2-ae62-d207-c52b">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1d00-7212-1c77-f1a6" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="17b6-f742-b229-4147">
+                      <profiles>
+                        <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e4dc-4f97-0aaf-8285">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ced8-d8af-2bef-1160" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="384a-b575-b68b-598c">
+                      <profiles>
+                        <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4d37-39e9-25f8-aa63">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e18-8fae-f3ec-5da7" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="a577-0a31-ec93-bc43">
+                      <profiles>
+                        <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c935-1204-82f9-3d0d">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5336-ee34-fab0-6e2d" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="8b60-0e0a-7b39-70ab">
+                      <profiles>
+                        <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ec47-1691-11ac-b986">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="575e-42fb-edda-bac0" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="f4d1-db55-37ed-8c8e">
+                      <profiles>
+                        <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3fb0-82e8-c80f-03f2">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5684-5e28-091c-6293" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="ce13-95fd-8a77-e328">
+                      <profiles>
+                        <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="023e-0d49-69c9-6ab9">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0579-27f7-c1ce-3d33" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="f9e0-d563-03d0-0cf9" includeChildSelections="false"/>
+            <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="563d-de8f-1ae5-bd1a" includeChildSelections="false"/>
+          </constraints>
+          <modifiers>
+            <modifier type="decrement" value="1" field="563d-de8f-1ae5-bd1a">
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="parent" childId="900d-ed9f-ed0f-04bc" shared="true" includeChildSelections="false" childName="Heavy Weapon (count as 2)"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <profiles>
@@ -2731,7 +2383,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
     </selectionEntry>
     <selectionEntry type="model" import="true" name="Nemesis (S)" hidden="false" id="be0e-0c0b-2c03-21aa">
       <selectionEntryGroups>
-        <selectionEntryGroup name="Allegiance Trait" id="dbdc-2cf6-ab49-1fcb" hidden="false">
+        <selectionEntryGroup name="Allegiance Trait" id="dbdc-2cf6-ab49-1fcb" hidden="false" sortIndex="1">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9add-49d6-6866-204e" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4c3c-ea1b-6448-48e9" includeChildSelections="false"/>
@@ -2811,7 +2463,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup name="Nemesis Trait" id="7959-9958-cf21-c033" hidden="false">
+        <selectionEntryGroup name="Nemesis Trait" id="7959-9958-cf21-c033" hidden="false" sortIndex="2">
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9cc9-22e8-a791-44fb" includeChildSelections="false"/>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d1f3-9009-258e-9918" includeChildSelections="false"/>
@@ -2930,9 +2582,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup name="Weapons" id="0a87-cdd2-28bc-46e8" hidden="false">
+        <selectionEntryGroup name="Weapons" id="0a87-cdd2-28bc-46e8" hidden="false" sortIndex="3">
           <selectionEntryGroups>
-            <selectionEntryGroup name="Weapon x1" id="5033-4bea-1edc-3fa2" hidden="false">
+            <selectionEntryGroup name="Heavy Weapon (count as 2)" id="5033-4bea-1edc-3fa2" hidden="false">
               <selectionEntries>
                 <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="6eaf-73b8-8fc8-f469">
                   <profiles>
@@ -3040,13 +2692,10 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ed69-c7e4-a30d-603f" includeChildSelections="false"/>
               </constraints>
             </selectionEntryGroup>
-          </selectionEntryGroups>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a02c-8b4d-df93-4bbf" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c21c-c716-a3b8-0bc3" includeChildSelections="false"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Weapon / Trait x2" hidden="false" id="7c8e-e08a-5741-f9cb">
+            <selectionEntryGroup name="Weapon / Trait" id="6f2f-1d1e-ead8-d866" hidden="false">
+              <constraints>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="12ff-2e50-c679-9a2d" includeChildSelections="false"/>
+              </constraints>
               <selectionEntries>
                 <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="1d1d-a3d2-7451-d9a9">
                   <profiles>
@@ -3484,56 +3133,94 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="be56-3f27-9a67-f0d6" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="0de9-2e06-f34c-7f0e">
-                  <profiles>
-                    <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7ab3-8dae-b410-6f6a">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9630-c889-b0e9-bd7e" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="2749-b2ca-3e64-68fd">
-                  <profiles>
-                    <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6c40-929d-51db-550c">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5b97-a62d-b74b-3684" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="434c-c76a-12e1-2b10">
-                  <profiles>
-                    <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5df0-ca9f-e5d5-931e">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="58cb-7b98-35e2-f824" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="bf21-d61e-3f2d-3900">
-                  <profiles>
-                    <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="eb3a-a2ac-e90a-5a0d">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="122f-2a60-33a2-bcdb" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="f94b-fb8c-4555-922b">
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup name="Bonus Trait" id="130a-2337-6464-cc41" hidden="false">
                   <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="0a35-973b-5a4d-ef64">
+                      <profiles>
+                        <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="308c-447c-e229-6d3d">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f01-3ab7-dc10-51e1" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="8a27-e4fe-5e24-b579">
+                      <profiles>
+                        <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3e62-5f74-7ef5-7ff2">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="56b4-619d-8709-f13a" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="d9ff-40f2-05a1-25b0">
+                      <profiles>
+                        <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="babf-6726-45a0-d4d0">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f040-966d-16ce-8ed9" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="f3cf-c12f-e6a8-3d96">
+                      <profiles>
+                        <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4fef-9a4c-d6d3-3c2b">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e64-23fc-16a9-0427" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="64f2-0fea-a724-3f0a">
+                      <profiles>
+                        <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b72d-fefc-35df-c7b3">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4a2d-1e7a-4770-36e9" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="aaa5-306b-0c11-e2c6">
+                      <profiles>
+                        <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f5b3-c2dc-8090-45f2">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ac0a-c593-7aa7-7ac0" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="fcf7-a3b7-ce9c-c6be">
+                      <profiles>
+                        <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b212-e811-234d-f50f">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0cd0-a60f-846d-eb2e" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
                     <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="2205-f1fb-ac32-af93">
                       <profiles>
                         <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5d22-9e1e-51df-8823">
@@ -3542,112 +3229,88 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                           </characteristics>
                         </profile>
                       </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="74c1-5213-99ad-4aad" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="f94b-fb8c-4555-922b">
+                      <profiles>
+                        <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6642-7bf6-fbfe-0071">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d7c5-9317-d7bf-93e2" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="bf21-d61e-3f2d-3900">
+                      <profiles>
+                        <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="eb3a-a2ac-e90a-5a0d">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="122f-2a60-33a2-bcdb" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="434c-c76a-12e1-2b10">
+                      <profiles>
+                        <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5df0-ca9f-e5d5-931e">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="58cb-7b98-35e2-f824" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="2749-b2ca-3e64-68fd">
+                      <profiles>
+                        <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6c40-929d-51db-550c">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5b97-a62d-b74b-3684" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="0de9-2e06-f34c-7f0e">
+                      <profiles>
+                        <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7ab3-8dae-b410-6f6a">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9630-c889-b0e9-bd7e" includeChildSelections="false"/>
+                      </constraints>
                     </selectionEntry>
                   </selectionEntries>
-                  <profiles>
-                    <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6642-7bf6-fbfe-0071">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d7c5-9317-d7bf-93e2" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="fcf7-a3b7-ce9c-c6be">
-                  <profiles>
-                    <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b212-e811-234d-f50f">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0cd0-a60f-846d-eb2e" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="aaa5-306b-0c11-e2c6">
-                  <profiles>
-                    <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f5b3-c2dc-8090-45f2">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ac0a-c593-7aa7-7ac0" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="64f2-0fea-a724-3f0a">
-                  <profiles>
-                    <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b72d-fefc-35df-c7b3">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4a2d-1e7a-4770-36e9" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="f3cf-c12f-e6a8-3d96">
-                  <profiles>
-                    <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4fef-9a4c-d6d3-3c2b">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e64-23fc-16a9-0427" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="d9ff-40f2-05a1-25b0">
-                  <profiles>
-                    <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="babf-6726-45a0-d4d0">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f040-966d-16ce-8ed9" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="8a27-e4fe-5e24-b579">
-                  <profiles>
-                    <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3e62-5f74-7ef5-7ff2">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="56b4-619d-8709-f13a" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="0a35-973b-5a4d-ef64">
-                  <profiles>
-                    <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="308c-447c-e229-6d3d">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f01-3ab7-dc10-51e1" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-              </selectionEntries>
-              <constraints>
-                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="4e2b-7dd3-c923-b8ae" includeChildSelections="false"/>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="5799-6327-6bb3-38be" includeChildSelections="false"/>
-              </constraints>
-            </selectionEntry>
-          </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="a02c-8b4d-df93-4bbf" includeChildSelections="false"/>
+            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="c21c-c716-a3b8-0bc3" includeChildSelections="false"/>
+          </constraints>
+          <modifiers>
+            <modifier type="decrement" value="1" field="c21c-c716-a3b8-0bc3">
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="parent" childId="5033-4bea-1edc-3fa2" shared="true" includeChildSelections="false" childName="Heavy Weapon (count as 2)"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntryGroup>
-        <selectionEntryGroup name="Close combat weapon" id="b1d8-4876-bde6-b0a4" hidden="false">
+        <selectionEntryGroup name="Close combat weapon" id="b1d8-4876-bde6-b0a4" hidden="false" sortIndex="4">
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c13d-caa0-3d74-e24b" includeChildSelections="false"/>
           </constraints>
@@ -3705,78 +3368,78 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
     </selectionEntry>
     <selectionEntry type="model" import="true" name="Nemesis (M)" hidden="false" id="ffe5-857d-4e47-593c">
       <selectionEntryGroups>
-        <selectionEntryGroup name="Allegiance Trait" id="77f8-6514-4ae9-af30" hidden="false">
+        <selectionEntryGroup name="Allegiance Trait" id="5a8b-adba-e525-2005" hidden="false" sortIndex="1">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="baa8-ef4e-1462-6094" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e772-68d2-57d9-d1d4" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d13b-098d-e96f-a374" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3369-0b9c-7600-0ca4" includeChildSelections="false"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Leagues of Vontann: Acquisition at all costs" hidden="false" id="251f-14ad-2bb4-da23">
+            <selectionEntry type="upgrade" import="true" name="Leagues of Vontann: Acquisition at all costs" hidden="false" id="7004-c916-1774-3284">
               <profiles>
-                <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="14e0-d407-9ca7-77f4">
+                <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1886-77b8-0a0d-3816">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Chaos: Let the galaxy burn" hidden="false" id="d248-6242-abfb-1776">
+            <selectionEntry type="upgrade" import="true" name="Chaos: Let the galaxy burn" hidden="false" id="bc31-19fd-c09d-7f73">
               <profiles>
-                <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="cf53-eb5e-92ff-67ad">
+                <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f4fc-5884-f947-c4cd">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Aeldari: Arrogant Superiority" hidden="false" id="1198-f451-39c0-e812">
+            <selectionEntry type="upgrade" import="true" name="Aeldari: Arrogant Superiority" hidden="false" id="c350-181c-789e-3d5d">
               <profiles>
-                <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a1a1-9494-098e-9d61">
+                <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="30b8-f03c-a379-c607">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Imperium: Defenders of the Imperium" hidden="false" id="56bd-e0f5-c164-842a">
+            <selectionEntry type="upgrade" import="true" name="Imperium: Defenders of the Imperium" hidden="false" id="54de-11d3-71b2-0370">
               <profiles>
-                <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="650b-255c-1c36-5671">
+                <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="898e-8dad-5673-2a83">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Ork: WAAAGH!" hidden="false" id="b94f-a43d-5374-de7e">
+            <selectionEntry type="upgrade" import="true" name="Ork: WAAAGH!" hidden="false" id="d1ec-785d-5335-ee20">
               <profiles>
-                <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="82f1-4f6b-b511-1b6f">
+                <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e27d-bdf7-41c8-83de">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Necron: Living Metal" hidden="false" id="ce20-a998-1e53-fd36">
+            <selectionEntry type="upgrade" import="true" name="Necron: Living Metal" hidden="false" id="46da-778e-77e1-942f">
               <profiles>
-                <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="18d7-33d2-7aa8-cb08">
+                <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="88b7-589d-e72c-5075">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="T&apos;au: Supporting Fire" hidden="false" id="8370-3720-f037-8cc1">
+            <selectionEntry type="upgrade" import="true" name="T&apos;au: Supporting Fire" hidden="false" id="5c52-7d03-f72f-bb83">
               <profiles>
-                <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="cac5-a24c-c882-ecc0">
+                <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1f64-3ef6-48bd-bc55">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Tyranid: Will of the hive mind" hidden="false" id="0381-d879-507b-8e35">
+            <selectionEntry type="upgrade" import="true" name="Tyranid: Will of the hive mind" hidden="false" id="5e18-9883-b86c-2088">
               <profiles>
-                <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="9e41-537b-a162-6b71">
+                <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c821-9416-ecd1-9a9a">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
                   </characteristics>
@@ -3785,54 +3448,54 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup name="Nemesis Trait" id="8c91-6674-fde0-e105" hidden="false">
+        <selectionEntryGroup name="Nemesis Trait" id="60e8-bca7-387e-4a0c" hidden="false" sortIndex="2">
           <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a66c-71b8-91dc-54dc" includeChildSelections="false"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="64fe-4e3d-7193-1b07" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f021-02de-2865-6c4d" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3cb3-74b4-2a25-9572" includeChildSelections="false"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="94c2-a41c-9707-ebd7"/>
-            <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="665a-b90b-e134-f4f6">
+            <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="666c-a93c-21bb-843b"/>
+            <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="d4e5-c44a-43e7-4e0e">
               <profiles>
-                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c07e-61bf-67a5-f3d9">
+                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c820-6a06-6752-5304">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="5a63-e013-3d10-5d65">
+            <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="917a-9124-4157-b217">
               <profiles>
-                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="9b7e-969e-f865-558e">
+                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b93e-de61-795f-c0ba">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="f8b2-46f5-d9ff-d4d2">
+            <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="8407-99c2-cda5-ff53">
               <profiles>
-                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b960-ce3f-0583-017b">
+                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="9b2d-6706-3fb2-9b28">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="433a-d5d1-b330-67c1">
+            <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="19e1-9ae1-eede-bccc">
               <profiles>
-                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0afd-9a4e-547c-ac92">
+                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e9db-d902-8679-87ef">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="97eb-f4b8-8020-c3b9">
+            <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="bddb-c4b9-90c1-4982">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="cae3-d50a-caae-6c3a">
+                <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="9f33-ebd5-10c3-af5c">
                   <profiles>
-                    <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="76d1-46b2-1408-03cc">
+                    <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f383-9b80-6ace-aeb1">
                       <characteristics>
                         <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
                       </characteristics>
@@ -3841,61 +3504,61 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                 </selectionEntry>
               </selectionEntries>
               <profiles>
-                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8ce3-9d9f-6776-df06">
+                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0e69-78ff-d8c3-e3e9">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="753f-d17b-7c93-bda5">
+            <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="395d-c52f-8962-1a2c">
               <profiles>
-                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="757d-eba2-d5ea-3e7c">
+                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="da73-e829-d21c-3214">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="1158-9a46-bde4-5ac2">
+            <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="0710-c939-6ba8-97c3">
               <profiles>
-                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4ad3-6aef-9c73-2686">
+                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="95f3-e3de-3253-8cc3">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="c268-9461-c34e-8eb0">
+            <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="e7a3-1478-665a-90d9">
               <profiles>
-                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="37e6-f071-ca8d-d3c2">
+                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="12e7-06f4-fd16-6dd7">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="93af-079f-a008-11d8">
+            <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="ce02-588c-c5bf-0855">
               <profiles>
-                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c9d1-ace7-b395-595e">
+                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8618-01e6-7314-f456">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="3c6d-d92e-6d7e-0809">
+            <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="7bde-1eeb-57b6-dbbe">
               <profiles>
-                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7709-9f92-c89e-7b4b">
+                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="902e-1bd0-f242-bfec">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="b81d-b182-5320-d627">
+            <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="d9d0-4668-de49-7126">
               <profiles>
-                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5beb-1ac1-3cb4-fb2f">
+                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1c08-0425-d94c-d7eb">
                   <characteristics>
                     <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
                   </characteristics>
@@ -3904,491 +3567,13 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup name="Weapons" id="3b54-fab1-3e46-85c2" hidden="false">
+        <selectionEntryGroup name="Weapons" id="6258-0619-9554-dd62" hidden="false" sortIndex="3">
           <selectionEntryGroups>
-            <selectionEntryGroup name="Weapons / Trait x2" id="2607-ce42-f608-740c" hidden="false">
-              <constraints>
-                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="2de4-4f59-274b-1a9a" includeChildSelections="false"/>
-              </constraints>
+            <selectionEntryGroup name="Heavy Weapon (count as 2)" id="236b-9017-8966-ba98" hidden="false">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="9762-0a4c-b6db-f6f9" sortIndex="2">
+                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="4371-76ee-992e-5f2e">
                   <profiles>
-                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="83ff-d2a6-7ab2-fa8d">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="ad8c-d1e3-a993-1f0c" sortIndex="4">
-                  <profiles>
-                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="34d1-1765-9e64-8dcb">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="1018-c258-3a1d-3622" sortIndex="12">
-                  <profiles>
-                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0682-2b55-5faf-1dec">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="1d7f-488e-801e-7efb" sortIndex="14">
-                  <profiles>
-                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7aca-e999-9c6b-4b1c">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="ff12-c540-69f8-2aea" sortIndex="13">
-                  <profiles>
-                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="957a-53fd-6019-fa98">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="67b5-b49f-2000-e1fc" sortIndex="15">
-                  <profiles>
-                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d002-b329-3b9e-5685">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="cda6-da06-a850-5d47" sortIndex="16">
-                  <profiles>
-                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e0fc-2cca-7e70-31a0">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="bf55-ddb2-687a-eaf4" sortIndex="18">
-                  <profiles>
-                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5d86-b369-5e91-66f1">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="8398-d098-626a-def1" sortIndex="37">
-                  <profiles>
-                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cb93-a22b-4e51-72a7">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="4c8e-8fad-f7cf-bb82" sortIndex="20">
-                  <profiles>
-                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="10ea-2ace-1ded-94b1">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="72cb-59fc-2ff8-f6bc">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="451e-3272-190d-6813" sortIndex="23">
-                  <profiles>
-                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5939-e236-60d7-e075">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2e0e-3b72-949a-536a">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="3195-24cd-7cf5-bf04" sortIndex="21">
-                  <profiles>
-                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9abf-352e-7841-99fb">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="bce0-2413-60ee-b076" sortIndex="19">
-                  <profiles>
-                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="85f0-e24d-2429-1e28">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="2e33-1044-e95d-45bf" sortIndex="28">
-                  <profiles>
-                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8fb8-643b-8cb0-c72f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="1866-704c-5093-9d51" sortIndex="32">
-                  <profiles>
-                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5fab-f8f8-b039-26df">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="b247-4ee7-337c-cf2a" sortIndex="33">
-                  <profiles>
-                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e276-34fa-ea00-f64a">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="e452-30a7-5b8b-de65" sortIndex="34">
-                  <profiles>
-                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f020-206a-15ca-32ed">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="299a-50f9-f2dc-7983" sortIndex="35">
-                  <profiles>
-                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="aad9-ac05-5604-e29a">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="650f-ce10-1533-f3aa" sortIndex="39">
-                  <profiles>
-                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="16dc-b70b-1e32-5042">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="ae22-dbeb-00a5-2c2f" sortIndex="5">
-                  <profiles>
-                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e593-bbfa-c49f-492c">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="e6b4-98f9-4be5-a979" sortIndex="8">
-                  <profiles>
-                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b6d3-ef32-51e7-69e2">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="8aa4-5539-6778-8d88" sortIndex="9">
-                  <profiles>
-                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8796-a906-5d4b-ffa2">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="6ead-adda-6f28-1355" sortIndex="22">
-                  <profiles>
-                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3575-13c5-cad9-81bb">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="feb5-3914-ccf7-1754" sortIndex="24">
-                  <profiles>
-                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="40a1-8824-71c0-41ea">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="2200-7996-90b8-265a" sortIndex="25">
-                  <profiles>
-                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c5a5-6ae5-5788-ed85">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="8d16-c55e-1266-a20b" sortIndex="26">
-                  <profiles>
-                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ffc9-245a-aaaa-ce1a">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="ee00-bb89-0872-67e1" sortIndex="27">
-                  <profiles>
-                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2491-8e3a-799b-dc4e">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="832c-49ab-449b-923d" sortIndex="29">
-                  <profiles>
-                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2b53-878e-7a3f-e4fe">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="a763-40a1-a233-a3cd">
-                  <profiles>
-                    <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8b78-6efa-1ac0-5504">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="a670-a1cb-3e80-925b">
-                  <profiles>
-                    <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="75b9-14a0-0dc7-88ed">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="4b7e-c09b-98ec-f8fe">
-                  <profiles>
-                    <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d5fb-85d7-a673-4ef6">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="febc-e3aa-355b-6acd">
-                  <profiles>
-                    <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="853b-f808-1862-c806">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="5926-ca90-f2f3-02d6">
-                  <profiles>
-                    <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8567-3556-175f-f20e">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="e856-1d9c-e5f7-4fe8">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="5adc-bffe-001a-407f">
-                      <profiles>
-                        <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a27b-734c-5c93-2274">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <profiles>
-                    <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7260-51c1-cf82-58f7">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="d141-92b2-25f3-470c">
-                  <profiles>
-                    <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0ff5-fce7-0ad9-9d2e">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="dac0-4823-1c11-4d7e">
-                  <profiles>
-                    <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="65ee-8c45-ffa4-0f9f">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="3f80-3c82-7bd3-7b2f">
-                  <profiles>
-                    <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e714-9792-e86e-5ced">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="2832-971a-946f-5275">
-                  <profiles>
-                    <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0f83-4a0c-26dc-99d9">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="883a-82a4-b9c6-30a8">
-                  <profiles>
-                    <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b314-da55-41b1-54dd">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="fc0b-4b14-8775-9024">
-                  <profiles>
-                    <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="fe0c-767b-20d5-ff17">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="Weapon x1" id="7599-585c-710e-1169" hidden="false">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="873b-5c0d-7809-593a">
-                  <profiles>
-                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1c9d-e498-b03e-9990">
+                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="500c-1334-e273-5002">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4398,9 +3583,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="a6af-bf7b-3447-a254">
+                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="6864-2a0f-2ec8-81a0">
                   <profiles>
-                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cd08-8357-6569-1b7b">
+                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9f3f-a9f6-9102-ead7">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
@@ -4410,9 +3595,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="3b3d-93cc-53f7-a13b">
+                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="4359-d0b3-edec-b9bc">
                   <profiles>
-                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="df04-96c4-7368-3944">
+                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bb24-57c7-103a-29a6">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4422,9 +3607,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="0716-09eb-681f-f2d5">
+                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="22fc-e61a-ab69-fdd8">
                   <profiles>
-                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8c3b-52b5-e540-580d">
+                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="45bb-cf26-6834-6011">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4434,9 +3619,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="a9b2-dcd7-3965-65df">
+                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="bd7c-7bcc-0e98-cd5a">
                   <profiles>
-                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4541-54df-5161-fb7e">
+                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="58e3-2d96-311a-1b60">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4444,7 +3629,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                         <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
                       </characteristics>
                     </profile>
-                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="750b-54d6-4d43-e66b">
+                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5810-afc3-1143-ea86">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4454,9 +3639,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="5a86-e53e-a33e-013c">
+                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="a98b-dc1d-ec1d-d6b2">
                   <profiles>
-                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4ace-41cd-7653-9c6d">
+                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="15ae-0d09-eeb1-a76b">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4464,7 +3649,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                         <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
                       </characteristics>
                     </profile>
-                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8e09-29c2-befa-8a3b">
+                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c6a8-f6f1-a18e-b156">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4474,9 +3659,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="6188-c1ff-fddf-1aa8">
+                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="5447-acc2-810f-00d7">
                   <profiles>
-                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="aeda-aa5c-be18-3088">
+                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="224b-a69d-b50f-93b4">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4488,24 +3673,636 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                 </selectionEntry>
               </selectionEntries>
               <constraints>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="a461-8555-77f9-ef4e" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cfd2-17b0-5b38-8255" includeChildSelections="false"/>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="5d73-a4b5-fa00-c716" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f79b-df96-55d6-3f9e" includeChildSelections="false"/>
               </constraints>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Weapon / Trait" id="fe9c-74dc-4143-dd04" hidden="false">
+              <constraints>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="c06c-d802-b62f-182c" includeChildSelections="false"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="9b74-16b4-91db-2920">
+                  <profiles>
+                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ec27-bed9-e2da-b211">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fa5e-081e-e374-f98e" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="fceb-0785-2078-40df">
+                  <profiles>
+                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5128-6aa1-4c93-83b5">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4d0a-e1aa-460d-524c" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="6e12-f5b0-7978-ff7a">
+                  <profiles>
+                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5f3e-0cf6-e0a0-bd1e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1f32-d173-bdcb-8867" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="117c-2c6d-3edd-1348">
+                  <profiles>
+                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5050-4f32-9684-80ff">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3416-0309-3513-9187" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="744b-b572-df4f-572d">
+                  <profiles>
+                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1f82-54cc-1298-cb0e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bdb2-d5bb-c2e9-ee85" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="b5ee-96cd-be9f-e7b1">
+                  <profiles>
+                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="80b5-9487-6c9d-416e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3558-99e1-c5ce-29ac" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="90a7-8faf-319d-03e4">
+                  <profiles>
+                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4f84-04e0-c76b-9dea">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0b80-dafb-a59a-2a1c" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="109f-afe1-3003-83f7">
+                  <profiles>
+                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e004-22e9-7fb2-d55c">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6fbe-9ca8-f2c7-ce70" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="3c39-f8c7-4d6d-31f8">
+                  <profiles>
+                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b863-a454-23a4-c688">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a000-2e9f-d939-c9bb" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="2386-2f14-3f7d-234d">
+                  <profiles>
+                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8acf-2e55-584a-ac63">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fa35-82d3-2600-b4e1" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="9142-23e4-f6fe-5e23">
+                  <profiles>
+                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d8d6-5f41-32db-1d61">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5478-4e1f-b3cb-d270" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="c657-5567-8c06-ad9a">
+                  <profiles>
+                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ffdd-74e8-92ea-ca9e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d57e-1fc2-1e63-9b6f" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="de96-8593-da1a-420c">
+                  <profiles>
+                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="addc-7bf2-6dad-6a77">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0c52-cc6b-57d0-effe">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5152-d7ca-3564-29dd" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="a240-c261-b336-9a91">
+                  <profiles>
+                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4230-d2c8-ee0d-efee">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f49a-f1eb-e4f6-efe9" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="82c3-3a17-6e3a-a704">
+                  <profiles>
+                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="461f-625f-19ee-ec94">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="48b7-9607-f3d2-54c0" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="6a48-ee75-9db5-0757">
+                  <profiles>
+                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3c81-0225-b6af-c409">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3941-1858-2886-b6c2">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1350-a6c6-6a42-39dd" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="8fae-8256-4d85-6cea">
+                  <profiles>
+                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="30b4-7710-83e9-0ff9">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="93b8-6e51-9cef-fd07" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="a3d8-1a06-4db1-44d9">
+                  <profiles>
+                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c3ad-f14d-7918-d55e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b675-266f-0fb7-22ff" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="21bd-672a-f5db-486f">
+                  <profiles>
+                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b894-2558-2972-e8a9">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="27a5-4fe8-178a-ef42" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="6cba-764f-db8e-bdd3">
+                  <profiles>
+                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4e8c-b122-724c-31fc">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c39d-aff0-f9b8-b703" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="e32e-54c0-263b-08e4">
+                  <profiles>
+                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a0ad-c317-1980-1c6d">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1f44-6cb5-ed5b-9aa1" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="8ad0-0f6e-e30d-7ba8">
+                  <profiles>
+                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="143f-870d-4217-462a">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="93ce-842e-4ec8-0d39" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="e9fa-eba2-e69c-7df1">
+                  <profiles>
+                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fbff-f2ef-62c6-8b60">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3f02-c8a5-0bf3-822b" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="a262-f1d6-d4d5-5a3d">
+                  <profiles>
+                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5672-7292-63f3-b170">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="84d1-2d03-85d8-a79c" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="05d0-791f-a4f5-dd7c">
+                  <profiles>
+                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="669a-16a4-310d-760f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8d33-7872-1399-c970" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="b097-5d3b-2df9-8257">
+                  <profiles>
+                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c9d6-1bb6-6a8e-3008">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="69b0-0596-e809-b73f" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="5bb6-6865-f532-e747">
+                  <profiles>
+                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="eaa5-0849-c7f7-d7f0">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="eb07-81d3-5e58-60d2" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="ebc6-8dfa-ef65-a757">
+                  <profiles>
+                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3d70-aa1d-c1d0-e606">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2746-6f22-7e0b-d2db" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup name="Bonus Trait" id="e6de-a621-cdf0-b186" hidden="false">
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="97c4-7c67-d814-64b6">
+                      <profiles>
+                        <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b137-6be3-520e-1b9b">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8896-848c-60f4-d631" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="91bc-ffe7-b804-d4e9">
+                      <profiles>
+                        <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e236-f564-be9f-2e39">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1733-45d4-9d99-2457" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="764c-fb96-ca22-9f9f">
+                      <profiles>
+                        <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="af58-00a5-74e5-2455">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f0eb-71f1-a5ed-aae3" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="26c3-d4f8-491d-c85d">
+                      <profiles>
+                        <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="03d4-495e-ade4-f0cd">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="143b-a75f-d94a-6d05" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="4c0e-76fb-69f7-308d">
+                      <profiles>
+                        <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6e95-0a26-7134-3888">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7422-15d4-5bc4-4ea6" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="a13f-a6ef-7dbb-ec46">
+                      <profiles>
+                        <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4930-0519-41a0-c061">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b976-a79d-60ae-2c6e" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="4d6f-00e5-b68b-1723">
+                      <profiles>
+                        <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ce39-cdb7-9933-a420">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0004-ee6d-301e-30f3" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="2587-5e83-eac4-e59f">
+                      <profiles>
+                        <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3369-1c07-93c1-85ea">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2c2d-28e9-27f3-9cc8" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="a68d-6a99-da55-cf9e">
+                      <profiles>
+                        <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ece0-bef9-64d4-73dc">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="51b5-0e21-58ad-f09f" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="d096-395d-5214-34ac">
+                      <profiles>
+                        <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e386-424e-8894-18d4">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1321-b9e5-ae8f-3402" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="3e78-ba9a-15ec-d50f">
+                      <profiles>
+                        <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="18ce-1231-9f8d-01a7">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="76f1-6a6a-3fff-292e" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="ad30-2b6c-d617-ed8d">
+                      <profiles>
+                        <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d6d2-4415-cef3-02a6">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="92ef-dd42-2aee-9c51" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="dd81-68d3-082e-e9bd">
+                      <profiles>
+                        <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="9558-7324-70c4-9acd">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b506-0c39-15f5-b4db" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8657-9050-7959-8b37" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6701-2062-c33f-4446" includeChildSelections="false"/>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="b0dc-100f-e989-b888" includeChildSelections="false"/>
+            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="3226-a580-09f4-7cd6" includeChildSelections="false"/>
           </constraints>
+          <modifiers>
+            <modifier type="decrement" value="1" field="3226-a580-09f4-7cd6">
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="parent" childId="236b-9017-8966-ba98" shared="true" includeChildSelections="false" childName="Heavy Weapon (count as 2)"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntryGroup>
-        <selectionEntryGroup name="Close combat weapon" id="77d1-5218-ebe6-cc26" hidden="false">
+        <selectionEntryGroup name="Close combat weapon" id="ed9e-6f01-e340-a2af" hidden="false" sortIndex="4">
           <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a778-6d52-fbdf-8082" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f28e-46b4-9f6f-e62a" includeChildSelections="false"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="da02-cd96-035d-d0fa">
+            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="8159-b139-18a0-5db6">
               <profiles>
-                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3bdc-1bdc-ca56-bbcd">
+                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="19ce-1385-f627-28bc">
                   <characteristics>
                     <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
                     <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
@@ -4553,6 +4350,117 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
       <categoryLinks>
         <categoryLink targetId="cf83-4496-b58e-ac82" id="12ad-8024-f54d-4bb9" primary="true" name="Operative"/>
       </categoryLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="XV26 Stealth battlesuit (Pts 3)" hidden="false" id="ed70-9e25-d0b9-841a">
+      <categoryLinks>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="df50-4bc9-fb4f-f1c2" primary="true" name="Operative"/>
+      </categoryLinks>
+      <profiles>
+        <profile name="XV26 Stealth battlesuit (Pts 3)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="b3e1-5fcd-d6b6-0708">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">3</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">3+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">12</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Stealth Field" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="78a2-ef89-aa3c-2ee8">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this NPO has a Conceal order, it&apos;s not visible to enemy operatives more than 3&quot; from it (this takes precedence over all other rules)</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Weapon Options" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="930d-8ba3-4918-285c">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This NPO has a burst cannon and fists. 1 in 3 can have a fusion blaster instead of a burst cannon.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink name="Marksman" id="38f7-ffee-46d0-8a83" hidden="false" type="profile" targetId="a6db-a06f-71ee-1feb"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Fists" hidden="false" id="3b25-9e44-2b98-c896">
+          <profiles>
+            <profile name="⚔ Fists" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4282-3fb7-e48a-05aa">
+              <characteristics>
+                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
+                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="66d0-ac7a-b6f6-02a2" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fed4-0045-8c78-1607" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Weapon" id="1b45-3eea-4895-217f" hidden="false">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Burst cannon" hidden="false" id="40f8-98e5-b5d5-f330">
+              <profiles>
+                <profile name="⌖ Burst cannon (sweeping)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cc46-5099-0aaf-2b83">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless, Torrent 1&quot;</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="⌖ Burst cannon (focused)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="db3a-d843-1030-335b">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink name="Ceaseless" id="f227-1dd6-8cfd-047e" hidden="false" type="rule" targetId="752d-ce38-c325-4b8a"/>
+                <infoLink name="Torrent x" id="2281-db8a-3e19-6fd1" hidden="false" type="rule" targetId="ad45-b4bb-1345-e4f9"/>
+              </infoLinks>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="746e-7987-498f-9686" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Fusion blaster" hidden="false" id="ab90-d42c-2877-02bc">
+              <profiles>
+                <profile name="⌖ Fusion blaster (long range)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1cee-c38a-e1f3-21fe">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 12&quot;, Piercing 1</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="⌖ Fusion blaster (short range)" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2d32-c129-a965-32dc">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink name="Piercing x" id="da79-3874-b199-efde" hidden="false" type="rule" targetId="4c07-2cb3-1417-cbb7"/>
+                <infoLink name="Range x" id="3b85-8892-0571-dc32" hidden="false" type="rule" targetId="a528-829e-8268-c005"/>
+                <infoLink name="Devastating x" id="8892-78ac-3610-1bc3" hidden="false" type="rule" targetId="a8ba-6e3a-76b3-f05c"/>
+              </infoLinks>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5048-2aca-2b80-35a0" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="43f5-e4f4-2367-5981" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c068-088a-e4bb-2638" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
   </selectionEntries>
   <sharedProfiles>

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -2932,12 +2932,123 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
         </selectionEntryGroup>
         <selectionEntryGroup name="Weapons" id="0a87-cdd2-28bc-46e8" hidden="false">
           <selectionEntryGroups>
-            <selectionEntryGroup name="Weapons / Trait x2" id="a236-9349-e947-20b6" hidden="false">
-              <constraints>
-                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="4e2b-7dd3-c923-b8ae" includeChildSelections="false"/>
-              </constraints>
+            <selectionEntryGroup name="Weapon x1" id="5033-4bea-1edc-3fa2" hidden="false">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="1d1d-a3d2-7451-d9a9" sortIndex="2">
+                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="6eaf-73b8-8fc8-f469">
+                  <profiles>
+                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="82e7-9cea-1518-fc5b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="1e9e-5f24-8e0e-c408">
+                  <profiles>
+                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="01c7-cda6-beb1-360f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="3e66-f94d-d1e2-dbb7">
+                  <profiles>
+                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ea10-3061-ff6c-b49f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="5a9c-c997-3483-7f84">
+                  <profiles>
+                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5fa7-785e-c09b-5688">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="af99-4f07-bfcb-0487">
+                  <profiles>
+                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3ed6-e459-011f-1457">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cb05-8bbb-8a61-0f0f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="4991-3d4b-f11e-e8dd">
+                  <profiles>
+                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4ff2-a736-951e-f528">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5c24-da57-cd58-bb47">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="79dd-a55a-21b2-c021">
+                  <profiles>
+                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1ae6-7b63-1ef5-7059">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <constraints>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="b0ac-bef8-a801-e373" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ed69-c7e4-a30d-603f" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a02c-8b4d-df93-4bbf" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c21c-c716-a3b8-0bc3" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Weapon / Trait x2" hidden="false" id="7c8e-e08a-5741-f9cb">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="1d1d-a3d2-7451-d9a9">
                   <profiles>
                     <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d6d8-126a-8cd6-ae3f">
                       <characteristics>
@@ -2952,7 +3063,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1430-8a0f-bdb9-9e87" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="e5fe-32e9-0b88-bb00" sortIndex="4">
+                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="e5fe-32e9-0b88-bb00">
                   <profiles>
                     <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4706-ee37-bf81-5ddd">
                       <characteristics>
@@ -2967,7 +3078,52 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="542a-007f-4867-36de" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="536c-bd24-a3e1-4bee" sortIndex="12">
+                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="3a7d-2904-5c60-065e">
+                  <profiles>
+                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b8f2-063c-2bf0-6046">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="40e6-1666-8c4d-2a15" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="0ea6-616a-0c5c-8cbd">
+                  <profiles>
+                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fc4b-63f0-cf4b-b208">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a80c-62e8-4b8a-45f8" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="c1dc-de3e-28ce-84cb">
+                  <profiles>
+                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0008-143b-8ab6-4ddb">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6245-bedd-beec-e499" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="536c-bd24-a3e1-4bee">
                   <profiles>
                     <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="196f-c756-a830-1992">
                       <characteristics>
@@ -2982,22 +3138,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d431-955f-ba04-5578" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="e6a4-3b56-c40d-814d" sortIndex="14">
-                  <profiles>
-                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b91d-2b6c-0d57-e1ba">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0ff2-6f30-4959-a539" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="d6ca-ba1c-9281-576c" sortIndex="13">
+                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="d6ca-ba1c-9281-576c">
                   <profiles>
                     <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ba4e-bf28-59e7-a770">
                       <characteristics>
@@ -3012,7 +3153,22 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0e41-2583-9920-1a3b" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="fc87-5b29-a721-6012" sortIndex="15">
+                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="e6a4-3b56-c40d-814d">
+                  <profiles>
+                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b91d-2b6c-0d57-e1ba">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0ff2-6f30-4959-a539" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="fc87-5b29-a721-6012">
                   <profiles>
                     <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8eb6-00ac-2fa0-7164">
                       <characteristics>
@@ -3027,7 +3183,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dba7-b3d2-4e2e-9afa" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="ef5e-3779-77d0-0f01" sortIndex="16">
+                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="ef5e-3779-77d0-0f01">
                   <profiles>
                     <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ff68-01af-8db2-971f">
                       <characteristics>
@@ -3042,7 +3198,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="11e7-cddf-98a8-8057" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="6a12-3114-a92b-09d5" sortIndex="18">
+                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="6a12-3114-a92b-09d5">
                   <profiles>
                     <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e52e-3391-f328-3e2b">
                       <characteristics>
@@ -3057,22 +3213,22 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="adb4-1bec-a712-901a" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="3246-3456-e551-0234" sortIndex="37">
+                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="2e29-1aaa-0621-9547">
                   <profiles>
-                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0a5a-9220-dc26-3e42">
+                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="790f-a588-3ea1-f1c5">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="74b1-4b42-ba7f-3c0d" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e503-62c9-df4f-453a" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="a67d-ba56-e75f-7d66" sortIndex="20">
+                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="a67d-ba56-e75f-7d66">
                   <profiles>
                     <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1434-6ab4-6192-84cd">
                       <characteristics>
@@ -3095,7 +3251,37 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="649e-59db-8134-9eeb" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="c279-d485-0536-4775" sortIndex="23">
+                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="61f3-951f-1260-5422">
+                  <profiles>
+                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7eb8-77af-f06e-7b28">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a405-e588-7de3-bb86" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="bfcc-b53a-c527-1874">
+                  <profiles>
+                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d6ef-9144-e99e-8d85">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="15eb-0047-10c0-b90a" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="c279-d485-0536-4775">
                   <profiles>
                     <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="660c-729f-580a-b0a9">
                       <characteristics>
@@ -3118,187 +3304,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0fca-79c6-57cd-deba" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="61f3-951f-1260-5422" sortIndex="21">
-                  <profiles>
-                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7eb8-77af-f06e-7b28">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a405-e588-7de3-bb86" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="2e29-1aaa-0621-9547" sortIndex="19">
-                  <profiles>
-                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="790f-a588-3ea1-f1c5">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e503-62c9-df4f-453a" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="fcdc-1c64-701c-7291" sortIndex="28">
-                  <profiles>
-                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="558f-69c3-8ae0-9f11">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2eee-b26d-858c-db2a" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="a6f5-9601-cdd8-d870" sortIndex="32">
-                  <profiles>
-                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="252f-84cc-9f5c-0663">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9903-337e-f4b0-7f6d" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="d035-b830-3c31-c838" sortIndex="33">
-                  <profiles>
-                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f8f7-424f-4408-866d">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5c08-0875-865b-f886" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="4db2-6f54-5896-f237" sortIndex="34">
-                  <profiles>
-                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b512-b4b0-d412-262a">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="269c-ea69-fdd5-73ed" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="1572-8a93-7804-56c6" sortIndex="35">
-                  <profiles>
-                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="23c3-84fc-b9fe-1bd4">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="43da-a871-5c90-ce48" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="9c76-2061-5cb7-96e2" sortIndex="39">
-                  <profiles>
-                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="10e5-ea4c-e71d-cc82">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="be56-3f27-9a67-f0d6" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="3a7d-2904-5c60-065e" sortIndex="5">
-                  <profiles>
-                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b8f2-063c-2bf0-6046">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="40e6-1666-8c4d-2a15" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="0ea6-616a-0c5c-8cbd" sortIndex="8">
-                  <profiles>
-                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fc4b-63f0-cf4b-b208">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a80c-62e8-4b8a-45f8" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="c1dc-de3e-28ce-84cb" sortIndex="9">
-                  <profiles>
-                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0008-143b-8ab6-4ddb">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6245-bedd-beec-e499" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="bfcc-b53a-c527-1874" sortIndex="22">
-                  <profiles>
-                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d6ef-9144-e99e-8d85">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="15eb-0047-10c0-b90a" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="8e08-158d-63f5-84f0" sortIndex="24">
+                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="8e08-158d-63f5-84f0">
                   <profiles>
                     <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c553-c2f1-8fb5-c4ca">
                       <characteristics>
@@ -3313,7 +3319,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="caa1-378a-ad4f-2a0f" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="c5ee-6268-35dc-7e28" sortIndex="25">
+                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="c5ee-6268-35dc-7e28">
                   <profiles>
                     <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5784-fda9-143c-d362">
                       <characteristics>
@@ -3328,7 +3334,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e2da-18cc-74a8-96e5" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="2121-30aa-877d-014e" sortIndex="26">
+                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="2121-30aa-877d-014e">
                   <profiles>
                     <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b417-b776-01c5-c9d1">
                       <characteristics>
@@ -3343,7 +3349,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4e39-9c9f-2084-4cbb" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="ff41-fcb6-5d3c-acbc" sortIndex="27">
+                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="ff41-fcb6-5d3c-acbc">
                   <profiles>
                     <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="50b0-8aaf-7169-c288">
                       <characteristics>
@@ -3358,7 +3364,22 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ace5-e995-fdfd-6e5d" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="5146-e069-b3fc-fa21" sortIndex="29">
+                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="fcdc-1c64-701c-7291">
+                  <profiles>
+                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="558f-69c3-8ae0-9f11">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2eee-b26d-858c-db2a" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="5146-e069-b3fc-fa21">
                   <profiles>
                     <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c8d4-e3f6-5318-f3e8">
                       <characteristics>
@@ -3373,16 +3394,94 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dabe-027c-2b39-6e1e" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="0a35-973b-5a4d-ef64">
+                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="a6f5-9601-cdd8-d870">
                   <profiles>
-                    <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="308c-447c-e229-6d3d">
+                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="252f-84cc-9f5c-0663">
                       <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f01-3ab7-dc10-51e1" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9903-337e-f4b0-7f6d" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="d035-b830-3c31-c838">
+                  <profiles>
+                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f8f7-424f-4408-866d">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5c08-0875-865b-f886" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="4db2-6f54-5896-f237">
+                  <profiles>
+                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b512-b4b0-d412-262a">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="269c-ea69-fdd5-73ed" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="1572-8a93-7804-56c6">
+                  <profiles>
+                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="23c3-84fc-b9fe-1bd4">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="43da-a871-5c90-ce48" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="3246-3456-e551-0234">
+                  <profiles>
+                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0a5a-9220-dc26-3e42">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="74b1-4b42-ba7f-3c0d" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="9c76-2061-5cb7-96e2">
+                  <profiles>
+                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="10e5-ea4c-e71d-cc82">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="be56-3f27-9a67-f0d6" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="0de9-2e06-f34c-7f0e">
@@ -3528,121 +3627,24 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="56b4-619d-8709-f13a" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntry>
-              </selectionEntries>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="Weapon x1" id="5033-4bea-1edc-3fa2" hidden="false">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="6eaf-73b8-8fc8-f469">
+                <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="0a35-973b-5a4d-ef64">
                   <profiles>
-                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="82e7-9cea-1518-fc5b">
+                    <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="308c-447c-e229-6d3d">
                       <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="1e9e-5f24-8e0e-c408">
-                  <profiles>
-                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="01c7-cda6-beb1-360f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="3e66-f94d-d1e2-dbb7">
-                  <profiles>
-                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ea10-3061-ff6c-b49f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="5a9c-c997-3483-7f84">
-                  <profiles>
-                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5fa7-785e-c09b-5688">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="af99-4f07-bfcb-0487">
-                  <profiles>
-                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3ed6-e459-011f-1457">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cb05-8bbb-8a61-0f0f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="4991-3d4b-f11e-e8dd">
-                  <profiles>
-                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4ff2-a736-951e-f528">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5c24-da57-cd58-bb47">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="79dd-a55a-21b2-c021">
-                  <profiles>
-                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1ae6-7b63-1ef5-7059">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f01-3ab7-dc10-51e1" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
               </selectionEntries>
               <constraints>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="b0ac-bef8-a801-e373" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ed69-c7e4-a30d-603f" includeChildSelections="false"/>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="4e2b-7dd3-c923-b8ae" includeChildSelections="false"/>
               </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a02c-8b4d-df93-4bbf" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c21c-c716-a3b8-0bc3" includeChildSelections="false"/>
-          </constraints>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup name="Close combat weapon" id="b1d8-4876-bde6-b0a4" hidden="false">
           <constraints>

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -109,7 +109,7 @@
             <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">2</characteristic>
             <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
             <characteristic name="Save" typeId="3241-5548-12d6-f103">5+</characteristic>
-            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">7</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">67</characteristic>
           </characteristics>
         </profile>
       </profiles>

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -1760,7 +1760,7 @@
             </selectionEntryGroup>
             <selectionEntryGroup name="Weapon / Trait" id="555d-ba02-79d1-883e" hidden="false">
               <constraints>
-                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="4fcf-9f88-4532-9d5f" includeChildSelections="false"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="4fcf-9f88-4532-9d5f" includeChildSelections="false"/>
               </constraints>
               <selectionEntries>
                 <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="5d33-e3ef-7c85-6971">
@@ -1770,7 +1770,7 @@
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
                         <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
@@ -2736,7 +2736,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
                         <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
@@ -3721,7 +3721,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
                         <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">-</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -3642,6 +3642,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
               </selectionEntries>
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="4e2b-7dd3-c923-b8ae" includeChildSelections="false"/>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="5799-6327-6bb3-38be" includeChildSelections="false"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -1396,138 +1396,215 @@
         </profile>
       </profiles>
     </selectionEntry>
-    <selectionEntry type="model" import="true" name="Nemesis (S)" hidden="false" id="d19e-756d-b1ce-e474">
+    <selectionEntry type="model" import="true" name="Nemesis (L)" hidden="false" id="d19e-756d-b1ce-e474">
       <selectionEntryGroups>
         <selectionEntryGroup name="Allegiance Trait" id="8987-3f7b-1772-4233" hidden="false">
-          <profiles>
-            <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="648d-5a6a-a1a1-1c14">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6ee7-d969-ea32-490d">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c635-7dc5-7b3f-743f">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ec34-7b1e-c621-2af4">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8928-c83e-b378-7384">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2664-7a1f-c901-4d0e">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5be5-efd8-e934-4723">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="586a-a460-3121-2f3d">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bdb9-e93f-b644-ccba" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f6c-4613-7603-fd45" includeChildSelections="false"/>
           </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Leagues of Vontann: Acquisition at all costs" hidden="false" id="94ef-2a37-c14d-6f5c">
+              <profiles>
+                <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ec34-7b1e-c621-2af4">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Chaos: Let the galaxy burn" hidden="false" id="ff89-dc6b-e2c7-ecb8">
+              <profiles>
+                <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8928-c83e-b378-7384">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Aeldari: Arrogant Superiority" hidden="false" id="08df-d27b-4b31-6167">
+              <profiles>
+                <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="648d-5a6a-a1a1-1c14">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Imperium: Defenders of the Imperium" hidden="false" id="08b8-2096-3125-ffde">
+              <profiles>
+                <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="586a-a460-3121-2f3d">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Ork: WAAAGH!" hidden="false" id="e037-2d4b-cc16-5297">
+              <profiles>
+                <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c635-7dc5-7b3f-743f">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Necron: Living Metal" hidden="false" id="6fe8-8c54-081c-0e90">
+              <profiles>
+                <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5be5-efd8-e934-4723">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="T&apos;au: Supporting Fire" hidden="false" id="9a95-d628-68fc-5826">
+              <profiles>
+                <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2664-7a1f-c901-4d0e">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tyranid: Will of the hive mind" hidden="false" id="936b-b437-00e1-7168">
+              <profiles>
+                <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6ee7-d969-ea32-490d">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup name="Nemesis Trait" id="ca26-013f-2758-775c" hidden="false">
-          <profiles>
-            <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c439-9e65-8f61-88f8">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b981-b25b-b4a1-7481">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="92aa-6d81-73ce-93b1">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f41c-1291-a5ff-2426">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="dfe3-87b5-8edf-f629">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b343-4b47-73c0-f171">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1dfe-eb50-8534-2ab5">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a0ea-33e6-c114-5da5">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c284-90f2-fa12-7796">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b047-76ff-d45c-cc0d">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c62b-45af-79d2-3234">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2da1-97d1-2372-544d">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6c6f-118b-b1f6-17d7">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a3d2-3f00-0807-c949" includeChildSelections="false"/>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2f25-ae57-e508-3a09" includeChildSelections="false"/>
           </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="add1-07a1-5b5c-14a8"/>
+            <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="d109-2341-fdf6-d6a7">
+              <profiles>
+                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a0ea-33e6-c114-5da5">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="78a1-e1c9-eec2-ce6f">
+              <profiles>
+                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b981-b25b-b4a1-7481">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="2773-eb8c-6360-4ffd">
+              <profiles>
+                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b047-76ff-d45c-cc0d">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="cd5f-7560-3551-4ab5">
+              <profiles>
+                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="dfe3-87b5-8edf-f629">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="0a6a-5e34-f53c-adc9">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="21a4-6cd0-1cc9-cef6">
+                  <profiles>
+                    <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c284-90f2-fa12-7796">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <profiles>
+                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="92aa-6d81-73ce-93b1">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="ff8e-8dfa-63e7-433b">
+              <profiles>
+                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f41c-1291-a5ff-2426">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="565e-9e58-52fe-d394">
+              <profiles>
+                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c62b-45af-79d2-3234">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="d0fc-f47e-a184-f97b">
+              <profiles>
+                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2da1-97d1-2372-544d">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="3f45-d276-16c9-26ba">
+              <profiles>
+                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b343-4b47-73c0-f171">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="a965-1826-618a-bccd">
+              <profiles>
+                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6c6f-118b-b1f6-17d7">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="9132-c6c0-a947-77d7">
+              <profiles>
+                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1dfe-eb50-8534-2ab5">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup name="Weapons" id="3f35-4ad4-8112-2bf6" hidden="false">
           <selectionEntryGroups>
-            <selectionEntryGroup name="Weapons / Trait x2" id="3782-f40c-3b8c-7912" hidden="false">
+            <selectionEntryGroup name="3 Choices" id="3782-f40c-3b8c-7912" hidden="false">
               <constraints>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="a8b4-6323-14d4-5dbb" includeChildSelections="false"/>
-                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="c6a0-1826-bfd0-4978" includeChildSelections="false"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="c6a0-1826-bfd0-4978" includeChildSelections="false"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="51cd-7dde-9593-458d">
+                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="51cd-7dde-9593-458d" sortIndex="2">
                   <profiles>
                     <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3a15-e8d8-ecbf-3f88">
                       <characteristics>
@@ -1539,7 +1616,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="a6b5-15bd-6e18-a16c">
+                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="a6b5-15bd-6e18-a16c" sortIndex="4">
                   <profiles>
                     <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fe89-81b2-c524-72ae">
                       <characteristics>
@@ -1551,7 +1628,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="8179-fb7f-da28-bd3d">
+                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="8179-fb7f-da28-bd3d" sortIndex="12">
                   <profiles>
                     <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0859-fe1b-9f30-16ce">
                       <characteristics>
@@ -1563,7 +1640,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="e94d-eacd-b5a4-3de5">
+                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="e94d-eacd-b5a4-3de5" sortIndex="14">
                   <profiles>
                     <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d8ee-4242-8a44-b2db">
                       <characteristics>
@@ -1575,7 +1652,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="4b3f-34b5-2141-0506">
+                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="4b3f-34b5-2141-0506" sortIndex="13">
                   <profiles>
                     <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="15e7-9ab9-3185-b1d5">
                       <characteristics>
@@ -1587,7 +1664,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="bd79-5a4d-25f6-dc32">
+                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="bd79-5a4d-25f6-dc32" sortIndex="15">
                   <profiles>
                     <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9f66-6563-c823-8dc3">
                       <characteristics>
@@ -1599,7 +1676,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="2116-851b-acae-3dea">
+                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="2116-851b-acae-3dea" sortIndex="16">
                   <profiles>
                     <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c3bb-46e6-d592-68d0">
                       <characteristics>
@@ -1611,7 +1688,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="ec9d-47ac-3d9d-f58c">
+                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="ec9d-47ac-3d9d-f58c" sortIndex="18">
                   <profiles>
                     <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8b32-0d3b-521d-8c09">
                       <characteristics>
@@ -1623,7 +1700,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="49aa-6bdd-53c0-d8ec">
+                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="49aa-6bdd-53c0-d8ec" sortIndex="37">
                   <profiles>
                     <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="637b-6bdb-a219-1a9c">
                       <characteristics>
@@ -1635,7 +1712,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="7cf8-9abe-1d98-806a">
+                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="7cf8-9abe-1d98-806a" sortIndex="20">
                   <profiles>
                     <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="457f-c62b-e6f0-ce67">
                       <characteristics>
@@ -1655,7 +1732,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="b4d2-9ef9-e5d5-db29">
+                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="b4d2-9ef9-e5d5-db29" sortIndex="23">
                   <profiles>
                     <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fffb-f08e-99cc-9a7f">
                       <characteristics>
@@ -1675,7 +1752,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="a582-60fe-9009-b17f">
+                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="a582-60fe-9009-b17f" sortIndex="21">
                   <profiles>
                     <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="371f-2d38-bbc4-3cdf">
                       <characteristics>
@@ -1687,7 +1764,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="acb7-1d59-86d7-e8ec">
+                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="acb7-1d59-86d7-e8ec" sortIndex="19">
                   <profiles>
                     <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1e11-7167-1783-79e3">
                       <characteristics>
@@ -1699,7 +1776,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="63fd-3a3d-6575-eef1">
+                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="63fd-3a3d-6575-eef1" sortIndex="28">
                   <profiles>
                     <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c622-0a87-aa20-5ef7">
                       <characteristics>
@@ -1711,7 +1788,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="eddf-1d22-6faa-64a7">
+                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="eddf-1d22-6faa-64a7" sortIndex="32">
                   <profiles>
                     <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3855-798e-49da-2ebc">
                       <characteristics>
@@ -1723,7 +1800,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="4fcb-52e8-07a3-9904">
+                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="4fcb-52e8-07a3-9904" sortIndex="33">
                   <profiles>
                     <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="83bf-109d-3f9e-a875">
                       <characteristics>
@@ -1735,7 +1812,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="2213-e28e-0a03-78a5">
+                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="2213-e28e-0a03-78a5" sortIndex="34">
                   <profiles>
                     <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5841-60fe-6fbd-6f79">
                       <characteristics>
@@ -1747,7 +1824,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="9ecc-ca30-80e1-50e1">
+                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="9ecc-ca30-80e1-50e1" sortIndex="35">
                   <profiles>
                     <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e506-01f0-5186-9d4b">
                       <characteristics>
@@ -1759,7 +1836,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="8de4-f7e7-2349-72f0">
+                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="8de4-f7e7-2349-72f0" sortIndex="39">
                   <profiles>
                     <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cc1b-4a16-c47d-1379">
                       <characteristics>
@@ -1771,7 +1848,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="b082-e17b-ae4b-a4c2">
+                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="b082-e17b-ae4b-a4c2" sortIndex="5">
                   <profiles>
                     <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5bb9-84ae-e06d-a613">
                       <characteristics>
@@ -1783,7 +1860,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="bac4-b9d0-5420-ae0a">
+                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="bac4-b9d0-5420-ae0a" sortIndex="8">
                   <profiles>
                     <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0c9a-7c3e-ccd6-6b99">
                       <characteristics>
@@ -1795,7 +1872,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="1e80-be8e-8252-7bff">
+                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="1e80-be8e-8252-7bff" sortIndex="9">
                   <profiles>
                     <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="977c-f63f-48ba-d4e5">
                       <characteristics>
@@ -1807,7 +1884,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="f47c-77ca-b5e2-afb5">
+                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="f47c-77ca-b5e2-afb5" sortIndex="22">
                   <profiles>
                     <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e895-cd17-a0fd-e911">
                       <characteristics>
@@ -1819,7 +1896,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="3d0e-b4c1-ccae-1416">
+                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="3d0e-b4c1-ccae-1416" sortIndex="24">
                   <profiles>
                     <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1695-16f5-2e1d-98ce">
                       <characteristics>
@@ -1831,7 +1908,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="da09-5083-d75a-ade0">
+                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="da09-5083-d75a-ade0" sortIndex="25">
                   <profiles>
                     <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="adee-9217-e850-56d5">
                       <characteristics>
@@ -1843,7 +1920,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="8276-b301-d183-1a9f">
+                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="8276-b301-d183-1a9f" sortIndex="26">
                   <profiles>
                     <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f0d0-755a-8167-bf90">
                       <characteristics>
@@ -1855,7 +1932,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="2f61-9931-dd3e-bcb0">
+                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="2f61-9931-dd3e-bcb0" sortIndex="27">
                   <profiles>
                     <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bac2-c943-d1f4-11db">
                       <characteristics>
@@ -1867,7 +1944,7 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="f940-6694-02d7-f1f9">
+                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="f940-6694-02d7-f1f9" sortIndex="29">
                   <profiles>
                     <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0879-476e-fc0b-c6fa">
                       <characteristics>
@@ -1879,182 +1956,716 @@
                     </profile>
                   </profiles>
                 </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="db35-9889-d6b1-4a6e">
+                  <profiles>
+                    <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c439-9e65-8f61-88f8">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="31bb-c597-de90-3e0b">
+                  <profiles>
+                    <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3b2a-5ac7-1842-3500">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="11a2-0739-5a89-3468">
+                  <profiles>
+                    <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="650c-b8ce-dfc0-011d">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="35ff-b9af-b8f1-4d2c">
+                  <profiles>
+                    <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5636-b0d5-8410-58f5">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="d30e-787b-10fa-72e0">
+                  <profiles>
+                    <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b257-2fdf-3b8f-f686">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="6c23-a97d-31f0-5aa7">
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="6f8d-21c4-24ab-ee33">
+                      <profiles>
+                        <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ad38-f47d-1be6-566a">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <profiles>
+                    <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0b91-3da2-6679-c48d">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="530c-e607-4827-462f">
+                  <profiles>
+                    <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="56a6-e28d-3214-f90e">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="06c3-bcba-9af5-4423">
+                  <profiles>
+                    <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b1c0-cb02-2836-67a4">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="4edc-cd33-6459-3f70">
+                  <profiles>
+                    <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b6ed-0a17-6553-1d1b">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="afca-bfa9-33c2-aaa9">
+                  <profiles>
+                    <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a0bc-b5fa-fcb1-c0fb">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="4847-c056-3fa2-7781">
+                  <profiles>
+                    <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2a1a-4420-2ce1-c002">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="63bc-9dc7-fb4a-9cb2">
+                  <profiles>
+                    <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="edcc-149d-fa78-217a">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
               </selectionEntries>
-              <profiles>
-                <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3ce4-0b97-8020-4579">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="525a-508f-d4b5-f82e">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1617-ec77-4b48-efb9">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="12a0-e13d-11ec-25bc">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4d14-7636-4c2f-3c0d">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2323-a02b-0577-6d10">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1c8e-7ff2-cc64-8b85">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3326-12f4-42bb-6205">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2496-2a00-5f4b-e7ed">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2ac9-fc6d-8f3e-4032">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2f07-ee0e-ca17-7d39">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="cdef-556f-b625-7ae7">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e1ce-a3e8-02cf-b7bf">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
             </selectionEntryGroup>
-            <selectionEntryGroup name="Weapon x1" id="ddcc-612d-8e31-bbc1" hidden="false">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="928d-4aa8-8dc3-0b9f">
-                  <profiles>
-                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2155-8760-f817-7be8">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="6ca3-be48-3535-e3f5">
-                  <profiles>
-                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b0da-aa8d-27d7-3b1f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="d23d-4c77-20ae-ea20">
-                  <profiles>
-                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e000-d507-db21-f91a">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="58a0-020c-138c-90d4">
-                  <profiles>
-                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0fa0-6ae5-65d7-6b7d">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="1026-e8a1-4179-7194">
-                  <profiles>
-                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5c8a-d8fe-51f4-4812">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8796-e3c8-f29c-ee96">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="fd87-3c6c-b9de-c147">
-                  <profiles>
-                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="eea5-ca71-7602-b84e">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2e93-af17-75a4-9d39">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="2a0d-c6c9-ec36-59cb">
-                  <profiles>
-                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7540-1044-2337-fd3f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-              </selectionEntries>
-              <constraints>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="c113-52d7-d3e9-377e" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4dab-3286-cdc9-472a" includeChildSelections="false"/>
-              </constraints>
+            <selectionEntryGroup name="2 Choices" id="ddcc-612d-8e31-bbc1" hidden="false">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="Weapon" id="e15c-7ed3-157f-e825" hidden="false">
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="2a0d-c6c9-ec36-59cb">
+                      <profiles>
+                        <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7540-1044-2337-fd3f">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="928d-4aa8-8dc3-0b9f">
+                      <profiles>
+                        <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2155-8760-f817-7be8">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="6ca3-be48-3535-e3f5">
+                      <profiles>
+                        <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b0da-aa8d-27d7-3b1f">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="d23d-4c77-20ae-ea20">
+                      <profiles>
+                        <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e000-d507-db21-f91a">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="58a0-020c-138c-90d4">
+                      <profiles>
+                        <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0fa0-6ae5-65d7-6b7d">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="1026-e8a1-4179-7194">
+                      <profiles>
+                        <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5c8a-d8fe-51f4-4812">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8796-e3c8-f29c-ee96">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="fd87-3c6c-b9de-c147">
+                      <profiles>
+                        <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="eea5-ca71-7602-b84e">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2e93-af17-75a4-9d39">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <constraints>
+                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="c113-52d7-d3e9-377e" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4dab-3286-cdc9-472a" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="Weapon / Trait" id="5bb1-02d4-004a-4116" hidden="false">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2269-a22e-8be2-6b51" includeChildSelections="false"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="c4de-3b31-e3a2-4206" sortIndex="2">
+                      <profiles>
+                        <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e915-2671-6505-f044">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="dcfb-988d-55cc-ee16" sortIndex="4">
+                      <profiles>
+                        <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="717a-ad9d-f85e-65a9">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="fca9-48ef-c91f-3090" sortIndex="12">
+                      <profiles>
+                        <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d2aa-ac3c-1a3c-510c">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="8cb4-f51f-3aaa-137f" sortIndex="14">
+                      <profiles>
+                        <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c203-0e9e-23bb-e374">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="3d19-2b77-ef00-4dc8" sortIndex="13">
+                      <profiles>
+                        <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7c8c-c2d9-ea11-8c21">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="ee60-f97d-1439-e216" sortIndex="15">
+                      <profiles>
+                        <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d27b-8bc2-2cf5-26b9">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="a652-50b6-ac4c-7d47" sortIndex="16">
+                      <profiles>
+                        <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9490-24f8-7549-31dd">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="f348-e09a-2a90-ce82" sortIndex="18">
+                      <profiles>
+                        <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="68c4-f592-4f32-fadb">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="31b6-2883-a525-57c3" sortIndex="37">
+                      <profiles>
+                        <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="972f-b820-a8b1-0585">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="fe70-c4aa-b6b2-a499" sortIndex="20">
+                      <profiles>
+                        <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6dc9-5b29-e1d9-7e14">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bc07-ba74-fdb6-f910">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="b165-1095-71f3-ffea" sortIndex="23">
+                      <profiles>
+                        <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b1b4-4b4d-b286-7dac">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="20da-7bc5-ed89-1df8">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="2266-4dcd-a467-1790" sortIndex="21">
+                      <profiles>
+                        <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6e39-b387-3d13-db55">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="a18c-4eb9-aed6-d747" sortIndex="19">
+                      <profiles>
+                        <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4899-3732-8200-b1e0">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="abe5-486a-d438-07af" sortIndex="28">
+                      <profiles>
+                        <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cb8c-ffdd-4b2a-44c8">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="e936-6206-c9ee-c645" sortIndex="32">
+                      <profiles>
+                        <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d2e6-2421-1cd6-a5f1">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="55b9-a48d-7655-4930" sortIndex="33">
+                      <profiles>
+                        <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0f9c-1d51-b591-6dcc">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="fbae-558f-78d6-2270" sortIndex="34">
+                      <profiles>
+                        <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7391-084c-3eac-4146">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="c0e6-5d4a-2c4b-3f76" sortIndex="35">
+                      <profiles>
+                        <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="95fb-b995-921e-6188">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="9ba8-16f5-7001-2454" sortIndex="39">
+                      <profiles>
+                        <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="289b-ca7d-8801-2a19">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="72e7-6af0-d02a-daec" sortIndex="5">
+                      <profiles>
+                        <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c81b-58d0-e805-59f0">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="95c8-9474-d491-7cbc" sortIndex="8">
+                      <profiles>
+                        <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5cb4-8a5c-c74d-348f">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="9081-5f06-54aa-a26e" sortIndex="9">
+                      <profiles>
+                        <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b2f6-9fb7-1b3b-6c86">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="bf7f-4de3-ab1c-a92c" sortIndex="22">
+                      <profiles>
+                        <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="77fb-1d11-ce4a-e17d">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="231d-5b13-dacb-72fb" sortIndex="24">
+                      <profiles>
+                        <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0042-bf75-e41f-aaa6">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="7ce2-39b1-7e57-5c00" sortIndex="25">
+                      <profiles>
+                        <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cec2-f8e2-3587-7a39">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="e379-268a-d776-1932" sortIndex="26">
+                      <profiles>
+                        <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="38a6-c394-028c-68e6">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="8507-4583-0e73-cb8b" sortIndex="27">
+                      <profiles>
+                        <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3bff-a700-5747-beda">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="a295-d80a-6779-6649" sortIndex="29">
+                      <profiles>
+                        <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="23ac-92d3-ea6a-1402">
+                          <characteristics>
+                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="6f22-8909-e901-2539">
+                      <profiles>
+                        <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7eab-b8b0-d25c-14a9">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="7918-aae0-0334-381f">
+                      <profiles>
+                        <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8f3f-2a98-5ddd-9b25">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="882f-7396-6d06-6499">
+                      <profiles>
+                        <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b84e-6d0d-cc56-8783">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="1b24-a845-1fff-ecd6">
+                      <profiles>
+                        <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1f7c-6cd8-7264-479f">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="2c0c-97a5-6364-0d31">
+                      <profiles>
+                        <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d780-5d0f-5ceb-78fe">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="07ee-1a4c-2c54-b48b">
+                      <selectionEntries>
+                        <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="43ca-7a62-f176-f9c2">
+                          <profiles>
+                            <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0179-8fc3-ecc1-6e73">
+                              <characteristics>
+                                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <profiles>
+                        <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a5d6-f6bb-35c3-737c">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="80d0-c5a7-2cba-ff26">
+                      <profiles>
+                        <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ef38-840b-26e6-e79d">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="ce86-4372-c948-a442">
+                      <profiles>
+                        <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="dc6a-d3d1-3ab0-850b">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="2840-039b-eca6-d594">
+                      <profiles>
+                        <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3537-dfd2-b486-bb39">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="a9be-e559-4248-f850">
+                      <profiles>
+                        <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0a02-6645-ac82-8a02">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="b379-6d8f-33ac-f5e0">
+                      <profiles>
+                        <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="38c0-66df-589a-525b">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="7be6-16bb-628e-ec59">
+                      <profiles>
+                        <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="fa08-1167-7673-f0ce">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <constraints>
@@ -2065,7 +2676,6 @@
         <selectionEntryGroup name="Close combat weapon" id="00ec-596a-ae74-5468" hidden="false">
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="52ae-f95e-17ad-e8ef" includeChildSelections="false"/>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="dda7-76d9-6276-ac2e" includeChildSelections="false"/>
           </constraints>
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="5a11-1573-1ba3-afa2">
@@ -2084,12 +2694,12 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <profiles>
-        <profile name="Nemesis Small (S) (Pts 4)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="9635-547c-17c0-61d2">
+        <profile name="Nemesis Large (L) (Pts 6)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="9635-547c-17c0-61d2">
           <characteristics>
             <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">-</characteristic>
             <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
             <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
-            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">35</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">75</characteristic>
           </characteristics>
         </profile>
         <profile name="Extra Defense" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a52e-8d44-15d2-b1a6">
@@ -2115,1737 +2725,221 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule name="Extra Defense" id="671e-f995-24cf-3b74" hidden="false">
-          <description>Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</description>
-        </rule>
-      </rules>
       <categoryLinks>
         <categoryLink targetId="cf83-4496-b58e-ac82" id="64da-795b-204b-af2f" primary="true" name="Operative"/>
       </categoryLinks>
     </selectionEntry>
-    <selectionEntry type="model" import="true" name="Nemesis (L)" hidden="false" id="b375-1cc0-1990-a18d">
+    <selectionEntry type="model" import="true" name="Nemesis (S)" hidden="false" id="be0e-0c0b-2c03-21aa">
       <selectionEntryGroups>
-        <selectionEntryGroup name="Allegiance Trait" id="51c4-75a2-f245-d01f" hidden="false">
-          <profiles>
-            <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="32ce-f9d3-fa56-6129">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="93e4-bfbf-c0de-0561">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f86a-7f1c-4fec-efb6">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3c5e-9105-e8ce-699a">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d1ec-827b-c4c3-e34b">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="debe-8953-8433-5bd6">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="98a3-5042-cfc1-75c9">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="76ff-83e2-76e4-ed3a">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
+        <selectionEntryGroup name="Allegiance Trait" id="dbdc-2cf6-ab49-1fcb" hidden="false">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0f0-8133-722e-f117" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="409d-9591-53a9-20a6" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9add-49d6-6866-204e" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4c3c-ea1b-6448-48e9" includeChildSelections="false"/>
           </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Nemesis Trait" id="9c5c-c1cd-cab8-3292" hidden="false">
-          <profiles>
-            <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="eb86-ffdb-699f-cee6">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3369-f828-27a8-95d0">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c99f-390a-fed6-079a">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="88d1-79f9-59a0-8bea">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d64d-a840-7026-07a3">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3c58-2493-a76c-69ab">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="9cbf-fab5-a216-33de">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4112-68e1-bc2e-e5e9">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e481-acc9-2b4c-7fbd">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3fe1-cf72-28fa-6dc0">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0162-3de1-bdfe-670a">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bea8-353d-0407-9daf">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7e7f-2ac9-acec-ca55">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="040b-599e-6e41-6512" includeChildSelections="false"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="831e-e730-4649-8e1c" includeChildSelections="false"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Weapons" id="5702-3b0e-f0e8-bacd" hidden="false">
-          <selectionEntryGroups>
-            <selectionEntryGroup name="Weapons Selection 2" id="7bb7-dd1c-73f1-e735" hidden="false">
-              <selectionEntryGroups>
-                <selectionEntryGroup name="Weapon x1" id="5603-bf51-4666-8496" hidden="false">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="44f4-0d39-160b-fbff">
-                      <profiles>
-                        <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d328-d531-9e03-86bc">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="d7d2-7e5d-1189-ba2e">
-                      <profiles>
-                        <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d29e-7154-68fa-fba8">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="87e9-50a8-fa62-114e">
-                      <profiles>
-                        <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bfbb-ebfa-0e94-c9e4">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="f93f-55aa-015b-bbc5">
-                      <profiles>
-                        <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="943b-1f7a-2086-2963">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="4e17-713d-ea31-1cb4">
-                      <profiles>
-                        <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4e80-6b9d-72c5-55ee">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a714-0ba9-94ca-a849">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="4671-b16e-c684-74b8">
-                      <profiles>
-                        <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b519-58fe-e7fa-9c69">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="15b0-cad5-0bae-d34c">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="ea54-1d11-b2df-6769">
-                      <profiles>
-                        <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2a17-749c-e7eb-9b12">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <constraints>
-                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="3d0f-1960-235c-5aca" includeChildSelections="false"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2595-1e6c-cc2a-f5c3" includeChildSelections="false"/>
-                  </constraints>
-                </selectionEntryGroup>
-                <selectionEntryGroup name="Weapons / Trait x2" id="b95a-ef96-01ea-2289" hidden="false">
-                  <constraints>
-                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="be75-312c-2c5c-5948" includeChildSelections="false"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4262-7f18-d084-0621" includeChildSelections="false"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="3401-97bd-0332-a58d">
-                      <profiles>
-                        <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="14f7-fe0c-c55b-d3fc">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="9b88-18a7-d260-20cc">
-                      <profiles>
-                        <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7b93-0d4e-ee7b-d3e9">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="c2ab-505c-b567-30c5">
-                      <profiles>
-                        <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="511d-05fa-b997-8467">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="ce59-3759-1346-751e">
-                      <profiles>
-                        <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e6dc-beaf-e338-a7d8">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="49b6-8977-ff99-9b7f">
-                      <profiles>
-                        <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="75a1-3099-a332-2b19">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="fccd-fe1d-5702-c366">
-                      <profiles>
-                        <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3d87-3045-370d-14a2">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="cd60-2ef2-0db8-a0a1">
-                      <profiles>
-                        <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4d55-57ea-113e-7771">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="b052-699f-b1e7-ea47">
-                      <profiles>
-                        <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="45c4-bfb7-6553-ee20">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="9b4d-25fc-d432-b496">
-                      <profiles>
-                        <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f036-0ada-674b-1ed1">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="ba98-04a6-d16a-e6fa">
-                      <profiles>
-                        <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0050-32e4-6a2b-91f8">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6a64-b8c6-bc05-d85b">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="5d52-3642-529b-8f7b">
-                      <profiles>
-                        <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a791-d476-b810-8fec">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6066-f261-25b7-5358">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="f080-0113-43bf-60f8">
-                      <profiles>
-                        <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5112-d868-2483-8f4a">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="730f-7ec2-559b-a1dd">
-                      <profiles>
-                        <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="13f6-3f18-bd2e-5496">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="cc8c-511e-c504-2d4b">
-                      <profiles>
-                        <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="85ec-ca76-f548-9114">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="f36e-07d9-2c2e-6098">
-                      <profiles>
-                        <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b80a-1676-b2ba-a9a6">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="3e51-fa92-0dc2-627d">
-                      <profiles>
-                        <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="780d-fe88-4449-2e15">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="8750-4526-e6a8-52b9">
-                      <profiles>
-                        <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0a26-3b39-a0b4-52cd">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="981b-7c2e-b973-958f">
-                      <profiles>
-                        <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="66ec-db19-bdfb-01ae">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="e66b-7319-9353-097e">
-                      <profiles>
-                        <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1366-51a7-6981-bedb">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="30f5-e5ac-1fb2-eab0">
-                      <profiles>
-                        <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8142-5415-9bab-1969">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="da12-2834-06f6-1007">
-                      <profiles>
-                        <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2959-cb45-4fc1-7f81">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="1873-23b0-6449-0dfd">
-                      <profiles>
-                        <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3168-63e5-c330-1097">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="e359-450a-71c1-b39c">
-                      <profiles>
-                        <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6441-bb10-951e-78ca">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="3f6e-8f26-64b7-bd16">
-                      <profiles>
-                        <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="71ff-ad6f-3332-2584">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="eb1b-d3ce-f09e-747c">
-                      <profiles>
-                        <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ed24-ff93-a25b-6090">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="4270-5104-b1ff-2c7d">
-                      <profiles>
-                        <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8c87-9e61-15d1-87c7">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="cf3b-6205-6a98-e1a4">
-                      <profiles>
-                        <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a0b7-5cb5-2cfd-dfd1">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="96f9-e084-aad8-2a66">
-                      <profiles>
-                        <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="db31-e54a-7494-7246">
-                          <characteristics>
-                            <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                            <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                            <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                            <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <profiles>
-                    <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2ca9-27ce-fc6d-1293">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bd34-8845-62e0-d917">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a7d4-454a-cdf0-359b">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="27b6-7c4f-fbd4-cc82">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0eb8-8661-e98f-e7c0">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d3d2-a50d-89ab-bb99">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="da2a-3249-9a4b-bb2a">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c48e-8d8c-d062-059f">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0aa0-682c-495a-6603">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6d02-51db-0426-31be">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c1a1-4a06-2334-490c">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d25c-ae3f-43b5-a2ba">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="fa6b-b64a-0743-80ce">
-                      <characteristics>
-                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <selectionEntryGroups>
-                    <selectionEntryGroup name="Weapons / Trait x2" id="2b04-84a0-0641-6156" hidden="false">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="910c-acdb-ffef-7f58" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5572-904a-ce68-6672" includeChildSelections="false"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="663a-141f-9acc-a1ea">
-                          <profiles>
-                            <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6119-ddac-7f8e-7957">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="40b6-0bba-0ca6-a859">
-                          <profiles>
-                            <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f5cf-40ce-a769-cf08">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="aa65-31d5-a7d9-b650">
-                          <profiles>
-                            <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4491-5e6a-0807-3efc">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="203b-9658-7b31-b9e1">
-                          <profiles>
-                            <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="03ad-c5f5-2b04-d437">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="d621-de52-195a-3b96">
-                          <profiles>
-                            <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="04e3-b7a4-55de-07ba">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="b56e-1084-1499-5750">
-                          <profiles>
-                            <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="705e-2d1f-36c1-bd3d">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="61f6-ecd2-1fd5-2cfe">
-                          <profiles>
-                            <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="766c-16e7-8ed9-7c1d">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="fbe2-7e28-09aa-500b">
-                          <profiles>
-                            <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ee6e-3651-118e-28d0">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="91fe-e9d4-3584-1aaa">
-                          <profiles>
-                            <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7c48-a273-4985-6997">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="1c01-662e-c6c1-4308">
-                          <profiles>
-                            <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="be3c-400f-fe5d-b894">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                              </characteristics>
-                            </profile>
-                            <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2cb3-8dc2-468f-088e">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="dfb9-a9e2-b2e2-4387">
-                          <profiles>
-                            <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0538-06b3-cb17-78dd">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                              </characteristics>
-                            </profile>
-                            <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a91d-2b19-247a-fa76">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="02a7-0fd8-76b6-cfc0">
-                          <profiles>
-                            <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="088e-d8ad-074c-b908">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="4887-09d7-f5ad-3b26">
-                          <profiles>
-                            <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8e26-54c9-05a5-19a1">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="e79f-01cc-f06e-1446">
-                          <profiles>
-                            <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0f32-8a8b-82a9-40ef">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="c177-b0e7-7f07-9495">
-                          <profiles>
-                            <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2021-3115-377c-15a3">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="454d-7a4f-14a4-fa40">
-                          <profiles>
-                            <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d3d3-b17a-c049-f0e6">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="eb78-58f2-4cbb-9c5d">
-                          <profiles>
-                            <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bccb-507f-b647-05cf">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="352a-6fec-4368-8797">
-                          <profiles>
-                            <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cdaa-e3f8-03ac-3deb">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="f0aa-cec5-c9a0-4eb5">
-                          <profiles>
-                            <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="573e-dec5-66e9-f6e0">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="9698-3e9f-f7af-6eee">
-                          <profiles>
-                            <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="dc37-046b-3647-9b01">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="2bf1-aba4-959b-8d68">
-                          <profiles>
-                            <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="bf78-7ff1-7cbf-902d">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="98c6-2b9b-c0c6-1f82">
-                          <profiles>
-                            <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="162b-64d9-2f00-dcba">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="3208-97ad-0d93-889f">
-                          <profiles>
-                            <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="77f7-cc12-d47a-43c1">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="2b24-e163-e30d-c779">
-                          <profiles>
-                            <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="dad8-af15-8004-edf8">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="bdb8-acf0-4a43-e8d5">
-                          <profiles>
-                            <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9bd7-2b2f-ef0d-1b9f">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="d52d-c89b-511b-5b4f">
-                          <profiles>
-                            <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="28f9-19a3-e420-d657">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="171a-493d-d50a-782d">
-                          <profiles>
-                            <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="dc48-1253-247a-a6f3">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                        <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="7744-c0bb-ad3d-d18e">
-                          <profiles>
-                            <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8006-763f-2cd0-16e5">
-                              <characteristics>
-                                <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                                <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                                <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                                <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
-                              </characteristics>
-                            </profile>
-                          </profiles>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <profiles>
-                        <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="28ba-5e22-6084-3d9d">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d659-46b7-57da-3d15">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1093-3d69-3806-492c">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c027-ca59-e574-bd7b">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7e6a-ae75-6fb2-c56d">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d0f3-5d53-baa4-10f0">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f964-0930-e3cc-7242">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="fdbe-826c-2ca2-321a">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="581f-b17b-29ea-ac42">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="ed95-eb9b-6a55-d2e3">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2245-8bc9-1e56-62ce">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bbac-f1c8-87a3-156f">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5955-9e39-16e2-a3dd">
-                          <characteristics>
-                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="Weapons / Trait x3" id="f331-8078-0e57-7cd4" hidden="false">
-              <constraints>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="cd19-054f-7d32-f4b2" includeChildSelections="false"/>
-                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="631e-ad35-d772-04d0" includeChildSelections="false"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="760c-d6f7-9533-5a1a">
-                  <profiles>
-                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ae4e-29ff-1f8c-ed04">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="6350-78a5-12e6-65e8">
-                  <profiles>
-                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3447-2591-7cb4-89ba">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="50a7-022b-0ad0-4da2">
-                  <profiles>
-                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7dd0-7adc-f3ca-d3b1">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="971d-cd51-e7ad-005e">
-                  <profiles>
-                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8df9-aa3c-dfeb-1bf8">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="6cdb-b511-4d0b-b5ff">
-                  <profiles>
-                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a6cf-3c9f-60e4-75b8">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="8119-3e83-fc0e-b491">
-                  <profiles>
-                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f33f-b686-76c0-fae8">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="c164-8cc7-8eae-b0a2">
-                  <profiles>
-                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3d1d-8887-4f05-c36f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="757b-1135-2bae-9886">
-                  <profiles>
-                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9c2b-760e-1a48-6512">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="28f5-06d9-3812-a7ce">
-                  <profiles>
-                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7bdc-eac0-870e-a7d1">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="1398-e5e6-e148-ddcf">
-                  <profiles>
-                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c19e-3698-04fb-2409">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="00cf-9ef3-30f0-511c">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="0cb6-9e92-9b6a-2e6c">
-                  <profiles>
-                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="eb82-f1d9-23ff-5a67">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="340a-4a8d-43c9-1764">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="63b9-ba1e-4b5a-cd72">
-                  <profiles>
-                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b869-d790-666f-49af">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="7964-6883-8ca3-070b">
-                  <profiles>
-                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6257-2de4-789d-d0bd">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="b63d-1941-42dd-da8c">
-                  <profiles>
-                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="87ed-32d2-497d-de79">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="4f10-d8e9-c336-b578">
-                  <profiles>
-                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0958-2367-f1ae-4edf">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="3489-ab8c-dfa0-64b9">
-                  <profiles>
-                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ade7-c059-7171-937e">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="e50c-6d65-056e-7c7c">
-                  <profiles>
-                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7d02-7594-79db-771f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="3a3e-1323-0a84-f704">
-                  <profiles>
-                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="810d-e78b-f1d1-9d5b">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="7cf9-ab4c-a9f5-5441">
-                  <profiles>
-                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5a5d-6bad-ad3c-5b9f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="dafd-ca0c-021d-837f">
-                  <profiles>
-                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0cd5-1653-7552-8463">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="9d8d-5e07-06a7-6078">
-                  <profiles>
-                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="16de-e6f0-e402-8b9f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="89c1-f570-ea5e-a82c">
-                  <profiles>
-                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="41d7-b9b3-f7e3-0ee1">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="1996-a9bf-3765-7ac7">
-                  <profiles>
-                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cad0-b3bc-e80e-4150">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="e601-e455-5ea0-6504">
-                  <profiles>
-                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fbff-fae5-1550-7e6f">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="2f7b-84e6-bc8f-6f27">
-                  <profiles>
-                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cdb2-abbb-7c8b-540c">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="bf77-92f9-1edd-4a31">
-                  <profiles>
-                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7f84-5d31-7ee6-53c0">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="a121-9038-69b3-41bf">
-                  <profiles>
-                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="544c-5414-c0e2-a5bf">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="8aec-6ca9-abee-8327">
-                  <profiles>
-                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f626-1a14-c1f5-fdbb">
-                      <characteristics>
-                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
-                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
-                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
-                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                </selectionEntry>
-              </selectionEntries>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Leagues of Vontann: Acquisition at all costs" hidden="false" id="84cd-6c72-8f54-4b1b">
               <profiles>
-                <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e3ae-2af0-81f7-a27d">
+                <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="dba9-c893-4ed6-c4c5">
                   <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="708a-fc23-7c1c-2871">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2a5b-5503-f032-5d4a">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="05a1-6257-bd59-eba3">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1b4b-9cf1-f4e5-0b9c">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bdf7-29a2-317e-3bcb">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="fb66-be3e-7550-f69c">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4b8b-436b-8a54-8108">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1206-85b7-1dad-42dc">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3904-1f49-95d8-9336">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="83b5-e732-3b77-67c3">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d811-801c-18ad-33cd">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="9349-e889-3915-e8ef">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <constraints>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="c1e7-ed6b-54e5-c7b2" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4b35-9761-24ff-1888" includeChildSelections="false"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Close combat weapon" id="5ab8-6299-8a5f-d642" hidden="false">
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7c39-c891-e682-94cb" includeChildSelections="false"/>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="2337-bc63-dcc9-1a1f" includeChildSelections="false"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="381c-9ca4-993a-ed8d">
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Chaos: Let the galaxy burn" hidden="false" id="a9ab-a2cc-c79a-be58">
               <profiles>
-                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="49fc-d78d-b3fe-8707">
+                <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d258-6867-a66b-7b6b">
                   <characteristics>
-                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
-                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
-                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
-                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Selection 0</characteristic>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Aeldari: Arrogant Superiority" hidden="false" id="8436-c353-f0f8-e8c2">
+              <profiles>
+                <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="eca7-aa8d-2c80-65be">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Imperium: Defenders of the Imperium" hidden="false" id="b924-7bb6-15e7-896b">
+              <profiles>
+                <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="58fc-105c-ac38-ae97">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Ork: WAAAGH!" hidden="false" id="3152-9c89-74cd-6166">
+              <profiles>
+                <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0fb9-67ee-e0e6-db9f">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Necron: Living Metal" hidden="false" id="8fcf-bc48-3cf0-fe1d">
+              <profiles>
+                <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a86c-2871-a1df-0d55">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="T&apos;au: Supporting Fire" hidden="false" id="61e7-f017-1d5b-6758">
+              <profiles>
+                <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="878e-b43a-c713-f503">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tyranid: Will of the hive mind" hidden="false" id="2f99-d7c9-4610-685b">
+              <profiles>
+                <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0b72-a77e-fba6-70ad">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <profiles>
-        <profile name="Nemesis Large (L) (Pts 6)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="5c3e-3694-729e-16d0">
-          <characteristics>
-            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">-</characteristic>
-            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
-            <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
-            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">75</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Extra Defense" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a7a2-a9b8-388e-952a">
-          <characteristics>
-            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Bulky" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="dd75-355e-0804-863c">
-          <characteristics>
-            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative cannot be placed on Vantage terrain higher than 2&quot; from the killzone floor.
-Whenever this operative would perform the fight action, the distance requirements for its control range can be changed to 1&quot; horizontally and 4&quot; vertically until the end of that action.
-This operative can move through other operatives (excluding Nemesis operatives)
-Ignore all changes to this operative&apos;s APL and if it&apos;s a player operative, APL changes don&apos;t affect the 5AP you can spend per turning point.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Towering size" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6ba9-2004-32bf-9330">
-          <characteristics>
-            <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the Firefight phase, whenever you determine this operative&apos;s order, you cannot select Conceal.
-This operative cannot be in cover or obscured by Light terrain, terrain parts less than 3&quot; tall or terrain that&apos;s not wholly intervening.
-Whenever another operative is performing the Shoot action, being within control range of other operatives doesn&apos;t prevent this operative from being selected as a valid target.
-This operative can move through terrain parts less than 2&quot; tall. It cannot move through Accessible terrain (excluding hatchways) unless that terrain is also less than 2&quot; tall.
-Whenever this operative would finish a move in a terrain feature less than 2&quot; tall, temporarily remove that terrain feature from the killzone, then return it when this operative leaves that location. If it&apos;s an equipment terrain feature, remove it from the battle instead.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule name="Extra Defense" id="292e-4144-2abd-1e39" hidden="false">
-          <description>Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</description>
-        </rule>
-      </rules>
-      <categoryLinks>
-        <categoryLink targetId="cf83-4496-b58e-ac82" id="b43f-ecce-be89-9a76" primary="true" name="Operative"/>
-      </categoryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Nemesis (M)" hidden="false" id="be0b-e701-602a-7b29">
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Allegiance Trait" id="3c53-26bc-df22-42bf" hidden="false">
-          <profiles>
-            <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7a13-93e2-63f1-880c">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="efc8-01ad-a23a-d9b9">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d4cc-26eb-2f76-510a">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="615a-0860-676c-5a3f">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="2b74-efe0-83c1-1362">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c732-3a1d-baa0-4798">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6061-0a33-1115-1553">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1692-d393-ecc2-c707">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
+        <selectionEntryGroup name="Nemesis Trait" id="7959-9958-cf21-c033" hidden="false">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dddb-b987-7082-d3da" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ae38-1cd5-a2a8-8649" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9cc9-22e8-a791-44fb" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d1f3-9009-258e-9918" includeChildSelections="false"/>
           </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="0fe5-df79-e0e7-d47b"/>
+            <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="5c6f-3d87-9243-6540">
+              <profiles>
+                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="01ed-b526-f8be-f555">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="0cda-249e-2b12-3eaa">
+              <profiles>
+                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e5a3-f333-c547-cfa2">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="4d27-6e0c-7793-2aba">
+              <profiles>
+                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bb69-c116-a0c8-df17">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="20d0-4f14-7a94-b7f8">
+              <profiles>
+                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e367-746b-7075-ec44">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="4dcd-9791-f1b4-21c1">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="5afb-d92a-089c-7717">
+                  <profiles>
+                    <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="116d-0a05-0c4f-e715">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <profiles>
+                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="06be-67d0-28b5-c92a">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="ca19-30e3-7133-573d">
+              <profiles>
+                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7128-77b4-729e-2f25">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="d67d-1883-aad9-b47d">
+              <profiles>
+                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d53e-1ae2-c714-d5bd">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="57a4-d591-2c4b-ebf2">
+              <profiles>
+                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b3a3-6deb-49d2-48c1">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="632a-e688-6601-257c">
+              <profiles>
+                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5c23-dee5-ec96-35ba">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="85b7-73bc-85c9-1c6e">
+              <profiles>
+                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c630-941c-0ea1-84e1">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="1956-dacc-f2c0-4413">
+              <profiles>
+                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f8f3-adb9-8d08-74ed">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup name="Nemesis Trait" id="18ef-9b71-3b32-dbe7" hidden="false">
-          <profiles>
-            <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="836a-a3e6-7a66-32c0">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7e4c-629d-e817-1d8c">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b80d-170a-ee95-6267">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6649-b89c-e6bc-fbcb">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0e9b-ac30-298b-d86a">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="edfd-6151-ae42-5cf2">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b50a-bded-c918-7193">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7839-3d21-f197-8d31">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3ede-5b4a-e07a-f7c2">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a1cd-8289-1041-246d">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b040-897c-81cb-0656">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8587-d505-2cdf-b5ad">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-              </characteristics>
-            </profile>
-            <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6e62-d928-3c15-28e7">
-              <characteristics>
-                <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="23ab-722b-7c36-8d6d" includeChildSelections="false"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0440-f22a-adc7-2ed7" includeChildSelections="false"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Weapons" id="631b-a555-d7d6-7ba1" hidden="false">
+        <selectionEntryGroup name="Weapons" id="0a87-cdd2-28bc-46e8" hidden="false">
           <selectionEntryGroups>
-            <selectionEntryGroup name="Weapons / Trait x2" id="bae1-5857-ae09-072e" hidden="false">
+            <selectionEntryGroup name="Weapons / Trait x2" id="a236-9349-e947-20b6" hidden="false">
               <constraints>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="351f-0f8a-2a1d-fc5e" includeChildSelections="false"/>
-                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="2fe8-b04c-0386-d157" includeChildSelections="false"/>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="4e2b-7dd3-c923-b8ae" includeChildSelections="false"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="0ae9-763a-a6f8-71c0">
+                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="1d1d-a3d2-7451-d9a9" sortIndex="2">
                   <profiles>
-                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b89b-d164-92f7-8f82">
+                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d6d8-126a-8cd6-ae3f">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3855,9 +2949,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="e0c0-0da0-1130-6ef9">
+                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="e5fe-32e9-0b88-bb00" sortIndex="4">
                   <profiles>
-                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8bd0-bf62-5b61-acf6">
+                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4706-ee37-bf81-5ddd">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3867,9 +2961,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="19cd-b1c7-fa62-6381">
+                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="536c-bd24-a3e1-4bee" sortIndex="12">
                   <profiles>
-                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6cd1-d063-770f-af51">
+                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="196f-c756-a830-1992">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3879,9 +2973,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="c52e-d62b-b71c-79a3">
+                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="e6a4-3b56-c40d-814d" sortIndex="14">
                   <profiles>
-                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="18ba-a42e-d7da-240e">
+                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b91d-2b6c-0d57-e1ba">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
@@ -3891,9 +2985,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="b547-1bcd-5b73-e826">
+                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="d6ca-ba1c-9281-576c" sortIndex="13">
                   <profiles>
-                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2998-a154-552e-202e">
+                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ba4e-bf28-59e7-a770">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3903,9 +2997,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="cb4a-e32a-f6e6-27e3">
+                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="fc87-5b29-a721-6012" sortIndex="15">
                   <profiles>
-                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d802-d70a-c250-6621">
+                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8eb6-00ac-2fa0-7164">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3915,9 +3009,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="052b-9114-d040-8113">
+                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="ef5e-3779-77d0-0f01" sortIndex="16">
                   <profiles>
-                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="a734-6455-8168-a056">
+                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ff68-01af-8db2-971f">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3927,9 +3021,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="244d-3061-4bf7-c5e9">
+                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="6a12-3114-a92b-09d5" sortIndex="18">
                   <profiles>
-                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7863-0d73-1742-aed3">
+                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e52e-3391-f328-3e2b">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3939,9 +3033,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="2c56-e210-6c8c-bb55">
+                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="3246-3456-e551-0234" sortIndex="37">
                   <profiles>
-                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1b95-aa69-93d3-e950">
+                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0a5a-9220-dc26-3e42">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3951,9 +3045,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="986c-7607-7e06-d2b3">
+                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="a67d-ba56-e75f-7d66" sortIndex="20">
                   <profiles>
-                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9e8e-a42e-8dc8-d8ed">
+                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1434-6ab4-6192-84cd">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3961,7 +3055,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                         <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
                       </characteristics>
                     </profile>
-                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1c16-241c-02a2-6f8c">
+                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e047-3d0f-f601-7a93">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3971,9 +3065,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="7f54-38f7-19ae-7a3a">
+                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="c279-d485-0536-4775" sortIndex="23">
                   <profiles>
-                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="700d-4dd2-b32f-165d">
+                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="660c-729f-580a-b0a9">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3981,7 +3075,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                         <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
                       </characteristics>
                     </profile>
-                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="078c-fada-dbb9-cd93">
+                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7246-0790-9d85-9b3d">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -3991,9 +3085,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="0297-c66d-3e63-5465">
+                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="61f3-951f-1260-5422" sortIndex="21">
                   <profiles>
-                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5ebc-6602-0f32-79ae">
+                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7eb8-77af-f06e-7b28">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4003,9 +3097,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="29ba-70ef-3044-a6b1">
+                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="2e29-1aaa-0621-9547" sortIndex="19">
                   <profiles>
-                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c7bf-5c05-bf1e-7175">
+                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="790f-a588-3ea1-f1c5">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4015,9 +3109,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="0705-6024-2e05-6832">
+                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="fcdc-1c64-701c-7291" sortIndex="28">
                   <profiles>
-                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3a9c-19c1-58c5-2ed9">
+                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="558f-69c3-8ae0-9f11">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
@@ -4027,9 +3121,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="44c6-4327-a73a-69b5">
+                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="a6f5-9601-cdd8-d870" sortIndex="32">
                   <profiles>
-                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f13d-1733-5af8-5e95">
+                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="252f-84cc-9f5c-0663">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4039,9 +3133,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="761d-1cc9-2e5b-d5f7">
+                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="d035-b830-3c31-c838" sortIndex="33">
                   <profiles>
-                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9a59-662b-ceac-9e11">
+                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f8f7-424f-4408-866d">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4051,9 +3145,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="11f6-e5ad-1c17-2280">
+                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="4db2-6f54-5896-f237" sortIndex="34">
                   <profiles>
-                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c751-a59a-7f2c-8cea">
+                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b512-b4b0-d412-262a">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4063,9 +3157,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="e4b5-a253-539d-b500">
+                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="1572-8a93-7804-56c6" sortIndex="35">
                   <profiles>
-                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="04a7-7836-e9d8-ffad">
+                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="23c3-84fc-b9fe-1bd4">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4075,9 +3169,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="1222-3ee1-3a77-c800">
+                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="9c76-2061-5cb7-96e2" sortIndex="39">
                   <profiles>
-                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8cc4-01c7-18e5-d54f">
+                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="10e5-ea4c-e71d-cc82">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
@@ -4087,9 +3181,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="82c0-eb7a-1e3d-8f45">
+                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="3a7d-2904-5c60-065e" sortIndex="5">
                   <profiles>
-                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2f65-d62e-b7f2-5e3a">
+                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b8f2-063c-2bf0-6046">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4099,9 +3193,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="d5ed-a63b-f000-0f34">
+                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="0ea6-616a-0c5c-8cbd" sortIndex="8">
                   <profiles>
-                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8b02-6646-c7e8-1c17">
+                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="fc4b-63f0-cf4b-b208">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4111,9 +3205,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="15ac-a58d-5c1a-62c1">
+                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="c1dc-de3e-28ce-84cb" sortIndex="9">
                   <profiles>
-                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7678-2c9a-fea3-485b">
+                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0008-143b-8ab6-4ddb">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
@@ -4123,9 +3217,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="b04a-da3d-ac40-7111">
+                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="bfcc-b53a-c527-1874" sortIndex="22">
                   <profiles>
-                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e0ae-1526-dc83-549a">
+                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d6ef-9144-e99e-8d85">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
@@ -4135,9 +3229,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="0cad-a594-c988-c649">
+                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="8e08-158d-63f5-84f0" sortIndex="24">
                   <profiles>
-                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="198c-0300-510f-c382">
+                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c553-c2f1-8fb5-c4ca">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4147,9 +3241,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="947b-2ed6-5ece-d683">
+                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="c5ee-6268-35dc-7e28" sortIndex="25">
                   <profiles>
-                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0e23-79b9-88da-7a6f">
+                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5784-fda9-143c-d362">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4159,9 +3253,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="8a87-d76e-fb88-faef">
+                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="2121-30aa-877d-014e" sortIndex="26">
                   <profiles>
-                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="29d2-b47f-a067-384b">
+                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b417-b776-01c5-c9d1">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4171,9 +3265,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="6c90-baa8-4d53-f774">
+                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="ff41-fcb6-5d3c-acbc" sortIndex="27">
                   <profiles>
-                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6e84-c585-29b9-d583">
+                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="50b0-8aaf-7169-c288">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4183,9 +3277,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="e698-86a4-24f8-d224">
+                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="5146-e069-b3fc-fa21" sortIndex="29">
                   <profiles>
-                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e22b-8c95-4690-6508">
+                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c8d4-e3f6-5318-f3e8">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4195,80 +3289,132 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-              </selectionEntries>
-              <profiles>
-                <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0184-66c2-6452-819c">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="bd65-f27f-d4b8-b558">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="82ba-0c5b-4dc0-4992">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4dec-3bfe-15eb-fcda">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="99fd-8f75-60ab-a96e">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a0c6-3055-5fe3-afc7">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5961-b6a2-2852-5ac7">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="1e68-00ae-5e68-a129">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6def-1ce7-2a3c-fbb6">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7f2b-6575-e3bc-b9bf">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7e18-4a9b-67a8-99a7">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6bdc-c2ee-b816-15db">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c9b8-af2a-ac02-a5f9">
-                  <characteristics>
-                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="Weapon x1" id="b881-816e-a44d-233b" hidden="false">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="7f09-445f-4da7-9c87">
+                <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="0a35-973b-5a4d-ef64">
                   <profiles>
-                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="6381-d0d9-10dc-59ab">
+                    <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="308c-447c-e229-6d3d">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="0de9-2e06-f34c-7f0e">
+                  <profiles>
+                    <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7ab3-8dae-b410-6f6a">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="2749-b2ca-3e64-68fd">
+                  <profiles>
+                    <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6c40-929d-51db-550c">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="434c-c76a-12e1-2b10">
+                  <profiles>
+                    <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5df0-ca9f-e5d5-931e">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="bf21-d61e-3f2d-3900">
+                  <profiles>
+                    <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="eb3a-a2ac-e90a-5a0d">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="f94b-fb8c-4555-922b">
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="2205-f1fb-ac32-af93">
+                      <profiles>
+                        <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5d22-9e1e-51df-8823">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <profiles>
+                    <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6642-7bf6-fbfe-0071">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="fcf7-a3b7-ce9c-c6be">
+                  <profiles>
+                    <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b212-e811-234d-f50f">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="aaa5-306b-0c11-e2c6">
+                  <profiles>
+                    <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="f5b3-c2dc-8090-45f2">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="64f2-0fea-a724-3f0a">
+                  <profiles>
+                    <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b72d-fefc-35df-c7b3">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="f3cf-c12f-e6a8-3d96">
+                  <profiles>
+                    <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4fef-9a4c-d6d3-3c2b">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="d9ff-40f2-05a1-25b0">
+                  <profiles>
+                    <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="babf-6726-45a0-d4d0">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="8a27-e4fe-5e24-b579">
+                  <profiles>
+                    <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="3e62-5f74-7ef5-7ff2">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Weapon x1" id="5033-4bea-1edc-3fa2" hidden="false">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="6eaf-73b8-8fc8-f469">
+                  <profiles>
+                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="82e7-9cea-1518-fc5b">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4278,9 +3424,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="dd86-002b-d44a-a84d">
+                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="1e9e-5f24-8e0e-c408">
                   <profiles>
-                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3d8f-e3ac-0b16-a2e1">
+                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="01c7-cda6-beb1-360f">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
@@ -4290,9 +3436,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="34a8-1c7c-01a0-078c">
+                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="3e66-f94d-d1e2-dbb7">
                   <profiles>
-                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5655-8a79-379c-ac2d">
+                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ea10-3061-ff6c-b49f">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4302,9 +3448,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="05ec-78dd-ef1f-4ec0">
+                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="5a9c-c997-3483-7f84">
                   <profiles>
-                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2387-8b5a-d8bb-fdd8">
+                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5fa7-785e-c09b-5688">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4314,9 +3460,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="3791-736d-5ab3-9627">
+                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="af99-4f07-bfcb-0487">
                   <profiles>
-                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3984-8626-18aa-9d2b">
+                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3ed6-e459-011f-1457">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4324,7 +3470,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                         <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
                       </characteristics>
                     </profile>
-                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4301-ec70-4045-d668">
+                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cb05-8bbb-8a61-0f0f">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4334,9 +3480,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="03a8-f339-c30d-0761">
+                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="4991-3d4b-f11e-e8dd">
                   <profiles>
-                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="16f0-ea74-719f-9d53">
+                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4ff2-a736-951e-f528">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4344,7 +3490,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                         <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
                       </characteristics>
                     </profile>
-                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ac95-97ab-95e4-e0a0">
+                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5c24-da57-cd58-bb47">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4354,9 +3500,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </profile>
                   </profiles>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="7ef0-3e44-ede3-479f">
+                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="79dd-a55a-21b2-c021">
                   <profiles>
-                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e71d-ee99-113e-1be0">
+                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1ae6-7b63-1ef5-7059">
                       <characteristics>
                         <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
                         <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
@@ -4368,25 +3514,24 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                 </selectionEntry>
               </selectionEntries>
               <constraints>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="982d-9839-03b2-c36f" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b8e4-8919-6914-f753" includeChildSelections="false"/>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="b0ac-bef8-a801-e373" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ed69-c7e4-a30d-603f" includeChildSelections="false"/>
               </constraints>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8bb5-f795-3d91-68c2" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0889-4888-a9a7-6888" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a02c-8b4d-df93-4bbf" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c21c-c716-a3b8-0bc3" includeChildSelections="false"/>
           </constraints>
         </selectionEntryGroup>
-        <selectionEntryGroup name="Close combat weapon" id="95b4-633e-df54-3eed" hidden="false">
+        <selectionEntryGroup name="Close combat weapon" id="b1d8-4876-bde6-b0a4" hidden="false">
           <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="294f-58f0-112b-beae" includeChildSelections="false"/>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="dd50-0b3a-2890-d416" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c13d-caa0-3d74-e24b" includeChildSelections="false"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="814d-a01b-bd5e-5d28">
+            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="2119-a5e1-f762-3ea6">
               <profiles>
-                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4ab2-cfcb-fea0-2ea1">
+                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1c5b-da92-a930-6d8f">
                   <characteristics>
                     <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
                     <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
@@ -4400,20 +3545,20 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <profiles>
-        <profile name="Nemesis Medium (M) (Pts 5)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="0f9b-9e24-8f3c-2729">
+        <profile name="Nemesis Small (S) (Pts 4)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="ace9-0872-af8a-ab0c">
           <characteristics>
             <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">-</characteristic>
             <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
             <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
-            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">50</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">35</characteristic>
           </characteristics>
         </profile>
-        <profile name="Extra Defense" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0342-1fee-177f-2598">
+        <profile name="Extra Defense" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b7fb-3c8d-86ee-ce52">
           <characteristics>
             <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Bulky" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="6b13-9669-0448-826b">
+        <profile name="Bulky" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8d06-cc08-1c8c-b42e">
           <characteristics>
             <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative cannot be placed on Vantage terrain higher than 2&quot; from the killzone floor.
 Whenever this operative would perform the fight action, the distance requirements for its control range can be changed to 1&quot; horizontally and 4&quot; vertically until the end of that action.
@@ -4421,7 +3566,7 @@ This operative can move through other operatives (excluding Nemesis operatives)
 Ignore all changes to this operative&apos;s APL and if it&apos;s a player operative, APL changes don&apos;t affect the 5AP you can spend per turning point.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Towering size" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="507d-dc9d-81b3-2da9">
+        <profile name="Towering size" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="88b1-0076-6ce0-fae9">
           <characteristics>
             <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the Firefight phase, whenever you determine this operative&apos;s order, you cannot select Conceal.
 This operative cannot be in cover or obscured by Light terrain, terrain parts less than 3&quot; tall or terrain that&apos;s not wholly intervening.
@@ -4431,13 +3576,859 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule name="Extra Defense" id="8ba2-7a3d-60ea-2086" hidden="false">
-          <description>Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</description>
-        </rule>
-      </rules>
       <categoryLinks>
-        <categoryLink targetId="cf83-4496-b58e-ac82" id="ab9f-e5c8-b988-0b6a" primary="true" name="Operative"/>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="6041-0d12-20d6-66e3" primary="true" name="Operative"/>
+      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Nemesis (M)" hidden="false" id="ffe5-857d-4e47-593c">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Allegiance Trait" id="77f8-6514-4ae9-af30" hidden="false">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="baa8-ef4e-1462-6094" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e772-68d2-57d9-d1d4" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Leagues of Vontann: Acquisition at all costs" hidden="false" id="251f-14ad-2bb4-da23">
+              <profiles>
+                <profile name="Leagues of Vontann: Acquisition at all costs" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="14e0-d407-9ca7-77f4">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Leagues of Vontann NPO or friendly Leagues of Vontann Nemesis operative is shooting against or fighting against an enemy operative that contests a marker, or an area of the killzone that determines victory, that Leagues of Vontann operative&apos;s weapons have the Balanced weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Chaos: Let the galaxy burn" hidden="false" id="d248-6242-abfb-1776">
+              <profiles>
+                <profile name="Chaos: Let the galaxy burn" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="cf53-eb5e-92ff-67ad">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a Chaos NPO or friendly Chaos Nemesis operative is wholly within enemy territory, its weapons have the Balanced weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Aeldari: Arrogant Superiority" hidden="false" id="1198-f451-39c0-e812">
+              <profiles>
+                <profile name="Aeldari: Arrogant Superiority" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a1a1-9494-098e-9d61">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Aeldari NPO or friendly Aeldari Nemesis operative is shooting against or fighting against a ready enemy operative, if two or more fails are rolled for it, one of them can be discarded to re-roll another.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Imperium: Defenders of the Imperium" hidden="false" id="56bd-e0f5-c164-842a">
+              <profiles>
+                <profile name="Imperium: Defenders of the Imperium" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="650b-255c-1c36-5671">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting an Imperium NPO or friendly Imperium Nemesis operative, if that Imperium operative is wholly within its territory, one of its defence dice can be retained as a normal success without rolling it (in addition to a cover save, if any).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Ork: WAAAGH!" hidden="false" id="b94f-a43d-5374-de7e">
+              <profiles>
+                <profile name="Ork: WAAAGH!" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="82f1-4f6b-b511-1b6f">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an Ork NPO is fighting, its weapons have the Balanced weapon rule. Worsen the hit stat of the Ork Nemesis operatives&apos; ranged weapons by 1, but their melee weapons have the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Necron: Living Metal" hidden="false" id="ce20-a998-1e53-fd36">
+              <profiles>
+                <profile name="Necron: Living Metal" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="18d7-33d2-7aa8-cb08">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the ready step of each Strategy phase, each Necron NPO and friendly Necron Nemesis operative regains up to D3+1 lost wounds (roll seperately for each).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="T&apos;au: Supporting Fire" hidden="false" id="8370-3720-f037-8cc1">
+              <profiles>
+                <profile name="T&apos;au: Supporting Fire" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="cac5-a24c-c882-ecc0">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever a T&apos;au Empire NPO is within 3&quot; of another, it&apos;s ranged weapons have the Accurate 1 weapon rule. Whenever a friendly T&apos;au Empire Nemesis operative is within 3&quot; of another friendly T&apos;au Empire operative, that Nemesis operative&apos;s ranged weapons have the Accurate 1 weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tyranid: Will of the hive mind" hidden="false" id="0381-d879-507b-8e35">
+              <profiles>
+                <profile name="Tyranid: Will of the hive mind" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="9e41-537b-a162-6b71">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore the changes to Tyranid NPO and Tyranid Nemesis operatives&apos; stats from being injured (including their weapon stats).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Nemesis Trait" id="8c91-6674-fde0-e105" hidden="false">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a66c-71b8-91dc-54dc" includeChildSelections="false"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="64fe-4e3d-7193-1b07" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="94c2-a41c-9707-ebd7"/>
+            <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="665a-b90b-e134-f4f6">
+              <profiles>
+                <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c07e-61bf-67a5-f3d9">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="5a63-e013-3d10-5d65">
+              <profiles>
+                <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="9b7e-969e-f865-558e">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="f8b2-46f5-d9ff-d4d2">
+              <profiles>
+                <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b960-ce3f-0583-017b">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="433a-d5d1-b330-67c1">
+              <profiles>
+                <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0afd-9a4e-547c-ac92">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="97eb-f4b8-8020-c3b9">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="cae3-d50a-caae-6c3a">
+                  <profiles>
+                    <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="76d1-46b2-1408-03cc">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <profiles>
+                <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8ce3-9d9f-6776-df06">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="753f-d17b-7c93-bda5">
+              <profiles>
+                <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="757d-eba2-d5ea-3e7c">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="1158-9a46-bde4-5ac2">
+              <profiles>
+                <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="4ad3-6aef-9c73-2686">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="c268-9461-c34e-8eb0">
+              <profiles>
+                <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="37e6-f071-ca8d-d3c2">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="93af-079f-a008-11d8">
+              <profiles>
+                <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="c9d1-ace7-b395-595e">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="3c6d-d92e-6d7e-0809">
+              <profiles>
+                <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7709-9f92-c89e-7b4b">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="b81d-b182-5320-d627">
+              <profiles>
+                <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5beb-1ac1-3cb4-fb2f">
+                  <characteristics>
+                    <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Weapons" id="3b54-fab1-3e46-85c2" hidden="false">
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Weapons / Trait x2" id="2607-ce42-f608-740c" hidden="false">
+              <constraints>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="2de4-4f59-274b-1a9a" includeChildSelections="false"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Autocannnon/Deathspitter/Missile Pod" hidden="false" id="9762-0a4c-b6db-f6f9" sortIndex="2">
+                  <profiles>
+                    <profile name="⌖ Autocannnon/Deathspitter/Missile Pod" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="83ff-d2a6-7ab2-fa8d">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="ad8c-d1e3-a993-1f0c" sortIndex="4">
+                  <profiles>
+                    <profile name="⌖ Burst Cannon/Scatter laser/Devourer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="34d1-1765-9e64-8dcb">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/4</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceasless, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="1018-c258-3a1d-3622" sortIndex="12">
+                  <profiles>
+                    <profile name="⌖ Havoc Launcher/Grotzooka/Spore mine launcher" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="0682-2b55-5faf-1dec">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="1d7f-488e-801e-7efb" sortIndex="14">
+                  <profiles>
+                    <profile name="⌖ Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="7aca-e999-9c6b-4b1c">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Saturate, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="ff12-c540-69f8-2aea" sortIndex="13">
+                  <profiles>
+                    <profile name="⌖ Heavy bolter" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="957a-53fd-6019-fa98">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing crits 1, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="67b5-b49f-2000-e1fc" sortIndex="15">
+                  <profiles>
+                    <profile name="⌖ Heavy phosphor blaster" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="d002-b329-3b9e-5685">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Saturate, Severe</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="cda6-da06-a850-5d47" sortIndex="16">
+                  <profiles>
+                    <profile name="⌖ Heavy stubber/Big shoota" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e0fc-2cca-7e70-31a0">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="bf55-ddb2-687a-eaf4" sortIndex="18">
+                  <profiles>
+                    <profile name="⌖ Lascannon/Bright lance/Dark lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5d86-b369-5e91-66f1">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="8398-d098-626a-def1" sortIndex="37">
+                  <profiles>
+                    <profile name="⚔ Thunder hammer" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cb93-a22b-4e51-72a7">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Shock, Stun</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="4c8e-8fad-f7cf-bb82" sortIndex="20">
+                  <profiles>
+                    <profile name="⌖ Missile launcher Frag" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="10ea-2ace-1ded-94b1">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Missile launcher Krak" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="72cb-59fc-2ff8-f6bc">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="451e-3272-190d-6813" sortIndex="23">
+                  <profiles>
+                    <profile name="⌖ Plasma gun Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5939-e236-60d7-e075">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma gun Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2e0e-3b72-949a-536a">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Hot, Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="3195-24cd-7cf5-bf04" sortIndex="21">
+                  <profiles>
+                    <profile name="⌖ Multi-melta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="9abf-352e-7841-99fb">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="bce0-2413-60ee-b076" sortIndex="19">
+                  <profiles>
+                    <profile name="⌖ Meltagun/Fusion blaster/Heat lance" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="85f0-e24d-2429-1e28">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 6&quot;, Devastating 4, Piercing 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="2e33-1044-e95d-45bf" sortIndex="28">
+                  <profiles>
+                    <profile name="⌖ Rokkit launcha" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8fb8-643b-8cb0-c72f">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="1866-704c-5093-9d51" sortIndex="32">
+                  <profiles>
+                    <profile name="⌖ Shuriken cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="5fab-f8f8-b039-26df">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="b247-4ee7-337c-cf2a" sortIndex="33">
+                  <profiles>
+                    <profile name="⌖ Splinter cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e276-34fa-ea00-f64a">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Torrent 1&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="e452-30a7-5b8b-de65" sortIndex="34">
+                  <profiles>
+                    <profile name="⌖ Starcannon/Heavy venom cannon/Kustom mega-blasta" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="f020-206a-15ca-32ed">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="299a-50f9-f2dc-7983" sortIndex="35">
+                  <profiles>
+                    <profile name="⌖ Stranglethorn cannon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="aad9-ac05-5604-e29a">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="650f-ce10-1533-f3aa" sortIndex="39">
+                  <profiles>
+                    <profile name="⌖ Twinned Weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="16dc-b70b-1e32-5042">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Twinned: Select one other ranged weapon this operative has to have the Ceaseless weapon rule; if it&apos;s a burst cannon, add 1 to it&apos;s Atk stat instead.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="ae22-dbeb-00a5-2c2f" sortIndex="5">
+                  <profiles>
+                    <profile name="⚔ Chain weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="e593-bbfa-c49f-492c">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="e6b4-98f9-4be5-a979" sortIndex="8">
+                  <profiles>
+                    <profile name="⚔ Dread saw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="b6d3-ef32-51e7-69e2">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="8aa4-5539-6778-8d88" sortIndex="9">
+                  <profiles>
+                    <profile name="⚔ Fleshmower" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8796-a906-5d4b-ffa2">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="6ead-adda-6f28-1355" sortIndex="22">
+                  <profiles>
+                    <profile name="⚔ Paired weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3575-13c5-cad9-81bb">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">-</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">-</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">-</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Paired: Select one other melee weapon this operative has and add 1 to its Atk stat</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="feb5-3914-ccf7-1754" sortIndex="24">
+                  <profiles>
+                    <profile name="⚔ Power fist/Crushing claw" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="40a1-8824-71c0-41ea">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/8</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Brutal, Shock</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="2200-7996-90b8-265a" sortIndex="25">
+                  <profiles>
+                    <profile name="⚔ Power scourge/Lasher tendrils" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="c5a5-6ae5-5788-ed85">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="8d16-c55e-1266-a20b" sortIndex="26">
+                  <profiles>
+                    <profile name="⚔ Power talon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="ffc9-245a-aaaa-ce1a">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+, Rending</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="ee00-bb89-0872-67e1" sortIndex="27">
+                  <profiles>
+                    <profile name="⚔ Power weapon/ Ghostglaive" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2491-8e3a-799b-dc4e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Lethal 5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="832c-49ab-449b-923d" sortIndex="29">
+                  <profiles>
+                    <profile name="⚔ Scything talons/Macro-scalpels" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="2b53-878e-7a3f-e4fe">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Ceaseless</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="a763-40a1-a233-a3cd">
+                  <profiles>
+                    <profile name="Violent demise" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8b78-6efa-1ac0-5504">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">If this operative is incapacitated, before it&apos;s removed from the killzone, inflice D6+1 damage on each other operative within 3&quot; of it (excluding operatives with Heavy terrain wholly intervening between them and this operative).</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="a670-a1cb-3e80-925b">
+                  <profiles>
+                    <profile name="Armoured" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="75b9-14a0-0dc7-88ed">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative with a weapon that has a Normal Dmg stat of 3 or less, improve this operative&apos;s Save stat by 1.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="4b7e-c09b-98ec-f8fe">
+                  <profiles>
+                    <profile name="Blitz" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d5fb-85d7-a673-4ef6">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative performs the Charge action during it&apos;s activation, it&apos;s melee weapons have the Severe and Shock weapon rules until the end of that activation.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="febc-e3aa-355b-6acd">
+                  <profiles>
+                    <profile name="Close-range lethality" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="853b-f808-1862-c806">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenver this operative is shooting the closest valid target within 8&quot; of it, its ranged weapons have the Lethal 5+ weapon rule, if the weapon already has that weapon rule, it also has the Severe weapon rule.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="5926-ca90-f2f3-02d6">
+                  <profiles>
+                    <profile name="Crushing impact" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="8567-3556-175f-f20e">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">When this operative finishes moving during the Charge action, inflict D3+3 damage on one enemy operative within its control range.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="e856-1d9c-e5f7-4fe8">
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Duellist" hidden="false" id="5adc-bffe-001a-407f">
+                      <profiles>
+                        <profile name="Duellist" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="a27b-734c-5c93-2274">
+                          <characteristics>
+                            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is fighting or retaliating, you can resolve one of its successes before the normal order. If you do, the success must be used to block</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <profiles>
+                    <profile name="Focused targeting" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="7260-51c1-cf82-58f7">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever this operative is shooting during it&apos;s activation, if it hasn&apos;t performed any other actions during that activation, its ranged weapons have the Punishing weapon rule.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="d141-92b2-25f3-470c">
+                  <profiles>
+                    <profile name="Fury" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0ff5-fce7-0ad9-9d2e">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative&apos;s melee weapons have the Ceasless weapon rule, if the weapon already has that weapon rule, it has the Relentless weapon rule. Worsen the hit stat of this operative&apos;s ranged weapons by 1.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="dac0-4823-1c11-4d7e">
+                  <profiles>
+                    <profile name="Implacable" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="65ee-8c45-ffa4-0f9f">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s weapon stats from being injured.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="3f80-3c82-7bd3-7b2f">
+                  <profiles>
+                    <profile name="Shielded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="e714-9792-e86e-5ced">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Once per battle, when an attack dice inflicts damage on his operative, you can ignore that inflicted damage.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="2832-971a-946f-5275">
+                  <profiles>
+                    <profile name="Shrouded" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="0f83-4a0c-26dc-99d9">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative from more than 8&quot; away, attack dice cannot be re-rolled.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="883a-82a4-b9c6-30a8">
+                  <profiles>
+                    <profile name="Tenacious" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="b314-da55-41b1-54dd">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Ignore any changes to this operative&apos;s move stat from being injured.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="fc0b-4b14-8775-9024">
+                  <profiles>
+                    <profile name="Tough" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="fe0c-767b-20d5-ff17">
+                      <characteristics>
+                        <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an attack dice inflicts damage of 4 or more on this operative, roll one D6: on a 5+, subtract 1 from that inflicted damage.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Weapon x1" id="7599-585c-710e-1169" hidden="false">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Cyclic ion raker" hidden="false" id="873b-5c0d-7809-593a">
+                  <profiles>
+                    <profile name="⌖ Cyclic ion raker" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="1c9d-e498-b03e-9990">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 1, Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Flamestorm cannon/Flamespurt" hidden="false" id="a6af-bf7b-3447-a254">
+                  <profiles>
+                    <profile name="⌖ Flamestorm cannon/Flamespurt" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="cd08-8357-6569-1b7b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">2+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">3/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Range 8&quot;, Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" hidden="false" id="3b3d-93cc-53f7-a13b">
+                  <profiles>
+                    <profile name="⌖ Heavy onslaught gattling cannon/Avenger chaincannon/Enmitic Exterminator" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="df04-96c4-7368-3944">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">6</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Selection 2, Torrent 2&quot;</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Heavy rail rifle/Doomsday blaster/Gauss destructor" hidden="false" id="0716-09eb-681f-f2d5">
+                  <profiles>
+                    <profile name="⌖ Heavy rail rifle/Doomsday blaster/Gauss destructor" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8c3b-52b5-e540-580d">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/7</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Macro plasma incinerator" hidden="false" id="a9b2-dcd7-3965-65df">
+                  <profiles>
+                    <profile name="⌖ Macro plasma incinerator Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4541-54df-5161-fb7e">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Macro plasma incinerator Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="750b-54d6-4d43-e66b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="5a86-e53e-a33e-013c">
+                  <profiles>
+                    <profile name="⌖ Plasma cannon Standard" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="4ace-41cd-7653-9c6d">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Piercing 1</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="⌖ Plasma cannon Supercharge" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="8e09-29c2-befa-8a3b">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">4</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">5/6</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Blast 2&quot;, Heavy (Reposition only), Hot, Lethal 5+, Piercing 1, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thermal spear/Fusion collider" hidden="false" id="6188-c1ff-fddf-1aa8">
+                  <profiles>
+                    <profile name="⌖ Thermal spear/Fusion collider" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="aeda-aa5c-be18-3088">
+                      <characteristics>
+                        <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">5</characteristic>
+                        <characteristic name="HIT" typeId="8044-2517-4ef7-33de">3+</characteristic>
+                        <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">6/3</characteristic>
+                        <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Devastating 4, Heavy (Reposition only), Piercing 2, Selection 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+              <constraints>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="a461-8555-77f9-ef4e" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cfd2-17b0-5b38-8255" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8657-9050-7959-8b37" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6701-2062-c33f-4446" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Close combat weapon" id="77d1-5218-ebe6-cc26" hidden="false">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a778-6d52-fbdf-8082" includeChildSelections="false"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="da02-cd96-035d-d0fa">
+              <profiles>
+                <profile name="⚔ Close combat weapon" typeId="f25f-4b13-b724-d5a8" typeName="Weapons" hidden="false" id="3bdc-1bdc-ca56-bbcd">
+                  <characteristics>
+                    <characteristic name="ATK" typeId="6056-b741-7cf3-5b43">3</characteristic>
+                    <characteristic name="HIT" typeId="8044-2517-4ef7-33de">4+</characteristic>
+                    <characteristic name="DMG" typeId="dd3e-ef09-5d1a-37b4">4/5</characteristic>
+                    <characteristic name="WR" typeId="05b8-00a1-69af-14b6">Selection 0</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <profiles>
+        <profile name="Nemesis Medium (S) (Pts 5)" typeId="5156-3fb9-39ce-7bdb" typeName="Operative" hidden="false" id="224c-531c-6901-623d">
+          <characteristics>
+            <characteristic name="APL" typeId="bc83-42aa-b7c1-f0b1">-</characteristic>
+            <characteristic name="Move" typeId="c996-ffb3-e0b4-ecfa">6&quot;</characteristic>
+            <characteristic name="Save" typeId="3241-5548-12d6-f103">4+</characteristic>
+            <characteristic name="Wounds" typeId="74f9-f91c-b8fd-89d9">50</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Extra Defense" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="19a2-1561-fe8c-62eb">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">Whenever an operative is shooting this operative, collect and roll one additional defence dice, unless this operative is injured.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Bulky" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="d50d-0081-85cb-e1e9">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">This operative cannot be placed on Vantage terrain higher than 2&quot; from the killzone floor.
+Whenever this operative would perform the fight action, the distance requirements for its control range can be changed to 1&quot; horizontally and 4&quot; vertically until the end of that action.
+This operative can move through other operatives (excluding Nemesis operatives)
+Ignore all changes to this operative&apos;s APL and if it&apos;s a player operative, APL changes don&apos;t affect the 5AP you can spend per turning point.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Towering size" typeId="f887-5881-0e6d-755c" typeName="Abilities" hidden="false" id="5190-7dca-f941-e7de">
+          <characteristics>
+            <characteristic name="Ability" typeId="3467-0678-083e-eb50">In the Firefight phase, whenever you determine this operative&apos;s order, you cannot select Conceal.
+This operative cannot be in cover or obscured by Light terrain, terrain parts less than 3&quot; tall or terrain that&apos;s not wholly intervening.
+Whenever another operative is performing the Shoot action, being within control range of other operatives doesn&apos;t prevent this operative from being selected as a valid target.
+This operative can move through terrain parts less than 2&quot; tall. It cannot move through Accessible terrain (excluding hatchways) unless that terrain is also less than 2&quot; tall.
+Whenever this operative would finish a move in a terrain feature less than 2&quot; tall, temporarily remove that terrain feature from the killzone, then return it when this operative leaves that location. If it&apos;s an equipment terrain feature, remove it from the battle instead.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink targetId="cf83-4496-b58e-ac82" id="12ad-8024-f54d-4bb9" primary="true" name="Operative"/>
       </categoryLinks>
     </selectionEntry>
   </selectionEntries>

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -2948,6 +2948,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1430-8a0f-bdb9-9e87" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Burst Cannon/Scatter laser/Devourer" hidden="false" id="e5fe-32e9-0b88-bb00" sortIndex="4">
                   <profiles>
@@ -2960,6 +2963,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="542a-007f-4867-36de" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Havoc Launcher/Grotzooka/Spore mine launcher" hidden="false" id="536c-bd24-a3e1-4bee" sortIndex="12">
                   <profiles>
@@ -2972,6 +2978,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d431-955f-ba04-5578" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Heavy flamer/Incendine combustor/Liquifier gun/Skorcha" hidden="false" id="e6a4-3b56-c40d-814d" sortIndex="14">
                   <profiles>
@@ -2984,6 +2993,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0ff2-6f30-4959-a539" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="d6ca-ba1c-9281-576c" sortIndex="13">
                   <profiles>
@@ -2996,6 +3008,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0e41-2583-9920-1a3b" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Heavy phosphor blaster" hidden="false" id="fc87-5b29-a721-6012" sortIndex="15">
                   <profiles>
@@ -3008,6 +3023,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dba7-b3d2-4e2e-9afa" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Heavy stubber/Big shoota" hidden="false" id="ef5e-3779-77d0-0f01" sortIndex="16">
                   <profiles>
@@ -3020,6 +3038,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="11e7-cddf-98a8-8057" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Lascannon/Bright lance/Dark lance" hidden="false" id="6a12-3114-a92b-09d5" sortIndex="18">
                   <profiles>
@@ -3032,6 +3053,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="adb4-1bec-a712-901a" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Thunder hammer" hidden="false" id="3246-3456-e551-0234" sortIndex="37">
                   <profiles>
@@ -3044,6 +3068,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="74b1-4b42-ba7f-3c0d" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Missile launcher" hidden="false" id="a67d-ba56-e75f-7d66" sortIndex="20">
                   <profiles>
@@ -3064,6 +3091,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="649e-59db-8134-9eeb" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Plasma gun" hidden="false" id="c279-d485-0536-4775" sortIndex="23">
                   <profiles>
@@ -3084,6 +3114,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0fca-79c6-57cd-deba" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="61f3-951f-1260-5422" sortIndex="21">
                   <profiles>
@@ -3096,6 +3129,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a405-e588-7de3-bb86" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Meltagun/Fusion blaster/Heat lance" hidden="false" id="2e29-1aaa-0621-9547" sortIndex="19">
                   <profiles>
@@ -3108,6 +3144,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e503-62c9-df4f-453a" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Rokkit launcha" hidden="false" id="fcdc-1c64-701c-7291" sortIndex="28">
                   <profiles>
@@ -3120,6 +3159,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2eee-b26d-858c-db2a" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Shuriken cannon" hidden="false" id="a6f5-9601-cdd8-d870" sortIndex="32">
                   <profiles>
@@ -3132,6 +3174,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9903-337e-f4b0-7f6d" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Splinter cannon" hidden="false" id="d035-b830-3c31-c838" sortIndex="33">
                   <profiles>
@@ -3144,6 +3189,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5c08-0875-865b-f886" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Starcannon/Heavy venom cannon/Kustom mega-blasta" hidden="false" id="4db2-6f54-5896-f237" sortIndex="34">
                   <profiles>
@@ -3156,6 +3204,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="269c-ea69-fdd5-73ed" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Stranglethorn cannon" hidden="false" id="1572-8a93-7804-56c6" sortIndex="35">
                   <profiles>
@@ -3168,6 +3219,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="43da-a871-5c90-ce48" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Twinned Weapon" hidden="false" id="9c76-2061-5cb7-96e2" sortIndex="39">
                   <profiles>
@@ -3180,6 +3234,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="be56-3f27-9a67-f0d6" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Chain weapon" hidden="false" id="3a7d-2904-5c60-065e" sortIndex="5">
                   <profiles>
@@ -3192,6 +3249,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="40e6-1666-8c4d-2a15" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Dread saw" hidden="false" id="0ea6-616a-0c5c-8cbd" sortIndex="8">
                   <profiles>
@@ -3204,6 +3264,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a80c-62e8-4b8a-45f8" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Fleshmower" hidden="false" id="c1dc-de3e-28ce-84cb" sortIndex="9">
                   <profiles>
@@ -3216,6 +3279,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6245-bedd-beec-e499" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Paired weapon" hidden="false" id="bfcc-b53a-c527-1874" sortIndex="22">
                   <profiles>
@@ -3228,6 +3294,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="15eb-0047-10c0-b90a" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Power fist/Crushing claw" hidden="false" id="8e08-158d-63f5-84f0" sortIndex="24">
                   <profiles>
@@ -3240,6 +3309,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="caa1-378a-ad4f-2a0f" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Power scourge/Lasher tendrils" hidden="false" id="c5ee-6268-35dc-7e28" sortIndex="25">
                   <profiles>
@@ -3252,6 +3324,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e2da-18cc-74a8-96e5" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Power talon" hidden="false" id="2121-30aa-877d-014e" sortIndex="26">
                   <profiles>
@@ -3264,6 +3339,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4e39-9c9f-2084-4cbb" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Power weapon/ Ghostglaive" hidden="false" id="ff41-fcb6-5d3c-acbc" sortIndex="27">
                   <profiles>
@@ -3276,6 +3354,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ace5-e995-fdfd-6e5d" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Scything talons/Macro-scalpels" hidden="false" id="5146-e069-b3fc-fa21" sortIndex="29">
                   <profiles>
@@ -3288,6 +3369,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dabe-027c-2b39-6e1e" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Violent demise" hidden="false" id="0a35-973b-5a4d-ef64">
                   <profiles>
@@ -3297,6 +3381,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f01-3ab7-dc10-51e1" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Armoured" hidden="false" id="0de9-2e06-f34c-7f0e">
                   <profiles>
@@ -3306,6 +3393,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9630-c889-b0e9-bd7e" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Blitz" hidden="false" id="2749-b2ca-3e64-68fd">
                   <profiles>
@@ -3315,6 +3405,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5b97-a62d-b74b-3684" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Close-range lethality" hidden="false" id="434c-c76a-12e1-2b10">
                   <profiles>
@@ -3324,6 +3417,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="58cb-7b98-35e2-f824" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Crushing impact" hidden="false" id="bf21-d61e-3f2d-3900">
                   <profiles>
@@ -3333,6 +3429,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="122f-2a60-33a2-bcdb" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Focused targeting" hidden="false" id="f94b-fb8c-4555-922b">
                   <selectionEntries>
@@ -3353,6 +3452,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d7c5-9317-d7bf-93e2" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Fury" hidden="false" id="fcf7-a3b7-ce9c-c6be">
                   <profiles>
@@ -3362,6 +3464,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0cd0-a60f-846d-eb2e" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Implacable" hidden="false" id="aaa5-306b-0c11-e2c6">
                   <profiles>
@@ -3371,6 +3476,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ac0a-c593-7aa7-7ac0" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Shielded" hidden="false" id="64f2-0fea-a724-3f0a">
                   <profiles>
@@ -3380,6 +3488,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4a2d-1e7a-4770-36e9" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Shrouded" hidden="false" id="f3cf-c12f-e6a8-3d96">
                   <profiles>
@@ -3389,6 +3500,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e64-23fc-16a9-0427" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Tenacious" hidden="false" id="d9ff-40f2-05a1-25b0">
                   <profiles>
@@ -3398,6 +3512,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f040-966d-16ce-8ed9" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
                 <selectionEntry type="upgrade" import="true" name="Tough" hidden="false" id="8a27-e4fe-5e24-b579">
                   <profiles>
@@ -3407,6 +3524,9 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                       </characteristics>
                     </profile>
                   </profiles>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="56b4-619d-8709-f13a" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>

--- a/2024 - Non-player Operatives.cat
+++ b/2024 - Non-player Operatives.cat
@@ -1523,7 +1523,7 @@
           <selectionEntryGroups>
             <selectionEntryGroup name="Weapons / Trait x2" id="3782-f40c-3b8c-7912" hidden="false">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a8b4-6323-14d4-5dbb" includeChildSelections="false"/>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="a8b4-6323-14d4-5dbb" includeChildSelections="false"/>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="c6a0-1826-bfd0-4978" includeChildSelections="false"/>
               </constraints>
               <selectionEntries>
@@ -2052,7 +2052,7 @@
                 </selectionEntry>
               </selectionEntries>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c113-52d7-d3e9-377e" includeChildSelections="false"/>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="c113-52d7-d3e9-377e" includeChildSelections="false"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4dab-3286-cdc9-472a" includeChildSelections="false"/>
               </constraints>
             </selectionEntryGroup>
@@ -2355,13 +2355,13 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                     </selectionEntry>
                   </selectionEntries>
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3d0f-1960-235c-5aca" includeChildSelections="false"/>
+                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="3d0f-1960-235c-5aca" includeChildSelections="false"/>
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2595-1e6c-cc2a-f5c3" includeChildSelections="false"/>
                   </constraints>
                 </selectionEntryGroup>
                 <selectionEntryGroup name="Weapons / Trait x2" id="b95a-ef96-01ea-2289" hidden="false">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="be75-312c-2c5c-5948" includeChildSelections="false"/>
+                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="be75-312c-2c5c-5948" includeChildSelections="false"/>
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4262-7f18-d084-0621" includeChildSelections="false"/>
                   </constraints>
                   <selectionEntries>
@@ -3219,7 +3219,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
             </selectionEntryGroup>
             <selectionEntryGroup name="Weapons / Trait x3" id="f331-8078-0e57-7cd4" hidden="false">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cd19-054f-7d32-f4b2" includeChildSelections="false"/>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="cd19-054f-7d32-f4b2" includeChildSelections="false"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="631e-ad35-d772-04d0" includeChildSelections="false"/>
               </constraints>
               <selectionEntries>
@@ -3646,7 +3646,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
             </selectionEntryGroup>
           </selectionEntryGroups>
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c1e7-ed6b-54e5-c7b2" includeChildSelections="false"/>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="c1e7-ed6b-54e5-c7b2" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4b35-9761-24ff-1888" includeChildSelections="false"/>
           </constraints>
         </selectionEntryGroup>
@@ -3839,7 +3839,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
           <selectionEntryGroups>
             <selectionEntryGroup name="Weapons / Trait x2" id="bae1-5857-ae09-072e" hidden="false">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="351f-0f8a-2a1d-fc5e" includeChildSelections="false"/>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="351f-0f8a-2a1d-fc5e" includeChildSelections="false"/>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="2fe8-b04c-0386-d157" includeChildSelections="false"/>
               </constraints>
               <selectionEntries>
@@ -4368,7 +4368,7 @@ Whenever this operative would finish a move in a terrain feature less than 2&quo
                 </selectionEntry>
               </selectionEntries>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="982d-9839-03b2-c36f" includeChildSelections="false"/>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="982d-9839-03b2-c36f" includeChildSelections="false"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b8e4-8919-6914-f753" includeChildSelections="false"/>
               </constraints>
             </selectionEntryGroup>


### PR DESCRIPTION
I've created 3 new operatives for Nemesis (S), Nemesis (M) and Nemesis (L), along with 2 T'au, 3 Chaos and 2 Tyranids NPOs from the Nemesis Book

To identify the new Control Point stat of NPOs, I've added the points in the name of the Operative. For example : "Lesser Daemon (Pts 2)" 
